### PR TITLE
refactor(rust): Refactor macro arg syntax

### DIFF
--- a/crates/polars-arrow/src/array/builder.rs
+++ b/crates/polars-arrow/src/array/builder.rs
@@ -342,8 +342,8 @@ pub fn make_builder(dtype: &ArrowDataType) -> Box<dyn ArrayBuilder> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArrayBuilder::new(dtype.clone())),
         Boolean => Box::new(BooleanArrayBuilder::new(dtype.clone())),
-        Primitive(prim_t) => with_match_primitive_type_full!(prim_t, |$T| {
-            Box::new(PrimitiveArrayBuilder::<$T>::new(dtype.clone()))
+        Primitive(prim_t) => with_match_primitive_type_full!(prim_t, |T| {
+            Box::new(PrimitiveArrayBuilder::<T>::new(dtype.clone()))
         }),
         LargeBinary => Box::new(BinaryArrayBuilder::<i64>::new(dtype.clone())),
         FixedSizeBinary => Box::new(FixedSizeBinaryArrayBuilder::new(dtype.clone())),

--- a/crates/polars-arrow/src/array/builder.rs
+++ b/crates/polars-arrow/src/array/builder.rs
@@ -342,7 +342,7 @@ pub fn make_builder(dtype: &ArrowDataType) -> Box<dyn ArrayBuilder> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArrayBuilder::new(dtype.clone())),
         Boolean => Box::new(BooleanArrayBuilder::new(dtype.clone())),
-        Primitive(prim_t) => with_match_primitive_type_full!(prim_t, |T| {
+        Primitive(prim_t) => with_match_primitive_type_full!(prim_t, impl<T> {
             Box::new(PrimitiveArrayBuilder::<T>::new(dtype.clone()))
         }),
         LargeBinary => Box::new(BinaryArrayBuilder::<i64>::new(dtype.clone())),

--- a/crates/polars-arrow/src/array/equal/mod.rs
+++ b/crates/polars-arrow/src/array/equal/mod.rs
@@ -217,7 +217,7 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let rhs = rhs.as_any().downcast_ref().unwrap();
             boolean::equal(lhs, rhs)
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let lhs = lhs.as_any().downcast_ref().unwrap();
             let rhs = rhs.as_any().downcast_ref().unwrap();
             primitive::equal::<T>(lhs, rhs)
@@ -258,7 +258,7 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             struct_::equal(lhs, rhs)
         },
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref().unwrap();
                 dictionary::equal::<T>(lhs, rhs)

--- a/crates/polars-arrow/src/array/equal/mod.rs
+++ b/crates/polars-arrow/src/array/equal/mod.rs
@@ -217,10 +217,10 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let rhs = rhs.as_any().downcast_ref().unwrap();
             boolean::equal(lhs, rhs)
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
             let lhs = lhs.as_any().downcast_ref().unwrap();
             let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::equal::<$T>(lhs, rhs)
+            primitive::equal::<T>(lhs, rhs)
         }),
         Utf8 => {
             let lhs = lhs.as_any().downcast_ref().unwrap();
@@ -258,10 +258,10 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             struct_::equal(lhs, rhs)
         },
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
+            match_integer_type!(key_type, |T| {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref().unwrap();
-                dictionary::equal::<$T>(lhs, rhs)
+                dictionary::equal::<T>(lhs, rhs)
             })
         },
         FixedSizeBinary => {

--- a/crates/polars-arrow/src/array/ffi.rs
+++ b/crates/polars-arrow/src/array/ffi.rs
@@ -59,9 +59,9 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
     match array.dtype().to_physical_type() {
         Null => ffi_dyn!(array, NullArray),
         Boolean => ffi_dyn!(array, BooleanArray),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            ffi_dyn!(array, PrimitiveArray<$T>)
-        }),
+        Primitive(primitive) => {
+            with_match_primitive_type_full!(primitive, |T| ffi_dyn!(array, PrimitiveArray<T>))
+        },
         Binary => ffi_dyn!(array, BinaryArray<i32>),
         LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
         FixedSizeBinary => ffi_dyn!(array, FixedSizeBinaryArray),
@@ -76,8 +76,8 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
         BinaryView => ffi_dyn!(array, BinaryViewArray),
         Utf8View => ffi_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+            match_integer_type!(key_type, |T| {
+                let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
                 (
                     array.offset().unwrap(),
                     array.buffers(),

--- a/crates/polars-arrow/src/array/ffi.rs
+++ b/crates/polars-arrow/src/array/ffi.rs
@@ -60,7 +60,7 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
         Null => ffi_dyn!(array, NullArray),
         Boolean => ffi_dyn!(array, BooleanArray),
         Primitive(primitive) => {
-            with_match_primitive_type_full!(primitive, |T| ffi_dyn!(array, PrimitiveArray<T>))
+            with_match_primitive_type_full!(primitive, impl<T> ffi_dyn!(array, PrimitiveArray<T>))
         },
         Binary => ffi_dyn!(array, BinaryArray<i32>),
         LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
@@ -76,7 +76,7 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
         BinaryView => ffi_dyn!(array, BinaryViewArray),
         Utf8View => ffi_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
                 (
                     array.offset().unwrap(),

--- a/crates/polars-arrow/src/array/fmt.rs
+++ b/crates/polars-arrow/src/array/fmt.rs
@@ -17,8 +17,8 @@ pub fn get_value_display<'a, F: Write + 'a>(
         Boolean => Box::new(|f, index| {
             super::boolean::fmt::write_value(array.as_any().downcast_ref().unwrap(), index, f)
         }),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            let writer = super::primitive::fmt::get_write_value::<$T, _>(
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            let writer = super::primitive::fmt::get_write_value::<T, _>(
                 array.as_any().downcast_ref().unwrap(),
             );
             Box::new(move |f, index| writer(f, index))
@@ -105,9 +105,14 @@ pub fn get_value_display<'a, F: Write + 'a>(
                 f,
             )
         }),
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
             Box::new(move |f, index| {
-                super::dictionary::fmt::write_value::<$T,_>(array.as_any().downcast_ref().unwrap(), index, null, f)
+                super::dictionary::fmt::write_value::<T, _>(
+                    array.as_any().downcast_ref().unwrap(),
+                    index,
+                    null,
+                    f,
+                )
             })
         }),
     }

--- a/crates/polars-arrow/src/array/fmt.rs
+++ b/crates/polars-arrow/src/array/fmt.rs
@@ -17,7 +17,7 @@ pub fn get_value_display<'a, F: Write + 'a>(
         Boolean => Box::new(|f, index| {
             super::boolean::fmt::write_value(array.as_any().downcast_ref().unwrap(), index, f)
         }),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let writer = super::primitive::fmt::get_write_value::<T, _>(
                 array.as_any().downcast_ref().unwrap(),
             );
@@ -105,7 +105,7 @@ pub fn get_value_display<'a, F: Write + 'a>(
                 f,
             )
         }),
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             Box::new(move |f, index| {
                 super::dictionary::fmt::write_value::<T, _>(
                     array.as_any().downcast_ref().unwrap(),

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -355,8 +355,8 @@ impl std::fmt::Debug for dyn Array + '_ {
         match self.dtype().to_physical_type() {
             Null => fmt_dyn!(self, NullArray, f),
             Boolean => fmt_dyn!(self, BooleanArray, f),
-            Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-                fmt_dyn!(self, PrimitiveArray<$T>, f)
+            Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+                fmt_dyn!(self, PrimitiveArray<T>, f)
             }),
             BinaryView => fmt_dyn!(self, BinaryViewArray, f),
             Utf8View => fmt_dyn!(self, Utf8ViewArray, f),
@@ -371,9 +371,7 @@ impl std::fmt::Debug for dyn Array + '_ {
             Struct => fmt_dyn!(self, StructArray, f),
             Union => fmt_dyn!(self, UnionArray, f),
             Dictionary(key_type) => {
-                match_integer_type!(key_type, |$T| {
-                    fmt_dyn!(self, DictionaryArray::<$T>, f)
-                })
+                match_integer_type!(key_type, |T| fmt_dyn!(self, DictionaryArray::<T>, f))
             },
             Map => fmt_dyn!(self, MapArray, f),
         }
@@ -386,8 +384,8 @@ pub fn new_empty_array(dtype: ArrowDataType) -> Box<dyn Array> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArray::new_empty(dtype)),
         Boolean => Box::new(BooleanArray::new_empty(dtype)),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            Box::new(PrimitiveArray::<$T>::new_empty(dtype))
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            Box::new(PrimitiveArray::<T>::new_empty(dtype))
         }),
         Binary => Box::new(BinaryArray::<i32>::new_empty(dtype)),
         LargeBinary => Box::new(BinaryArray::<i64>::new_empty(dtype)),
@@ -403,8 +401,8 @@ pub fn new_empty_array(dtype: ArrowDataType) -> Box<dyn Array> {
         Utf8View => Box::new(Utf8ViewArray::new_empty(dtype)),
         BinaryView => Box::new(BinaryViewArray::new_empty(dtype)),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                Box::new(DictionaryArray::<$T>::new_empty(dtype))
+            match_integer_type!(key_type, |T| {
+                Box::new(DictionaryArray::<T>::new_empty(dtype))
             })
         },
     }
@@ -419,8 +417,8 @@ pub fn new_null_array(dtype: ArrowDataType, length: usize) -> Box<dyn Array> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArray::new_null(dtype, length)),
         Boolean => Box::new(BooleanArray::new_null(dtype, length)),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            Box::new(PrimitiveArray::<$T>::new_null(dtype, length))
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            Box::new(PrimitiveArray::<T>::new_null(dtype, length))
         }),
         Binary => Box::new(BinaryArray::<i32>::new_null(dtype, length)),
         LargeBinary => Box::new(BinaryArray::<i64>::new_null(dtype, length)),
@@ -436,8 +434,8 @@ pub fn new_null_array(dtype: ArrowDataType, length: usize) -> Box<dyn Array> {
         BinaryView => Box::new(BinaryViewArray::new_null(dtype, length)),
         Utf8View => Box::new(Utf8ViewArray::new_null(dtype, length)),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                Box::new(DictionaryArray::<$T>::new_null(dtype, length))
+            match_integer_type!(key_type, |T| {
+                Box::new(DictionaryArray::<T>::new_null(dtype, length))
             })
         },
     }
@@ -641,9 +639,9 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
     match array.dtype().to_physical_type() {
         Null => clone_dyn!(array, NullArray),
         Boolean => clone_dyn!(array, BooleanArray),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            clone_dyn!(array, PrimitiveArray<$T>)
-        }),
+        Primitive(primitive) => {
+            with_match_primitive_type_full!(primitive, |T| clone_dyn!(array, PrimitiveArray<T>))
+        },
         Binary => clone_dyn!(array, BinaryArray<i32>),
         LargeBinary => clone_dyn!(array, BinaryArray<i64>),
         FixedSizeBinary => clone_dyn!(array, FixedSizeBinaryArray),
@@ -658,9 +656,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         BinaryView => clone_dyn!(array, BinaryViewArray),
         Utf8View => clone_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                clone_dyn!(array, DictionaryArray::<$T>)
-            })
+            match_integer_type!(key_type, |T| clone_dyn!(array, DictionaryArray::<T>))
         },
     }
 }

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -355,7 +355,7 @@ impl std::fmt::Debug for dyn Array + '_ {
         match self.dtype().to_physical_type() {
             Null => fmt_dyn!(self, NullArray, f),
             Boolean => fmt_dyn!(self, BooleanArray, f),
-            Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
                 fmt_dyn!(self, PrimitiveArray<T>, f)
             }),
             BinaryView => fmt_dyn!(self, BinaryViewArray, f),
@@ -371,7 +371,7 @@ impl std::fmt::Debug for dyn Array + '_ {
             Struct => fmt_dyn!(self, StructArray, f),
             Union => fmt_dyn!(self, UnionArray, f),
             Dictionary(key_type) => {
-                match_integer_type!(key_type, |T| fmt_dyn!(self, DictionaryArray::<T>, f))
+                match_integer_type!(key_type, impl<T> fmt_dyn!(self, DictionaryArray::<T>, f))
             },
             Map => fmt_dyn!(self, MapArray, f),
         }
@@ -384,7 +384,7 @@ pub fn new_empty_array(dtype: ArrowDataType) -> Box<dyn Array> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArray::new_empty(dtype)),
         Boolean => Box::new(BooleanArray::new_empty(dtype)),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             Box::new(PrimitiveArray::<T>::new_empty(dtype))
         }),
         Binary => Box::new(BinaryArray::<i32>::new_empty(dtype)),
@@ -401,7 +401,7 @@ pub fn new_empty_array(dtype: ArrowDataType) -> Box<dyn Array> {
         Utf8View => Box::new(Utf8ViewArray::new_empty(dtype)),
         BinaryView => Box::new(BinaryViewArray::new_empty(dtype)),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 Box::new(DictionaryArray::<T>::new_empty(dtype))
             })
         },
@@ -417,7 +417,7 @@ pub fn new_null_array(dtype: ArrowDataType, length: usize) -> Box<dyn Array> {
     match dtype.to_physical_type() {
         Null => Box::new(NullArray::new_null(dtype, length)),
         Boolean => Box::new(BooleanArray::new_null(dtype, length)),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             Box::new(PrimitiveArray::<T>::new_null(dtype, length))
         }),
         Binary => Box::new(BinaryArray::<i32>::new_null(dtype, length)),
@@ -434,7 +434,7 @@ pub fn new_null_array(dtype: ArrowDataType, length: usize) -> Box<dyn Array> {
         BinaryView => Box::new(BinaryViewArray::new_null(dtype, length)),
         Utf8View => Box::new(Utf8ViewArray::new_null(dtype, length)),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 Box::new(DictionaryArray::<T>::new_null(dtype, length))
             })
         },
@@ -640,7 +640,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         Null => clone_dyn!(array, NullArray),
         Boolean => clone_dyn!(array, BooleanArray),
         Primitive(primitive) => {
-            with_match_primitive_type_full!(primitive, |T| clone_dyn!(array, PrimitiveArray<T>))
+            with_match_primitive_type_full!(primitive, impl<T> clone_dyn!(array, PrimitiveArray<T>))
         },
         Binary => clone_dyn!(array, BinaryArray<i32>),
         LargeBinary => clone_dyn!(array, BinaryArray<i64>),
@@ -656,7 +656,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         BinaryView => clone_dyn!(array, BinaryViewArray),
         Utf8View => clone_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| clone_dyn!(array, DictionaryArray::<T>))
+            match_integer_type!(key_type, impl<T> clone_dyn!(array, DictionaryArray::<T>))
         },
     }
 }

--- a/crates/polars-arrow/src/compute/aggregate/memory.rs
+++ b/crates/polars-arrow/src/compute/aggregate/memory.rs
@@ -53,13 +53,10 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
             let array = array.as_any().downcast_ref::<DaysMsArray>().unwrap();
             array.values().len() * size_of::<i32>() * 2 + validity_size(array.validity())
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            let array = array
-                .as_any()
-                .downcast_ref::<PrimitiveArray<$T>>()
-                .unwrap();
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
-            array.values().len() * size_of::<$T>() + validity_size(array.validity())
+            array.values().len() * size_of::<T>() + validity_size(array.validity())
         }),
         Binary => dyn_binary!(array, BinaryArray<i32>, i32),
         FixedSizeBinary => {
@@ -128,11 +125,8 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .sum::<usize>();
             types + offsets + fields
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            let array = array
-                .as_any()
-                .downcast_ref::<DictionaryArray<$T>>()
-                .unwrap();
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
             estimated_bytes_size(array.keys()) + estimated_bytes_size(array.values().as_ref())
         }),
         Utf8View => binview_size::<str>(array.as_any().downcast_ref().unwrap()),

--- a/crates/polars-arrow/src/compute/aggregate/memory.rs
+++ b/crates/polars-arrow/src/compute/aggregate/memory.rs
@@ -53,7 +53,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
             let array = array.as_any().downcast_ref::<DaysMsArray>().unwrap();
             array.values().len() * size_of::<i32>() * 2 + validity_size(array.validity())
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
             array.values().len() * size_of::<T>() + validity_size(array.validity())
@@ -125,7 +125,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .sum::<usize>();
             types + offsets + fields
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
             estimated_bytes_size(array.keys()) + estimated_bytes_size(array.values().as_ref())
         }),

--- a/crates/polars-arrow/src/compute/concatenate.rs
+++ b/crates/polars-arrow/src/compute/concatenate.rs
@@ -90,8 +90,8 @@ pub fn concatenate_unchecked<A: AsRef<dyn Array>>(arrays: &[A]) -> PolarsResult<
         Null => Ok(Box::new(concatenate_null(arrays))),
         Boolean => Ok(Box::new(concatenate_bool(arrays))),
         Primitive(ptype) => {
-            with_match_primitive_type_full!(ptype, |$T| {
-                Ok(Box::new(concatenate_primitive::<$T, _>(arrays)))
+            with_match_primitive_type_full!(ptype, |T| {
+                Ok(Box::new(concatenate_primitive::<T, _>(arrays)))
             })
         },
         Binary => Ok(Box::new(concatenate_binary::<i32, _>(arrays)?)),

--- a/crates/polars-arrow/src/compute/concatenate.rs
+++ b/crates/polars-arrow/src/compute/concatenate.rs
@@ -90,7 +90,7 @@ pub fn concatenate_unchecked<A: AsRef<dyn Array>>(arrays: &[A]) -> PolarsResult<
         Null => Ok(Box::new(concatenate_null(arrays))),
         Boolean => Ok(Box::new(concatenate_bool(arrays))),
         Primitive(ptype) => {
-            with_match_primitive_type_full!(ptype, |T| {
+            with_match_primitive_type_full!(ptype, impl<T> {
                 Ok(Box::new(concatenate_primitive::<T, _>(arrays)))
             })
         },

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -25,7 +25,7 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> PolarsResult<Box<dyn Array
         Primitive(PrimitiveType::MonthDayNano) => {
             Box::new(PrimitiveArray::<months_days_ns>::try_from_ffi(array)?)
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             Box::new(PrimitiveArray::<T>::try_from_ffi(array)?)
         }),
         Utf8 => Box::new(Utf8Array::<i32>::try_from_ffi(array)?),
@@ -38,7 +38,7 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> PolarsResult<Box<dyn Array
         FixedSizeList => Box::new(FixedSizeListArray::try_from_ffi(array)?),
         Struct => Box::new(StructArray::try_from_ffi(array)?),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 Box::new(DictionaryArray::<T>::try_from_ffi(array)?)
             })
         },

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -25,8 +25,8 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> PolarsResult<Box<dyn Array
         Primitive(PrimitiveType::MonthDayNano) => {
             Box::new(PrimitiveArray::<months_days_ns>::try_from_ffi(array)?)
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            Box::new(PrimitiveArray::<$T>::try_from_ffi(array)?)
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            Box::new(PrimitiveArray::<T>::try_from_ffi(array)?)
         }),
         Utf8 => Box::new(Utf8Array::<i32>::try_from_ffi(array)?),
         LargeUtf8 => Box::new(Utf8Array::<i64>::try_from_ffi(array)?),
@@ -38,8 +38,8 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> PolarsResult<Box<dyn Array
         FixedSizeList => Box::new(FixedSizeListArray::try_from_ffi(array)?),
         Struct => Box::new(StructArray::try_from_ffi(array)?),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                Box::new(DictionaryArray::<$T>::try_from_ffi(array)?)
+            match_integer_type!(key_type, |T| {
+                Box::new(DictionaryArray::<T>::try_from_ffi(array)?)
             })
         },
         Union => Box::new(UnionArray::try_from_ffi(array)?),

--- a/crates/polars-arrow/src/ffi/bridge.rs
+++ b/crates/polars-arrow/src/ffi/bridge.rs
@@ -18,7 +18,7 @@ pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
         Null => ffi_dyn!(array, NullArray),
         Boolean => ffi_dyn!(array, BooleanArray),
         Primitive(primitive) => {
-            with_match_primitive_type_full!(primitive, |T| ffi_dyn!(array, PrimitiveArray<T>))
+            with_match_primitive_type_full!(primitive, impl<T> ffi_dyn!(array, PrimitiveArray<T>))
         },
         Binary => ffi_dyn!(array, BinaryArray<i32>),
         LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
@@ -32,7 +32,7 @@ pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
         Union => ffi_dyn!(array, UnionArray),
         Map => ffi_dyn!(array, MapArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| ffi_dyn!(array, DictionaryArray<T>))
+            match_integer_type!(key_type, impl<T> ffi_dyn!(array, DictionaryArray<T>))
         },
         BinaryView => ffi_dyn!(array, BinaryViewArray),
         Utf8View => ffi_dyn!(array, Utf8ViewArray),

--- a/crates/polars-arrow/src/ffi/bridge.rs
+++ b/crates/polars-arrow/src/ffi/bridge.rs
@@ -17,9 +17,9 @@ pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
     match array.dtype().to_physical_type() {
         Null => ffi_dyn!(array, NullArray),
         Boolean => ffi_dyn!(array, BooleanArray),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            ffi_dyn!(array, PrimitiveArray<$T>)
-        }),
+        Primitive(primitive) => {
+            with_match_primitive_type_full!(primitive, |T| ffi_dyn!(array, PrimitiveArray<T>))
+        },
         Binary => ffi_dyn!(array, BinaryArray<i32>),
         LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
         FixedSizeBinary => ffi_dyn!(array, FixedSizeBinaryArray),
@@ -32,9 +32,7 @@ pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
         Union => ffi_dyn!(array, UnionArray),
         Map => ffi_dyn!(array, MapArray),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                ffi_dyn!(array, DictionaryArray<$T>)
-            })
+            match_integer_type!(key_type, |T| ffi_dyn!(array, DictionaryArray<T>))
         },
         BinaryView => ffi_dyn!(array, BinaryViewArray),
         Utf8View => ffi_dyn!(array, Utf8ViewArray),

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -21,7 +21,7 @@ fn make_mutable(
         PhysicalType::Boolean => {
             Box::new(MutableBooleanArray::with_capacity(capacity)) as Box<dyn MutableArray>
         },
-        PhysicalType::Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             Box::new(MutablePrimitiveArray::<T>::with_capacity(capacity).to(dtype.clone()))
                 as Box<dyn MutableArray>
         }),

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -21,8 +21,8 @@ fn make_mutable(
         PhysicalType::Boolean => {
             Box::new(MutableBooleanArray::with_capacity(capacity)) as Box<dyn MutableArray>
         },
-        PhysicalType::Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            Box::new(MutablePrimitiveArray::<$T>::with_capacity(capacity).to(dtype.clone()))
+        PhysicalType::Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            Box::new(MutablePrimitiveArray::<T>::with_capacity(capacity).to(dtype.clone()))
                 as Box<dyn MutableArray>
         }),
         PhysicalType::Binary => {

--- a/crates/polars-arrow/src/io/ipc/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/ipc/read/deserialize.rs
@@ -59,7 +59,7 @@ pub fn read<R: Read + Seek>(
             scratch,
         )
         .map(|x| x.boxed()),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             read_primitive::<T, _>(
                 field_nodes,
                 dtype,
@@ -206,7 +206,7 @@ pub fn read<R: Read + Seek>(
         )
         .map(|x| x.boxed()),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| {
+            match_integer_type!(key_type, impl<T> {
                 read_dictionary::<T, _>(
                     field_nodes,
                     dtype,

--- a/crates/polars-arrow/src/io/ipc/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/ipc/read/deserialize.rs
@@ -59,8 +59,8 @@ pub fn read<R: Read + Seek>(
             scratch,
         )
         .map(|x| x.boxed()),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            read_primitive::<$T, _>(
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            read_primitive::<T, _>(
                 field_nodes,
                 dtype,
                 buffers,
@@ -206,8 +206,8 @@ pub fn read<R: Read + Seek>(
         )
         .map(|x| x.boxed()),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |$T| {
-                read_dictionary::<$T, _>(
+            match_integer_type!(key_type, |T| {
+                read_dictionary::<T, _>(
                     field_nodes,
                     dtype,
                     ipc_field.dictionary_id,

--- a/crates/polars-arrow/src/io/ipc/write/common.rs
+++ b/crates/polars-arrow/src/io/ipc/write/common.rs
@@ -46,22 +46,19 @@ pub fn dictionaries_to_encode(
     match array.dtype().to_physical_type() {
         Utf8 | LargeUtf8 | Binary | LargeBinary | Primitive(_) | Boolean | Null
         | FixedSizeBinary | BinaryView | Utf8View => Ok(()),
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            let dict_id = field.dictionary_id
-                .ok_or_else(|| polars_err!(InvalidOperation: "Dictionaries must have an associated id"))?;
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            let dict_id = field.dictionary_id.ok_or_else(
+                || polars_err!(InvalidOperation: "Dictionaries must have an associated id"),
+            )?;
 
             if dictionary_tracker.insert(dict_id, array)? {
                 dicts_to_encode.push((dict_id, array.to_boxed()));
             }
 
-            let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+            let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
             let values = array.values();
             // @Q? Should this not pick fields[0]?
-            dictionaries_to_encode(field,
-                values.as_ref(),
-                dictionary_tracker,
-                dicts_to_encode,
-            )?;
+            dictionaries_to_encode(field, values.as_ref(), dictionary_tracker, dicts_to_encode)?;
 
             Ok(())
         }),
@@ -156,8 +153,8 @@ pub fn encode_dictionary(
         panic!("Given array is not a DictionaryArray")
     };
 
-    match_integer_type!(key_type, |$T| {
-        let array: &DictionaryArray<$T> = array.as_any().downcast_ref().unwrap();
+    match_integer_type!(key_type, |T| {
+        let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
 
         encode_dictionary_values(dict_id, array.values().as_ref(), options)
     })
@@ -488,11 +485,8 @@ impl DictionaryTracker {
     pub fn insert(&mut self, dict_id: i64, array: &dyn Array) -> PolarsResult<bool> {
         let values = match array.dtype().to_storage() {
             ArrowDataType::Dictionary(key_type, _, _) => {
-                match_integer_type!(key_type, |$T| {
-                    let array = array
-                        .as_any()
-                        .downcast_ref::<DictionaryArray<$T>>()
-                        .unwrap();
+                match_integer_type!(key_type, |T| {
+                    let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
                     array.values()
                 })
             },

--- a/crates/polars-arrow/src/io/ipc/write/common.rs
+++ b/crates/polars-arrow/src/io/ipc/write/common.rs
@@ -46,7 +46,7 @@ pub fn dictionaries_to_encode(
     match array.dtype().to_physical_type() {
         Utf8 | LargeUtf8 | Binary | LargeBinary | Primitive(_) | Boolean | Null
         | FixedSizeBinary | BinaryView | Utf8View => Ok(()),
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             let dict_id = field.dictionary_id.ok_or_else(
                 || polars_err!(InvalidOperation: "Dictionaries must have an associated id"),
             )?;
@@ -153,7 +153,7 @@ pub fn encode_dictionary(
         panic!("Given array is not a DictionaryArray")
     };
 
-    match_integer_type!(key_type, |T| {
+    match_integer_type!(key_type, impl<T> {
         let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
 
         encode_dictionary_values(dict_id, array.values().as_ref(), options)
@@ -485,7 +485,7 @@ impl DictionaryTracker {
     pub fn insert(&mut self, dict_id: i64, array: &dyn Array) -> PolarsResult<bool> {
         let values = match array.dtype().to_storage() {
             ArrowDataType::Dictionary(key_type, _, _) => {
-                match_integer_type!(key_type, |T| {
+                match_integer_type!(key_type, impl<T> {
                     let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
                     array.values()
                 })

--- a/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
@@ -58,7 +58,7 @@ pub fn write(
             is_little_endian,
             compression,
         ),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let array = array.as_any().downcast_ref().unwrap();
             write_primitive::<T>(
                 array,
@@ -145,7 +145,7 @@ pub fn write(
             is_little_endian,
             compression,
         ),
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
             let keys_array: &PrimitiveArray<T> = array.keys().as_any().downcast_ref().unwrap();
 

--- a/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
@@ -58,9 +58,16 @@ pub fn write(
             is_little_endian,
             compression,
         ),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
             let array = array.as_any().downcast_ref().unwrap();
-            write_primitive::<$T>(array, buffers, arrow_data, offset, is_little_endian, compression)
+            write_primitive::<T>(
+                array,
+                buffers,
+                arrow_data,
+                offset,
+                is_little_endian,
+                compression,
+            )
         }),
         Binary => write_binary::<i32>(
             array.as_any().downcast_ref().unwrap(),
@@ -138,17 +145,17 @@ pub fn write(
             is_little_endian,
             compression,
         ),
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            let array: &DictionaryArray<$T> = array.as_any().downcast_ref().unwrap();
-            let keys_array: &PrimitiveArray<$T> = array.keys().as_any().downcast_ref().unwrap();
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
+            let keys_array: &PrimitiveArray<T> = array.keys().as_any().downcast_ref().unwrap();
 
-            write_primitive::<$T>(
+            write_primitive::<T>(
                 keys_array,
                 buffers,
                 arrow_data,
                 offset,
                 is_little_endian,
-                compression
+                compression,
             )
         }),
         Union => {

--- a/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
@@ -69,8 +69,8 @@ pub fn write_array(
             write_bitmap(ctx, array.validity())?;
             write_bitmap(ctx, Some(array.values()))?;
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            let array: &PrimitiveArray<$T> = array.as_any().downcast_ref().unwrap();
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            let array: &PrimitiveArray<T> = array.as_any().downcast_ref().unwrap();
             write_primitive(ctx, array)?;
         }),
         Binary => {
@@ -123,10 +123,10 @@ pub fn write_array(
                 write_array(ctx, field_arr.as_ref())?;
             }
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            let array: &DictionaryArray<$T> = array.as_any().downcast_ref().unwrap();
-            let keys_array: &PrimitiveArray<$T> = array.keys().as_any().downcast_ref().unwrap();
-            write_primitive::<$T>(ctx, keys_array)?
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
+            let keys_array: &PrimitiveArray<T> = array.keys().as_any().downcast_ref().unwrap();
+            write_primitive::<T>(ctx, keys_array)?
         }),
         Map => {
             let array: &MapArray = array.as_any().downcast_ref().unwrap();

--- a/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
@@ -69,7 +69,7 @@ pub fn write_array(
             write_bitmap(ctx, array.validity())?;
             write_bitmap(ctx, Some(array.values()))?;
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let array: &PrimitiveArray<T> = array.as_any().downcast_ref().unwrap();
             write_primitive(ctx, array)?;
         }),
@@ -123,7 +123,7 @@ pub fn write_array(
                 write_array(ctx, field_arr.as_ref())?;
             }
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             let array: &DictionaryArray<T> = array.as_any().downcast_ref().unwrap();
             let keys_array: &PrimitiveArray<T> = array.keys().as_any().downcast_ref().unwrap();
             write_primitive::<T>(ctx, keys_array)?

--- a/crates/polars-arrow/src/mmap/array.rs
+++ b/crates/polars-arrow/src/mmap/array.rs
@@ -533,7 +533,7 @@ fn get_array<T: AsRef<[u8]> + Send + Sync + 'static>(
     match dtype.to_physical_type() {
         Null => mmap_null(data, &node, block_offset, buffers),
         Boolean => mmap_boolean(data, &node, block_offset, buffers),
-        Primitive(p) => with_match_primitive_type_full!(p, |T| {
+        Primitive(p) => with_match_primitive_type_full!(p, impl<T> {
             mmap_primitive::<T, _>(data, &node, block_offset, buffers)
         }),
         Utf8 | Binary => mmap_binary::<i32, _>(data, &node, block_offset, buffers),
@@ -586,7 +586,7 @@ fn get_array<T: AsRef<[u8]> + Send + Sync + 'static>(
             variadic_buffer_counts,
             buffers,
         ),
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             mmap_dict::<T, _>(
                 data,
                 &node,

--- a/crates/polars-arrow/src/mmap/array.rs
+++ b/crates/polars-arrow/src/mmap/array.rs
@@ -533,8 +533,8 @@ fn get_array<T: AsRef<[u8]> + Send + Sync + 'static>(
     match dtype.to_physical_type() {
         Null => mmap_null(data, &node, block_offset, buffers),
         Boolean => mmap_boolean(data, &node, block_offset, buffers),
-        Primitive(p) => with_match_primitive_type_full!(p, |$T| {
-            mmap_primitive::<$T, _>(data, &node, block_offset, buffers)
+        Primitive(p) => with_match_primitive_type_full!(p, |T| {
+            mmap_primitive::<T, _>(data, &node, block_offset, buffers)
         }),
         Utf8 | Binary => mmap_binary::<i32, _>(data, &node, block_offset, buffers),
         Utf8View | BinaryView => {
@@ -586,8 +586,8 @@ fn get_array<T: AsRef<[u8]> + Send + Sync + 'static>(
             variadic_buffer_counts,
             buffers,
         ),
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            mmap_dict::<$T, _>(
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            mmap_dict::<T, _>(
                 data,
                 &node,
                 block_offset,

--- a/crates/polars-arrow/src/scalar/equal.rs
+++ b/crates/polars-arrow/src/scalar/equal.rs
@@ -38,14 +38,14 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
     match lhs.dtype().to_physical_type() {
         Null => dyn_eq!(NullScalar, lhs, rhs),
         Boolean => dyn_eq!(BooleanScalar, lhs, rhs),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             dyn_eq!(PrimitiveScalar<T>, lhs, rhs)
         }),
         LargeUtf8 => dyn_eq!(Utf8Scalar<i64>, lhs, rhs),
         LargeBinary => dyn_eq!(BinaryScalar<i64>, lhs, rhs),
         LargeList => dyn_eq!(ListScalar<i64>, lhs, rhs),
         Dictionary(key_type) => {
-            match_integer_type!(key_type, |T| dyn_eq!(DictionaryScalar<T>, lhs, rhs))
+            match_integer_type!(key_type, impl<T> dyn_eq!(DictionaryScalar<T>, lhs, rhs))
         },
         Struct => dyn_eq!(StructScalar, lhs, rhs),
         FixedSizeBinary => dyn_eq!(FixedSizeBinaryScalar, lhs, rhs),

--- a/crates/polars-arrow/src/scalar/equal.rs
+++ b/crates/polars-arrow/src/scalar/equal.rs
@@ -38,15 +38,15 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
     match lhs.dtype().to_physical_type() {
         Null => dyn_eq!(NullScalar, lhs, rhs),
         Boolean => dyn_eq!(BooleanScalar, lhs, rhs),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            dyn_eq!(PrimitiveScalar<$T>, lhs, rhs)
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            dyn_eq!(PrimitiveScalar<T>, lhs, rhs)
         }),
         LargeUtf8 => dyn_eq!(Utf8Scalar<i64>, lhs, rhs),
         LargeBinary => dyn_eq!(BinaryScalar<i64>, lhs, rhs),
         LargeList => dyn_eq!(ListScalar<i64>, lhs, rhs),
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            dyn_eq!(DictionaryScalar<$T>, lhs, rhs)
-        }),
+        Dictionary(key_type) => {
+            match_integer_type!(key_type, |T| dyn_eq!(DictionaryScalar<T>, lhs, rhs))
+        },
         Struct => dyn_eq!(StructScalar, lhs, rhs),
         FixedSizeBinary => dyn_eq!(FixedSizeBinaryScalar, lhs, rhs),
         FixedSizeList => dyn_eq!(FixedSizeListScalar, lhs, rhs),

--- a/crates/polars-arrow/src/scalar/mod.rs
+++ b/crates/polars-arrow/src/scalar/mod.rs
@@ -119,7 +119,7 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(BooleanScalar::new(value))
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
             let value = if array.is_valid(index) {
                 Some(array.value(index))
@@ -187,7 +187,7 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(MapScalar::new(array.dtype().clone(), value))
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+        Dictionary(key_type) => match_integer_type!(key_type, impl<T> {
             let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
             let value = if array.is_valid(index) {
                 Some(array.value(index))

--- a/crates/polars-arrow/src/scalar/mod.rs
+++ b/crates/polars-arrow/src/scalar/mod.rs
@@ -119,11 +119,8 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(BooleanScalar::new(value))
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            let array = array
-                .as_any()
-                .downcast_ref::<PrimitiveArray<$T>>()
-                .unwrap();
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
             let value = if array.is_valid(index) {
                 Some(array.value(index))
             } else {
@@ -190,20 +187,14 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(MapScalar::new(array.dtype().clone(), value))
         },
-        Dictionary(key_type) => match_integer_type!(key_type, |$T| {
-            let array = array
-                .as_any()
-                .downcast_ref::<DictionaryArray<$T>>()
-                .unwrap();
+        Dictionary(key_type) => match_integer_type!(key_type, |T| {
+            let array = array.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
             let value = if array.is_valid(index) {
-                Some(array.value(index).into())
+                Some(array.value(index))
             } else {
                 None
             };
-            Box::new(DictionaryScalar::<$T>::new(
-                array.dtype().clone(),
-                value,
-            ))
+            Box::new(DictionaryScalar::<T>::new(array.dtype().clone(), value))
         }),
     }
 }

--- a/crates/polars-arrow/src/util/macros.rs
+++ b/crates/polars-arrow/src/util/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! with_match_primitive_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use polars_utils::float16::pf16;
     use $crate::datatypes::PrimitiveType::*;
@@ -26,7 +26,7 @@ macro_rules! with_match_primitive_type {(
 
 #[macro_export]
 macro_rules! with_match_primitive_type_full {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use polars_utils::float16::pf16;
     use $crate::datatypes::PrimitiveType::*;
@@ -52,7 +52,7 @@ macro_rules! with_match_primitive_type_full {(
 
 #[macro_export]
 macro_rules! match_integer_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use $crate::datatypes::IntegerType::*;
     match $key_type {

--- a/crates/polars-arrow/src/util/macros.rs
+++ b/crates/polars-arrow/src/util/macros.rs
@@ -6,19 +6,19 @@ macro_rules! with_match_primitive_type {(
     use $crate::datatypes::PrimitiveType::*;
 
     match $key_type {
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
-        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
+        Float16 => { type $T = pf16; $($body)* },
+        Float32 => { type $T = f32; $($body)* },
+        Float64 => { type $T = f64; $($body)* },
         _ => panic!("operator does not support primitive `{:?}`",
             $key_type)
     }
@@ -32,19 +32,19 @@ macro_rules! with_match_primitive_type_full {(
     use $crate::datatypes::PrimitiveType::*;
 
     match $key_type {
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
-        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
+        Float16 => { type $T = pf16; $($body)* },
+        Float32 => { type $T = f32; $($body)* },
+        Float64 => { type $T = f64; $($body)* },
         _ => panic!("operator does not support primitive `{:?}`",
             $key_type)
     }
@@ -56,15 +56,15 @@ macro_rules! match_integer_type {(
 ) => ({
     use $crate::datatypes::IntegerType::*;
     match $key_type {
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
     }
 })}

--- a/crates/polars-arrow/src/util/macros.rs
+++ b/crates/polars-arrow/src/util/macros.rs
@@ -1,25 +1,24 @@
 #[macro_export]
 macro_rules! with_match_primitive_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use polars_utils::float16::pf16;
     use $crate::datatypes::PrimitiveType::*;
 
     match $key_type {
-        Int8 => __with_ty__! { i8 },
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        UInt8 => __with_ty__! { u8 },
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
-        UInt128 => __with_ty__! { u128 },
-        Float16 => __with_ty__! { pf16 },
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
         _ => panic!("operator does not support primitive `{:?}`",
             $key_type)
     }
@@ -27,26 +26,25 @@ macro_rules! with_match_primitive_type {(
 
 #[macro_export]
 macro_rules! with_match_primitive_type_full {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use polars_utils::float16::pf16;
     use $crate::datatypes::PrimitiveType::*;
 
     match $key_type {
-        Int8 => __with_ty__! { i8 },
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        UInt8 => __with_ty__! { u8 },
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
-        UInt128 => __with_ty__! { u128 },
-        Float16 => __with_ty__! { pf16 },
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
         _ => panic!("operator does not support primitive `{:?}`",
             $key_type)
     }
@@ -54,20 +52,19 @@ macro_rules! with_match_primitive_type_full {(
 
 #[macro_export]
 macro_rules! match_integer_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::IntegerType::*;
     match $key_type {
-        Int8 => __with_ty__! { i8 },
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        UInt8 => __with_ty__! { u8 },
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
-        UInt128 => __with_ty__! { u128 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
     }
 })}

--- a/crates/polars-compute/src/cardinality.rs
+++ b/crates/polars-compute/src/cardinality.rs
@@ -42,26 +42,23 @@ pub fn estimate_cardinality(array: &dyn Array) -> usize {
             cardinality
         },
 
-        PT::Primitive(primitive_type) => with_match_primitive_type_full!(primitive_type, |$T| {
-             let mut hll = HyperLogLog::new();
+        PT::Primitive(primitive_type) => with_match_primitive_type_full!(primitive_type, |T| {
+            let mut hll = HyperLogLog::new();
 
-             let array = array
-                 .as_any()
-                 .downcast_ref::<PrimitiveArray<$T>>()
-                 .unwrap();
+            let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
-             if array.has_nulls() {
-                 for v in array.iter() {
-                     let v = v.copied().unwrap_or_default();
-                     hll.add(&v.to_total_ord());
-                 }
-             } else {
-                 for v in array.values_iter() {
-                     hll.add(&v.to_total_ord());
-                 }
-             }
+            if array.has_nulls() {
+                for v in array.iter() {
+                    let v = v.copied().unwrap_or_default();
+                    hll.add(&v.to_total_ord());
+                }
+            } else {
+                for v in array.values_iter() {
+                    hll.add(&v.to_total_ord());
+                }
+            }
 
-             hll.count()
+            hll.count()
         }),
         PT::FixedSizeBinary => {
             let mut hll = HyperLogLog::new();

--- a/crates/polars-compute/src/cardinality.rs
+++ b/crates/polars-compute/src/cardinality.rs
@@ -42,7 +42,7 @@ pub fn estimate_cardinality(array: &dyn Array) -> usize {
             cardinality
         },
 
-        PT::Primitive(primitive_type) => with_match_primitive_type_full!(primitive_type, |T| {
+        PT::Primitive(primitive_type) => with_match_primitive_type_full!(primitive_type, impl<T> {
             let mut hll = HyperLogLog::new();
 
             let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();

--- a/crates/polars-compute/src/cast/dictionary_to.rs
+++ b/crates/polars-compute/src/cast/dictionary_to.rs
@@ -40,7 +40,7 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey + num_traits::NumCast>(
 
             // SAFETY:
             // we return an error on overflow so the integers remain within bounds
-            match_integer_type!(to_keys_type, |T| {
+            match_integer_type!(to_keys_type, impl<T> {
                 key_cast!(keys, values, array, &to_key_type, T, to_type.clone())
             })
         },

--- a/crates/polars-compute/src/cast/dictionary_to.rs
+++ b/crates/polars-compute/src/cast/dictionary_to.rs
@@ -40,8 +40,8 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey + num_traits::NumCast>(
 
             // SAFETY:
             // we return an error on overflow so the integers remain within bounds
-            match_integer_type!(to_keys_type, |$T| {
-                key_cast!(keys, values, array, &to_key_type, $T, to_type.clone())
+            match_integer_type!(to_keys_type, |T| {
+                key_cast!(keys, values, array, &to_key_type, T, to_type.clone())
             })
         },
         _ => unimplemented!(),

--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -420,11 +420,11 @@ pub fn cast(
         (Struct(_), _) | (_, Struct(_)) => polars_bail!(InvalidOperation:
             "Cannot cast from struct to other types"
         ),
-        (Dictionary(index_type, ..), _) => match_integer_type!(index_type, |$T| {
-            dictionary_cast_dyn::<$T>(array, to_type, options)
+        (Dictionary(index_type, ..), _) => match_integer_type!(index_type, |T| {
+            dictionary_cast_dyn::<T>(array, to_type, options)
         }),
-        (_, Dictionary(index_type, value_type, ordered)) => match_integer_type!(index_type, |$T| {
-            cast_to_dictionary::<$T>(array, value_type, *ordered, options)
+        (_, Dictionary(index_type, value_type, ordered)) => match_integer_type!(index_type, |T| {
+            cast_to_dictionary::<T>(array, value_type, *ordered, options)
         }),
         // not supported by polars
         // (List(_), FixedSizeList(inner, size)) => cast_list_to_fixed_size_list::<i32>(

--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -420,12 +420,14 @@ pub fn cast(
         (Struct(_), _) | (_, Struct(_)) => polars_bail!(InvalidOperation:
             "Cannot cast from struct to other types"
         ),
-        (Dictionary(index_type, ..), _) => match_integer_type!(index_type, |T| {
+        (Dictionary(index_type, ..), _) => match_integer_type!(index_type, impl<T> {
             dictionary_cast_dyn::<T>(array, to_type, options)
         }),
-        (_, Dictionary(index_type, value_type, ordered)) => match_integer_type!(index_type, |T| {
-            cast_to_dictionary::<T>(array, value_type, *ordered, options)
-        }),
+        (_, Dictionary(index_type, value_type, ordered)) => {
+            match_integer_type!(index_type, impl<T> {
+                cast_to_dictionary::<T>(array, value_type, *ordered, options)
+            })
+        },
         // not supported by polars
         // (List(_), FixedSizeList(inner, size)) => cast_list_to_fixed_size_list::<i32>(
         //     array.as_any().downcast_ref().unwrap(),

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -53,7 +53,7 @@ pub fn filter_with_bitmap(array: &dyn Array, mask: &Bitmap) -> Box<dyn Array> {
 
     use arrow::datatypes::PhysicalType::*;
     match array.dtype().to_physical_type() {
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let array: &PrimitiveArray<T> = array.as_any().downcast_ref().unwrap();
             let (values, validity) =
                 primitive::filter_values_and_validity::<T>(array.values(), array.validity(), mask);

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -53,9 +53,10 @@ pub fn filter_with_bitmap(array: &dyn Array, mask: &Bitmap) -> Box<dyn Array> {
 
     use arrow::datatypes::PhysicalType::*;
     match array.dtype().to_physical_type() {
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
-            let array: &PrimitiveArray<$T> = array.as_any().downcast_ref().unwrap();
-            let (values, validity) = primitive::filter_values_and_validity::<$T>(array.values(), array.validity(), mask);
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+            let array: &PrimitiveArray<T> = array.as_any().downcast_ref().unwrap();
+            let (values, validity) =
+                primitive::filter_values_and_validity::<T>(array.values(), array.validity(), mask);
             Box::new(PrimitiveArray::from_vec(values).with_validity(validity))
         }),
         Boolean => {

--- a/crates/polars-compute/src/gather/fixed_size_list.rs
+++ b/crates/polars-compute/src/gather/fixed_size_list.rs
@@ -47,7 +47,7 @@ fn get_leaves(array: &FixedSizeListArray) -> &dyn Array {
 
 fn get_buffer_and_size(array: &dyn Array) -> (&[u8], usize) {
     match array.dtype().to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, impl<T> {
             let arr = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
             let values = arr.values();
             (bytemuck::cast_slice(values), size_of::<T>())
@@ -60,7 +60,7 @@ fn get_buffer_and_size(array: &dyn Array) -> (&[u8], usize) {
 
 unsafe fn from_buffer(mut buf: ManuallyDrop<Vec<u8>>, dtype: &ArrowDataType) -> ArrayRef {
     match dtype.to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, impl<T> {
             let ptr = buf.as_mut_ptr();
             let len_units = buf.len();
             let cap_units = buf.capacity();
@@ -83,7 +83,7 @@ unsafe fn from_buffer(mut buf: ManuallyDrop<Vec<u8>>, dtype: &ArrowDataType) -> 
 #[allow(clippy::unnecessary_cast)]
 unsafe fn aligned_vec(dt: &ArrowDataType, n_bytes: usize) -> Vec<u8> {
     match dt.to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, impl<T> {
             let n_units = (n_bytes / size_of::<T>()) + 1;
 
             let mut aligned: Vec<T> = Vec::with_capacity(n_units);

--- a/crates/polars-compute/src/gather/fixed_size_list.rs
+++ b/crates/polars-compute/src/gather/fixed_size_list.rs
@@ -47,12 +47,10 @@ fn get_leaves(array: &FixedSizeListArray) -> &dyn Array {
 
 fn get_buffer_and_size(array: &dyn Array) -> (&[u8], usize) {
     match array.dtype().to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
-
-            let arr = array.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
+            let arr = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
             let values = arr.values();
-            (bytemuck::cast_slice(values), size_of::<$T>())
-
+            (bytemuck::cast_slice(values), size_of::<T>())
         }),
         _ => {
             unimplemented!()
@@ -62,19 +60,18 @@ fn get_buffer_and_size(array: &dyn Array) -> (&[u8], usize) {
 
 unsafe fn from_buffer(mut buf: ManuallyDrop<Vec<u8>>, dtype: &ArrowDataType) -> ArrayRef {
     match dtype.to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
             let ptr = buf.as_mut_ptr();
             let len_units = buf.len();
             let cap_units = buf.capacity();
 
             let buf = Vec::from_raw_parts(
-                ptr as *mut $T,
-                len_units / size_of::<$T>(),
-                cap_units / size_of::<$T>(),
+                ptr as *mut T,
+                len_units / size_of::<T>(),
+                cap_units / size_of::<T>(),
             );
 
             PrimitiveArray::from_data_default(buf.into(), None).boxed()
-
         }),
         _ => {
             unimplemented!()
@@ -82,27 +79,27 @@ unsafe fn from_buffer(mut buf: ManuallyDrop<Vec<u8>>, dtype: &ArrowDataType) -> 
     }
 }
 
+// The `as *mut u8` cast below is a no-op for the u8 arm of the macro, but needed for the rest.
+#[allow(clippy::unnecessary_cast)]
 unsafe fn aligned_vec(dt: &ArrowDataType, n_bytes: usize) -> Vec<u8> {
     match dt.to_physical_type() {
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |T| {
+            let n_units = (n_bytes / size_of::<T>()) + 1;
 
-        let n_units = (n_bytes / size_of::<$T>()) + 1;
+            let mut aligned: Vec<T> = Vec::with_capacity(n_units);
 
-        let mut aligned: Vec<$T> = Vec::with_capacity(n_units);
+            let ptr = aligned.as_mut_ptr();
+            let len_units = aligned.len();
+            let cap_units = aligned.capacity();
 
-        let ptr = aligned.as_mut_ptr();
-        let len_units = aligned.len();
-        let cap_units = aligned.capacity();
+            std::mem::forget(aligned);
 
-        std::mem::forget(aligned);
-
-        Vec::from_raw_parts(
-            ptr as *mut u8,
-            len_units * size_of::<$T>(),
-            cap_units * size_of::<$T>(),
-        )
-
-            }),
+            Vec::from_raw_parts(
+                ptr as *mut u8,
+                len_units * size_of::<T>(),
+                cap_units * size_of::<T>(),
+            )
+        }),
         _ => {
             unimplemented!()
         },

--- a/crates/polars-compute/src/gather/mod.rs
+++ b/crates/polars-compute/src/gather/mod.rs
@@ -54,9 +54,9 @@ pub unsafe fn take_unchecked(values: &dyn Array, indices: &IdxArr) -> Box<dyn Ar
             let values = values.as_any().downcast_ref().unwrap();
             Box::new(boolean::take_unchecked(values, indices))
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
             let values = values.as_any().downcast_ref().unwrap();
-            Box::new(primitive::take_primitive_unchecked::<$T>(&values, indices))
+            Box::new(primitive::take_primitive_unchecked::<T>(values, indices))
         }),
         LargeBinary => {
             let values = values.as_any().downcast_ref().unwrap();

--- a/crates/polars-compute/src/gather/mod.rs
+++ b/crates/polars-compute/src/gather/mod.rs
@@ -54,7 +54,7 @@ pub unsafe fn take_unchecked(values: &dyn Array, indices: &IdxArr) -> Box<dyn Ar
             let values = values.as_any().downcast_ref().unwrap();
             Box::new(boolean::take_unchecked(values, indices))
         },
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             let values = values.as_any().downcast_ref().unwrap();
             Box::new(primitive::take_primitive_unchecked::<T>(values, indices))
         }),

--- a/crates/polars-compute/src/horizontal_flatten/mod.rs
+++ b/crates/polars-compute/src/horizontal_flatten/mod.rs
@@ -43,7 +43,7 @@ pub unsafe fn horizontal_flatten_unchecked(
             output_height,
             dtype,
         )),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, impl<T> {
             Box::new(horizontal_flatten_unchecked_impl_generic(
                 &arrays
                     .iter()

--- a/crates/polars-compute/src/horizontal_flatten/mod.rs
+++ b/crates/polars-compute/src/horizontal_flatten/mod.rs
@@ -43,15 +43,20 @@ pub unsafe fn horizontal_flatten_unchecked(
             output_height,
             dtype,
         )),
-        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |T| {
             Box::new(horizontal_flatten_unchecked_impl_generic(
                 &arrays
                     .iter()
-                    .map(|x| x.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap().clone())
+                    .map(|x| {
+                        x.as_any()
+                            .downcast_ref::<PrimitiveArray<T>>()
+                            .unwrap()
+                            .clone()
+                    })
                     .collect::<Vec<_>>(),
                 widths,
                 output_height,
-                dtype
+                dtype,
             ))
         }),
         LargeBinary => Box::new(horizontal_flatten_unchecked_impl_generic(

--- a/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
+++ b/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
@@ -147,11 +147,16 @@ pub fn get_fixed_size_list_builder(
     let phys_dtype = inner_type_logical.to_physical();
 
     let builder = if phys_dtype.is_primitive_numeric() {
-        with_match_physical_numeric_type!(phys_dtype, |$T| {
-        // SAFETY: physical type match logical type
-        unsafe {
-            Box::new(FixedSizeListNumericBuilder::<$T>::new(name, width, capacity,inner_type_logical.clone())) as Box<dyn FixedSizeListBuilder>
-        }
+        with_match_physical_numeric_type!(phys_dtype, |T| {
+            // SAFETY: physical type match logical type
+            unsafe {
+                Box::new(FixedSizeListNumericBuilder::<T>::new(
+                    name,
+                    width,
+                    capacity,
+                    inner_type_logical.clone(),
+                )) as Box<dyn FixedSizeListBuilder>
+            }
         })
     } else {
         Box::new(AnonymousOwnedFixedSizeListBuilder::new(

--- a/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
+++ b/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
@@ -147,7 +147,7 @@ pub fn get_fixed_size_list_builder(
     let phys_dtype = inner_type_logical.to_physical();
 
     let builder = if phys_dtype.is_primitive_numeric() {
-        with_match_physical_numeric_type!(phys_dtype, |T| {
+        with_match_physical_numeric_type!(phys_dtype, impl<T> {
             // SAFETY: physical type match logical type
             unsafe {
                 Box::new(FixedSizeListNumericBuilder::<T>::new(

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -226,12 +226,15 @@ where
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _mapping) => {
                 polars_ensure!(self.dtype() == &cats.physical().dtype(), ComputeError: "cannot cast numeric types to 'Categorical'");
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
+                with_match_categorical_physical_type!(cats.physical(), |C| {
                     // SAFETY: we are guarded by the type system.
-                    type PhysCa = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+                    type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = unsafe { &*(self as *const ChunkedArray<T> as *const PhysCa) };
-                    Ok(CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(ca.clone(), dtype.clone())
-                        .into_series())
+                    Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
+                        ca.clone(),
+                        dtype.clone(),
+                    )
+                    .into_series())
                 })
             },
 
@@ -240,11 +243,15 @@ where
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _mapping) => {
                 polars_ensure!(self.dtype() == &fcats.physical().dtype(), ComputeError: "cannot cast numeric types to 'Enum'");
-                with_match_categorical_physical_type!(fcats.physical(), |$C| {
+                with_match_categorical_physical_type!(fcats.physical(), |C| {
                     // SAFETY: we are guarded by the type system.
-                    type PhysCa = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+                    type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = unsafe { &*(self as *const ChunkedArray<T> as *const PhysCa) };
-                    Ok(CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(ca.clone(), dtype.clone()).into_series())
+                    Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
+                        ca.clone(),
+                        dtype.clone(),
+                    )
+                    .into_series())
                 })
             },
 
@@ -258,16 +265,24 @@ impl ChunkCast for StringChunked {
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _mapping) => {
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
-                    Ok(CategoricalChunked::<$C>::from_str_iter(self.name().clone(), dtype.clone(), self.iter())?
-                        .into_series())
+                with_match_categorical_physical_type!(cats.physical(), |C| {
+                    Ok(CategoricalChunked::<C>::from_str_iter(
+                        self.name().clone(),
+                        dtype.clone(),
+                        self.iter(),
+                    )?
+                    .into_series())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _mapping) => {
-                let ret = with_match_categorical_physical_type!(fcats.physical(), |$C| {
-                    CategoricalChunked::<$C>::from_str_iter(self.name().clone(), dtype.clone(), self.iter())?
-                        .into_series()
+                let ret = with_match_categorical_physical_type!(fcats.physical(), |C| {
+                    CategoricalChunked::<C>::from_str_iter(
+                        self.name().clone(),
+                        dtype.clone(),
+                        self.iter(),
+                    )?
+                    .into_series()
                 });
 
                 if options.is_strict() && self.null_count() != ret.null_count() {

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -226,7 +226,7 @@ where
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _mapping) => {
                 polars_ensure!(self.dtype() == &cats.physical().dtype(), ComputeError: "cannot cast numeric types to 'Categorical'");
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     // SAFETY: we are guarded by the type system.
                     type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = unsafe { &*(self as *const ChunkedArray<T> as *const PhysCa) };
@@ -243,7 +243,7 @@ where
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _mapping) => {
                 polars_ensure!(self.dtype() == &fcats.physical().dtype(), ComputeError: "cannot cast numeric types to 'Enum'");
-                with_match_categorical_physical_type!(fcats.physical(), |C| {
+                with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                     // SAFETY: we are guarded by the type system.
                     type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = unsafe { &*(self as *const ChunkedArray<T> as *const PhysCa) };
@@ -265,7 +265,7 @@ impl ChunkCast for StringChunked {
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _mapping) => {
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     Ok(CategoricalChunked::<C>::from_str_iter(
                         self.name().clone(),
                         dtype.clone(),
@@ -276,7 +276,7 @@ impl ChunkCast for StringChunked {
             },
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _mapping) => {
-                let ret = with_match_categorical_physical_type!(fcats.physical(), |C| {
+                let ret = with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                     CategoricalChunked::<C>::from_str_iter(
                         self.name().clone(),
                         dtype.clone(),

--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -268,7 +268,7 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
 
             DataType::Enum(fcats, _mapping) => {
                 // TODO @ cat-rework: if len >= self.mapping().upper_bound(), remap categories then index into array.
-                let ret = with_match_categorical_physical_type!(fcats.physical(), |C| {
+                let ret = with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                     CategoricalChunked::<C>::from_str_iter(
                         self.name().clone(),
                         dtype.clone(),
@@ -288,7 +288,7 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
                 // TODO @ cat-rework: if len >= self.mapping().upper_bound(), remap categories then index into array.
                 Ok(with_match_categorical_physical_type!(
                     cats.physical(),
-                    |C| {
+                    impl<C> {
                         CategoricalChunked::<C>::from_str_iter(
                             self.name().clone(),
                             dtype.clone(),

--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -268,12 +268,13 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
 
             DataType::Enum(fcats, _mapping) => {
                 // TODO @ cat-rework: if len >= self.mapping().upper_bound(), remap categories then index into array.
-                let ret = with_match_categorical_physical_type!(fcats.physical(), |$C| {
-                    CategoricalChunked::<$C>::from_str_iter(
+                let ret = with_match_categorical_physical_type!(fcats.physical(), |C| {
+                    CategoricalChunked::<C>::from_str_iter(
                         self.name().clone(),
                         dtype.clone(),
-                        self.iter_str()
-                    )?.into_series()
+                        self.iter_str(),
+                    )?
+                    .into_series()
                 });
 
                 if options.is_strict() && self.null_count() != ret.null_count() {
@@ -285,15 +286,17 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
 
             DataType::Categorical(cats, _mapping) => {
                 // TODO @ cat-rework: if len >= self.mapping().upper_bound(), remap categories then index into array.
-                Ok(
-                    with_match_categorical_physical_type!(cats.physical(), |$C| {
-                        CategoricalChunked::<$C>::from_str_iter(
+                Ok(with_match_categorical_physical_type!(
+                    cats.physical(),
+                    |C| {
+                        CategoricalChunked::<C>::from_str_iter(
                             self.name().clone(),
                             dtype.clone(),
-                            self.iter_str()
-                        )?.into_series()
-                    }),
-                )
+                            self.iter_str(),
+                        )?
+                        .into_series()
+                    }
+                ))
             },
 
             dt if dt.is_integer() => {

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -83,7 +83,7 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         },
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(cats, mapping) => {
-            with_match_categorical_physical_type!(cats.physical(), |C| {
+            with_match_categorical_physical_type!(cats.physical(), impl<C> {
                 type A = <C as PolarsDataType>::Array;
                 let arr = &*(arr as *const dyn Array as *const A);
                 let cat_id = arr.value_unchecked(idx).as_cat();
@@ -92,7 +92,7 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         },
         #[cfg(feature = "dtype-categorical")]
         DataType::Enum(fcats, mapping) => {
-            with_match_categorical_physical_type!(fcats.physical(), |C| {
+            with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                 type A = <C as PolarsDataType>::Array;
                 let arr = &*(arr as *const dyn Array as *const A);
                 let cat_id = arr.value_unchecked(idx).as_cat();

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -83,8 +83,8 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         },
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(cats, mapping) => {
-            with_match_categorical_physical_type!(cats.physical(), |$C| {
-                type A = <$C as PolarsDataType>::Array;
+            with_match_categorical_physical_type!(cats.physical(), |C| {
+                type A = <C as PolarsDataType>::Array;
                 let arr = &*(arr as *const dyn Array as *const A);
                 let cat_id = arr.value_unchecked(idx).as_cat();
                 AnyValue::Categorical(cat_id, mapping)
@@ -92,8 +92,8 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         },
         #[cfg(feature = "dtype-categorical")]
         DataType::Enum(fcats, mapping) => {
-            with_match_categorical_physical_type!(fcats.physical(), |$C| {
-                type A = <$C as PolarsDataType>::Array;
+            with_match_categorical_physical_type!(fcats.physical(), |C| {
+                type A = <C as PolarsDataType>::Array;
                 let arr = &*(arr as *const dyn Array as *const A);
                 let cat_id = arr.value_unchecked(idx).as_cat();
                 AnyValue::Enum(cat_id, mapping)

--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -32,7 +32,7 @@ impl ListChunked {
                 ExplodeByOffsets::explode_by_offsets(t, offsets, options).into_series()
             },
             dtype => {
-                with_match_physical_numeric_polars_type!(dtype, |T| {
+                with_match_physical_numeric_polars_type!(dtype, impl<T> {
                     let t: &ChunkedArray<T> = values.as_ref().as_ref();
                     ExplodeByOffsets::explode_by_offsets(t, offsets, options).into_series()
                 })

--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -32,8 +32,8 @@ impl ListChunked {
                 ExplodeByOffsets::explode_by_offsets(t, offsets, options).into_series()
             },
             dtype => {
-                with_match_physical_numeric_polars_type!(dtype, |$T| {
-                    let t: &ChunkedArray<$T> = values.as_ref().as_ref();
+                with_match_physical_numeric_polars_type!(dtype, |T| {
+                    let t: &ChunkedArray<T> = values.as_ref().as_ref();
                     ExplodeByOffsets::explode_by_offsets(t, offsets, options).into_series()
                 })
             },

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -120,7 +120,7 @@ impl Series {
                     {
                         with_match_categorical_physical_type!(
                             logical_type.cat_physical().unwrap(),
-                            |C| {
+                            impl<C> {
                                 let ca = self.cat::<C>().unwrap();
                                 fill_null_cat(ca, strategy)
                             }
@@ -138,7 +138,7 @@ impl Series {
                         fill_null_binary(ca, strategy).map(|ca| ca.into_series())
                     },
                     dt if dt.is_primitive_numeric() => {
-                        with_match_physical_numeric_polars_type!(dt, |T| {
+                        with_match_physical_numeric_polars_type!(dt, impl<T> {
                             let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                             fill_null_numeric(ca, strategy).map(|ca| ca.into_series())
                         })

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -118,10 +118,13 @@ impl Series {
                             FillNullStrategy::Forward(_) | FillNullStrategy::Backward(_)
                         )) =>
                     {
-                        with_match_categorical_physical_type!(logical_type.cat_physical().unwrap(), |$C| {
-                            let ca = self.cat::<$C>().unwrap();
-                            fill_null_cat(ca, strategy)
-                        })
+                        with_match_categorical_physical_type!(
+                            logical_type.cat_physical().unwrap(),
+                            |C| {
+                                let ca = self.cat::<C>().unwrap();
+                                fill_null_cat(ca, strategy)
+                            }
+                        )
                     },
 
                     Boolean => fill_null_bool(s.bool().unwrap(), strategy),
@@ -135,9 +138,9 @@ impl Series {
                         fill_null_binary(ca, strategy).map(|ca| ca.into_series())
                     },
                     dt if dt.is_primitive_numeric() => {
-                        with_match_physical_numeric_polars_type!(dt, |$T| {
-                            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                                fill_null_numeric(ca, strategy).map(|ca| ca.into_series())
+                        with_match_physical_numeric_polars_type!(dt, |T| {
+                            let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+                            fill_null_numeric(ca, strategy).map(|ca| ca.into_series())
                         })
                     },
                     dt => {

--- a/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
+++ b/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
@@ -46,10 +46,9 @@ pub fn float_arg_max_sorted_ascending<T>(ca: &ChunkedArray<T>) -> usize
 where
     T: PolarsNumericType,
 {
-    with_match_physical_float_polars_type!(ca.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = unsafe {
-            &*(ca as *const ChunkedArray<T> as *const ChunkedArray<$T>)
-        };
+    with_match_physical_float_polars_type!(ca.dtype(), |F| {
+        let ca: &ChunkedArray<F> =
+            unsafe { &*(ca as *const ChunkedArray<T> as *const ChunkedArray<F>) };
         ca.float_arg_max_sorted_ascending()
     })
 }
@@ -60,10 +59,9 @@ pub fn float_arg_max_sorted_descending<T>(ca: &ChunkedArray<T>) -> usize
 where
     T: PolarsNumericType,
 {
-    with_match_physical_float_polars_type!(ca.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = unsafe {
-            &*(ca as *const ChunkedArray<T> as *const ChunkedArray<$T>)
-        };
+    with_match_physical_float_polars_type!(ca.dtype(), |F| {
+        let ca: &ChunkedArray<F> =
+            unsafe { &*(ca as *const ChunkedArray<T> as *const ChunkedArray<F>) };
         ca.float_arg_max_sorted_descending()
     })
 }

--- a/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
+++ b/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
@@ -46,7 +46,7 @@ pub fn float_arg_max_sorted_ascending<T>(ca: &ChunkedArray<T>) -> usize
 where
     T: PolarsNumericType,
 {
-    with_match_physical_float_polars_type!(ca.dtype(), |F| {
+    with_match_physical_float_polars_type!(ca.dtype(), impl<F> {
         let ca: &ChunkedArray<F> =
             unsafe { &*(ca as *const ChunkedArray<T> as *const ChunkedArray<F>) };
         ca.float_arg_max_sorted_ascending()
@@ -59,7 +59,7 @@ pub fn float_arg_max_sorted_descending<T>(ca: &ChunkedArray<T>) -> usize
 where
     T: PolarsNumericType,
 {
-    with_match_physical_float_polars_type!(ca.dtype(), |F| {
+    with_match_physical_float_polars_type!(ca.dtype(), impl<F> {
         let ca: &ChunkedArray<F> =
             unsafe { &*(ca as *const ChunkedArray<T> as *const ChunkedArray<F>) };
         ca.float_arg_max_sorted_descending()

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -416,14 +416,14 @@ impl Debug for Series {
             DataType::Object(_) => format_object_array(f, self, self.name(), "Series"),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     format_array!(f, self.cat::<C>().unwrap(), "cat", self.name(), "Series")
                 })
             },
 
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _) => {
-                with_match_categorical_physical_type!(fcats.physical(), |C| {
+                with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                     format_array!(f, self.cat::<C>().unwrap(), "enum", self.name(), "Series")
                 })
             },

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -416,15 +416,15 @@ impl Debug for Series {
             DataType::Object(_) => format_object_array(f, self, self.name(), "Series"),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
-                    format_array!(f, self.cat::<$C>().unwrap(), "cat", self.name(), "Series")
+                with_match_categorical_physical_type!(cats.physical(), |C| {
+                    format_array!(f, self.cat::<C>().unwrap(), "cat", self.name(), "Series")
                 })
             },
 
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _) => {
-                with_match_categorical_physical_type!(fcats.physical(), |$C| {
-                    format_array!(f, self.cat::<$C>().unwrap(), "enum", self.name(), "Series")
+                with_match_categorical_physical_type!(fcats.physical(), |C| {
+                    format_array!(f, self.cat::<C>().unwrap(), "enum", self.name(), "Series")
                 })
             },
             #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -86,8 +86,8 @@ pub fn rolling_numeric_minmax_by(by_col: &Column, slices: &GroupsSlice, is_max_b
     let starts: Vec<IdxSize> = slices.iter().map(|s| s[0]).collect();
     let ends: Vec<IdxSize> = slices.iter().map(|s| s[0] + s[1]).collect();
 
-    let arr = with_match_physical_numeric_polars_type!(phys_dtype, |$T| {
-        let ca: &ChunkedArray<$T> = by_phys.as_ref().as_ref().as_ref();
+    let arr = with_match_physical_numeric_polars_type!(phys_dtype, |T| {
+        let ca: &ChunkedArray<T> = by_phys.as_ref().as_ref().as_ref();
         let arr = ca.downcast_as_array();
         let values = arr.values().as_slice();
         let validity = arr.validity();

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -86,7 +86,7 @@ pub fn rolling_numeric_minmax_by(by_col: &Column, slices: &GroupsSlice, is_max_b
     let starts: Vec<IdxSize> = slices.iter().map(|s| s[0]).collect();
     let ends: Vec<IdxSize> = slices.iter().map(|s| s[0] + s[1]).collect();
 
-    let arr = with_match_physical_numeric_polars_type!(phys_dtype, |T| {
+    let arr = with_match_physical_numeric_polars_type!(phys_dtype, impl<T> {
         let ca: &ChunkedArray<T> = by_phys.as_ref().as_ref().as_ref();
         let arr = ca.downcast_as_array();
         let values = arr.values().as_slice();

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -597,8 +597,8 @@ fn any_values_to_categorical(
     dtype: &DataType,
     strict: bool,
 ) -> PolarsResult<Series> {
-    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |$C| {
-        let mut builder = CategoricalChunkedBuilder::<$C>::new(PlSmallStr::EMPTY, dtype.clone());
+    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+        let mut builder = CategoricalChunkedBuilder::<C>::new(PlSmallStr::EMPTY, dtype.clone());
 
         let mut owned = String::new(); // Amortize allocations.
         for av in values {
@@ -606,10 +606,10 @@ fn any_values_to_categorical(
                 AnyValue::String(s) => builder.append_str(s),
                 AnyValue::StringOwned(s) => builder.append_str(s),
 
-                &AnyValue::Enum(cat, &ref map) |
-                &AnyValue::EnumOwned(cat, ref map) |
-                &AnyValue::Categorical(cat, &ref map) |
-                &AnyValue::CategoricalOwned(cat, ref map) => builder.append_cat(cat, map),
+                &AnyValue::Enum(cat, &ref map)
+                | &AnyValue::EnumOwned(cat, ref map)
+                | &AnyValue::Categorical(cat, &ref map)
+                | &AnyValue::CategoricalOwned(cat, ref map) => builder.append_cat(cat, map),
 
                 AnyValue::Binary(_) | AnyValue::BinaryOwned(_) if !strict => {
                     builder.append_null();
@@ -618,7 +618,7 @@ fn any_values_to_categorical(
                 AnyValue::Null => {
                     builder.append_null();
                     Ok(())
-                }
+                },
 
                 av => {
                     if strict {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -597,7 +597,7 @@ fn any_values_to_categorical(
     dtype: &DataType,
     strict: bool,
 ) -> PolarsResult<Series> {
-    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), impl<C> {
         let mut builder = CategoricalChunkedBuilder::<C>::new(PlSmallStr::EMPTY, dtype.clone());
 
         let mut owned = String::new(); // Amortize allocations.

--- a/crates/polars-core/src/series/arithmetic/bitops.rs
+++ b/crates/polars-core/src/series/arithmetic/bitops.rs
@@ -25,8 +25,8 @@ macro_rules! impl_bitop {
                             Cow::Borrowed(rhs)
                         };
 
-                        with_match_physical_integer_polars_type!(dt, |$T| {
-                            let lhs: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
+                        with_match_physical_integer_polars_type!(dt, |T| {
+                            let lhs: &ChunkedArray<T> = self.as_ref().as_ref().as_ref();
                             let rhs = lhs.unpack_series_matching_type(&rhs)?;
                             Ok(lhs.$f(&rhs).into_series())
                         })

--- a/crates/polars-core/src/series/arithmetic/bitops.rs
+++ b/crates/polars-core/src/series/arithmetic/bitops.rs
@@ -25,7 +25,7 @@ macro_rules! impl_bitop {
                             Cow::Borrowed(rhs)
                         };
 
-                        with_match_physical_integer_polars_type!(dt, |T| {
+                        with_match_physical_integer_polars_type!(dt, impl<T> {
                             let lhs: &ChunkedArray<T> = self.as_ref().as_ref().as_ref();
                             let rhs = lhs.unpack_series_matching_type(&rhs)?;
                             Ok(lhs.$f(&rhs).into_series())

--- a/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
+++ b/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
@@ -419,7 +419,7 @@ mod inner {
             debug_assert_eq!(prim_dtype, &self.output_primitive_dtype);
 
             // Safety: Leaf dtypes have been checked to be numeric by `try_new()`
-            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |T| {
+            let out = with_match_physical_numeric_polars_type!(&prim_dtype, impl<T> {
                 self._finish_impl::<T>(prim_lhs, prim_rhs)
             });
 
@@ -466,14 +466,14 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 for inner_idx in 0..stride {
                                     let l = arr_lhs.value_unchecked(stride * outer_idx + inner_idx);
                                     let r = arr_rhs.value_unchecked(inner_idx);
 
-                                    *out_ptr.add(stride * outer_idx + inner_idx) = op(l, r);
+                                    *out_ptr.add(stride * outer_idx + inner_idx) = $OP(l, r);
                                 }
                             }
                         }
@@ -516,7 +516,7 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 let r = arr_rhs.value_unchecked(outer_idx);
@@ -524,7 +524,7 @@ mod inner {
                                 for inner_idx in 0..stride {
                                     let l = arr_lhs.value_unchecked(inner_idx);
 
-                                    *out_ptr.add(stride * outer_idx + inner_idx) = op(l, r);
+                                    *out_ptr.add(stride * outer_idx + inner_idx) = $OP(l, r);
                                 }
                             }
                         }
@@ -566,7 +566,7 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 let r = arr_rhs.value_unchecked(outer_idx);
@@ -575,7 +575,7 @@ mod inner {
                                     let idx = stride * outer_idx + inner_idx;
                                     let l = arr_lhs.value_unchecked(idx);
 
-                                    *out_ptr.add(idx) = op(l, r);
+                                    *out_ptr.add(idx) = $OP(l, r);
                                 }
                             }
                         }

--- a/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
+++ b/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
@@ -419,8 +419,8 @@ mod inner {
             debug_assert_eq!(prim_dtype, &self.output_primitive_dtype);
 
             // Safety: Leaf dtypes have been checked to be numeric by `try_new()`
-            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |$T| {
-                self._finish_impl::<$T>(prim_lhs, prim_rhs)
+            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |T| {
+                self._finish_impl::<T>(prim_lhs, prim_rhs)
             });
 
             debug_assert_eq!(out.dtype(), &output_dtype);
@@ -466,14 +466,14 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 for inner_idx in 0..stride {
                                     let l = arr_lhs.value_unchecked(stride * outer_idx + inner_idx);
                                     let r = arr_rhs.value_unchecked(inner_idx);
 
-                                    *out_ptr.add(stride * outer_idx + inner_idx) = $OP(l, r);
+                                    *out_ptr.add(stride * outer_idx + inner_idx) = op(l, r);
                                 }
                             }
                         }
@@ -516,7 +516,7 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 let r = arr_rhs.value_unchecked(outer_idx);
@@ -524,7 +524,7 @@ mod inner {
                                 for inner_idx in 0..stride {
                                     let l = arr_lhs.value_unchecked(inner_idx);
 
-                                    *out_ptr.add(stride * outer_idx + inner_idx) = $OP(l, r);
+                                    *out_ptr.add(stride * outer_idx + inner_idx) = op(l, r);
                                 }
                             }
                         }
@@ -566,7 +566,7 @@ mod inner {
                     let out_ptr: *mut T::Native = out_vec.as_mut_ptr();
                     let stride = self.stride;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
                         unsafe {
                             for outer_idx in 0..self.output_len {
                                 let r = arr_rhs.value_unchecked(outer_idx);
@@ -575,7 +575,7 @@ mod inner {
                                     let idx = stride * outer_idx + inner_idx;
                                     let l = arr_lhs.value_unchecked(idx);
 
-                                    *out_ptr.add(idx) = $OP(l, r);
+                                    *out_ptr.add(idx) = op(l, r);
                                 }
                             }
                         }

--- a/crates/polars-core/src/series/arithmetic/list.rs
+++ b/crates/polars-core/src/series/arithmetic/list.rs
@@ -433,8 +433,8 @@ mod inner {
             debug_assert_eq!(prim_dtype, &self.output_primitive_dtype);
 
             // Safety: Leaf dtypes have been checked to be numeric by `try_new()`
-            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |$T| {
-                self._finish_impl::<$T>(prim_lhs, prim_rhs)
+            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |T| {
+                self._finish_impl::<T>(prim_lhs, prim_rhs)
             })?;
 
             debug_assert_eq!(out.dtype(), &output_dtype);
@@ -531,18 +531,15 @@ mod inner {
                     // list lengths.
                     let mut mismatch_pos = 0;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
                         for (i, ((lhs_start, lhs_len), (rhs_start, rhs_len))) in offsets_lhs
                             .offset_and_length_iter()
                             .zip(offsets_rhs.offset_and_length_iter())
                             .enumerate()
                         {
-                            if
-                                (mismatch_pos == i)
-                                & (
-                                    (lhs_len == rhs_len)
-                                    | unsafe { !self.outer_validity.get_bit_unchecked(i) }
-                                )
+                            if (mismatch_pos == i)
+                                & ((lhs_len == rhs_len)
+                                    | unsafe { !self.outer_validity.get_bit_unchecked(i) })
                             {
                                 mismatch_pos += 1;
                             }
@@ -557,7 +554,7 @@ mod inner {
 
                                 let l = unsafe { arr_lhs.value_unchecked(l_idx) };
                                 let r = unsafe { arr_rhs.value_unchecked(r_idx) };
-                                let v = $OP(l, r);
+                                let v = op(l, r);
 
                                 unsafe { out_ptr.add(l_idx).write(v) };
                             }
@@ -640,8 +637,10 @@ mod inner {
 
                     let mut mismatch_pos = 0;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
-                        for (i, (lhs_start, lhs_len)) in offsets_lhs.offset_and_length_iter().enumerate() {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                        for (i, (lhs_start, lhs_len)) in
+                            offsets_lhs.offset_and_length_iter().enumerate()
+                        {
                             if ((lhs_len == width) & (mismatch_pos == i))
                                 | unsafe { !self.outer_validity.get_bit_unchecked(i) }
                             {
@@ -656,7 +655,7 @@ mod inner {
 
                                 let l = unsafe { arr_lhs.value_unchecked(l_idx) };
                                 let r = unsafe { arr_rhs.value_unchecked(r_idx) };
-                                let v = $OP(l, r);
+                                let v = op(l, r);
 
                                 unsafe {
                                     out_ptr.add(l_idx).write(v);
@@ -737,14 +736,15 @@ mod inner {
                     let mut out_vec = Vec::<T::Native>::with_capacity(n_values);
                     let out_ptr = out_vec.as_mut_ptr();
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
-                        for (i, l_range) in OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                        for (i, l_range) in
+                            OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
                         {
                             let r = unsafe { arr_rhs.value_unchecked(i) };
                             for l_idx in l_range {
                                 unsafe {
                                     let l = arr_lhs.value_unchecked(l_idx);
-                                    let v = $OP(l, r);
+                                    let v = op(l, r);
                                     out_ptr.add(l_idx).write(v);
                                 }
                             }
@@ -788,14 +788,15 @@ mod inner {
                     let arr_lhs_mut_slice = arr_lhs.get_mut_values().unwrap();
                     assert_eq!(arr_lhs_mut_slice.len(), n_values);
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
-                        for (i, l_range) in OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                        for (i, l_range) in
+                            OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
                         {
                             let r = unsafe { arr_rhs.value_unchecked(i) };
                             for l_idx in l_range {
                                 unsafe {
                                     let l = arr_lhs_mut_slice.get_unchecked_mut(l_idx);
-                                    *l = $OP(*l, r);
+                                    *l = op(*l, r);
                                 }
                             }
                         }

--- a/crates/polars-core/src/series/arithmetic/list.rs
+++ b/crates/polars-core/src/series/arithmetic/list.rs
@@ -433,7 +433,7 @@ mod inner {
             debug_assert_eq!(prim_dtype, &self.output_primitive_dtype);
 
             // Safety: Leaf dtypes have been checked to be numeric by `try_new()`
-            let out = with_match_physical_numeric_polars_type!(&prim_dtype, |T| {
+            let out = with_match_physical_numeric_polars_type!(&prim_dtype, impl<T> {
                 self._finish_impl::<T>(prim_lhs, prim_rhs)
             })?;
 
@@ -531,15 +531,18 @@ mod inner {
                     // list lengths.
                     let mut mismatch_pos = 0;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
                         for (i, ((lhs_start, lhs_len), (rhs_start, rhs_len))) in offsets_lhs
                             .offset_and_length_iter()
                             .zip(offsets_rhs.offset_and_length_iter())
                             .enumerate()
                         {
-                            if (mismatch_pos == i)
-                                & ((lhs_len == rhs_len)
-                                    | unsafe { !self.outer_validity.get_bit_unchecked(i) })
+                            if
+                                (mismatch_pos == i)
+                                & (
+                                    (lhs_len == rhs_len)
+                                    | unsafe { !self.outer_validity.get_bit_unchecked(i) }
+                                )
                             {
                                 mismatch_pos += 1;
                             }
@@ -554,7 +557,7 @@ mod inner {
 
                                 let l = unsafe { arr_lhs.value_unchecked(l_idx) };
                                 let r = unsafe { arr_rhs.value_unchecked(r_idx) };
-                                let v = op(l, r);
+                                let v = $OP(l, r);
 
                                 unsafe { out_ptr.add(l_idx).write(v) };
                             }
@@ -637,10 +640,8 @@ mod inner {
 
                     let mut mismatch_pos = 0;
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
-                        for (i, (lhs_start, lhs_len)) in
-                            offsets_lhs.offset_and_length_iter().enumerate()
-                        {
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                        for (i, (lhs_start, lhs_len)) in offsets_lhs.offset_and_length_iter().enumerate() {
                             if ((lhs_len == width) & (mismatch_pos == i))
                                 | unsafe { !self.outer_validity.get_bit_unchecked(i) }
                             {
@@ -655,7 +656,7 @@ mod inner {
 
                                 let l = unsafe { arr_lhs.value_unchecked(l_idx) };
                                 let r = unsafe { arr_rhs.value_unchecked(r_idx) };
-                                let v = op(l, r);
+                                let v = $OP(l, r);
 
                                 unsafe {
                                     out_ptr.add(l_idx).write(v);
@@ -736,15 +737,14 @@ mod inner {
                     let mut out_vec = Vec::<T::Native>::with_capacity(n_values);
                     let out_ptr = out_vec.as_mut_ptr();
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
-                        for (i, l_range) in
-                            OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                        for (i, l_range) in OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
                         {
                             let r = unsafe { arr_rhs.value_unchecked(i) };
                             for l_idx in l_range {
                                 unsafe {
                                     let l = arr_lhs.value_unchecked(l_idx);
-                                    let v = op(l, r);
+                                    let v = $OP(l, r);
                                     out_ptr.add(l_idx).write(v);
                                 }
                             }
@@ -788,15 +788,14 @@ mod inner {
                     let arr_lhs_mut_slice = arr_lhs.get_mut_values().unwrap();
                     assert_eq!(arr_lhs_mut_slice.len(), n_values);
 
-                    with_match_pl_num_arith!(&self.op.0, self.swapped, |op| {
-                        for (i, l_range) in
-                            OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
+                    with_match_pl_num_arith!(&self.op.0, self.swapped, |$OP| {
+                        for (i, l_range) in OffsetsBuffer::<i64>::leaf_ranges_iter(offsets_lhs).enumerate()
                         {
                             let r = unsafe { arr_rhs.value_unchecked(i) };
                             for l_idx in l_range {
                                 unsafe {
                                     let l = arr_lhs_mut_slice.get_unchecked_mut(l_idx);
-                                    *l = op(*l, r);
+                                    *l = $OP(*l, r);
                                 }
                             }
                         }

--- a/crates/polars-core/src/series/arithmetic/list_utils.rs
+++ b/crates/polars-core/src/series/arithmetic/list_utils.rs
@@ -88,14 +88,14 @@ impl NumericOp {
         let lhs = lhs.rechunk();
         let rhs = rhs.rechunk();
 
-        with_match_physical_numeric_polars_type!(lhs.dtype(), |$T| {
-            let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-            let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(lhs.dtype(), |T| {
+            let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref();
+            let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref();
 
             let lhs = lhs.downcast_get(0).unwrap();
             let rhs = rhs.downcast_get(0).unwrap();
 
-            Box::new(self.apply_arithmetic_kernel::<$T>(lhs.clone(), rhs.clone()))
+            Box::new(self.apply_arithmetic_kernel::<T>(lhs.clone(), rhs.clone()))
         })
     }
 
@@ -159,38 +159,44 @@ impl NumericOp {
 }
 
 macro_rules! with_match_pl_num_arith {
-    ($op:expr, $swapped:expr, | $_:tt $OP:tt | $($body:tt)* ) => ({
-        macro_rules! __with_func__ {( $_ $OP:tt ) => ( $($body)* )}
-
+    ($op:expr, $swapped:expr, |$OP:ident| $($body:tt)* ) => ({
         match $op {
-            NumericOp::Add => __with_func__! { (PlNumArithmetic::wrapping_add) },
+            NumericOp::Add => { let $OP = PlNumArithmetic::wrapping_add; $($body)* },
             NumericOp::Sub => {
                 if $swapped {
-                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_sub(a, b)) }
+                    let $OP = |b, a| PlNumArithmetic::wrapping_sub(a, b);
+                    $($body)*
                 } else {
-                    __with_func__! { (PlNumArithmetic::wrapping_sub) }
+                    let $OP = PlNumArithmetic::wrapping_sub;
+                    $($body)*
                 }
             },
-            NumericOp::Mul => __with_func__! { (PlNumArithmetic::wrapping_mul) },
+            NumericOp::Mul => { let $OP = PlNumArithmetic::wrapping_mul; $($body)* },
             NumericOp::Div => {
                 if $swapped {
-                    __with_func__! { (|b, a| PlNumArithmetic::legacy_div(a, b)) }
+                    let $OP = |b, a| PlNumArithmetic::legacy_div(a, b);
+                    $($body)*
                 } else {
-                    __with_func__! { (PlNumArithmetic::legacy_div) }
+                    let $OP = PlNumArithmetic::legacy_div;
+                    $($body)*
                 }
             },
             NumericOp::Rem => {
                 if $swapped {
-                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_mod(a, b)) }
+                    let $OP = |b, a| PlNumArithmetic::wrapping_mod(a, b);
+                    $($body)*
                 } else {
-                    __with_func__! { (PlNumArithmetic::wrapping_mod) }
+                    let $OP = PlNumArithmetic::wrapping_mod;
+                    $($body)*
                 }
             },
             NumericOp::FloorDiv => {
                 if $swapped {
-                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_floor_div(a, b)) }
+                    let $OP = |b, a| PlNumArithmetic::wrapping_floor_div(a, b);
+                    $($body)*
                 } else {
-                    __with_func__! { (PlNumArithmetic::wrapping_floor_div) }
+                    let $OP = PlNumArithmetic::wrapping_floor_div;
+                    $($body)*
                 }
             },
         }

--- a/crates/polars-core/src/series/arithmetic/list_utils.rs
+++ b/crates/polars-core/src/series/arithmetic/list_utils.rs
@@ -88,7 +88,7 @@ impl NumericOp {
         let lhs = lhs.rechunk();
         let rhs = rhs.rechunk();
 
-        with_match_physical_numeric_polars_type!(lhs.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(lhs.dtype(), impl<T> {
             let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref();
             let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref();
 
@@ -159,44 +159,38 @@ impl NumericOp {
 }
 
 macro_rules! with_match_pl_num_arith {
-    ($op:expr, $swapped:expr, |$OP:ident| $($body:tt)* ) => ({
+    ($op:expr, $swapped:expr, | $_:tt $OP:tt | $($body:tt)* ) => ({
+        macro_rules! __with_func__ {( $_ $OP:tt ) => ( $($body)* )}
+
         match $op {
-            NumericOp::Add => { let $OP = PlNumArithmetic::wrapping_add; $($body)* },
+            NumericOp::Add => __with_func__! { (PlNumArithmetic::wrapping_add) },
             NumericOp::Sub => {
                 if $swapped {
-                    let $OP = |b, a| PlNumArithmetic::wrapping_sub(a, b);
-                    $($body)*
+                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_sub(a, b)) }
                 } else {
-                    let $OP = PlNumArithmetic::wrapping_sub;
-                    $($body)*
+                    __with_func__! { (PlNumArithmetic::wrapping_sub) }
                 }
             },
-            NumericOp::Mul => { let $OP = PlNumArithmetic::wrapping_mul; $($body)* },
+            NumericOp::Mul => __with_func__! { (PlNumArithmetic::wrapping_mul) },
             NumericOp::Div => {
                 if $swapped {
-                    let $OP = |b, a| PlNumArithmetic::legacy_div(a, b);
-                    $($body)*
+                    __with_func__! { (|b, a| PlNumArithmetic::legacy_div(a, b)) }
                 } else {
-                    let $OP = PlNumArithmetic::legacy_div;
-                    $($body)*
+                    __with_func__! { (PlNumArithmetic::legacy_div) }
                 }
             },
             NumericOp::Rem => {
                 if $swapped {
-                    let $OP = |b, a| PlNumArithmetic::wrapping_mod(a, b);
-                    $($body)*
+                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_mod(a, b)) }
                 } else {
-                    let $OP = PlNumArithmetic::wrapping_mod;
-                    $($body)*
+                    __with_func__! { (PlNumArithmetic::wrapping_mod) }
                 }
             },
             NumericOp::FloorDiv => {
                 if $swapped {
-                    let $OP = |b, a| PlNumArithmetic::wrapping_floor_div(a, b);
-                    $($body)*
+                    __with_func__! { (|b, a| PlNumArithmetic::wrapping_floor_div(a, b)) }
                 } else {
-                    let $OP = PlNumArithmetic::wrapping_floor_div;
-                    $($body)*
+                    __with_func__! { (PlNumArithmetic::wrapping_floor_div) }
                 }
             },
         }

--- a/crates/polars-core/src/series/arrow_export/categorical.rs
+++ b/crates/polars-core/src/series/arrow_export/categorical.rs
@@ -46,9 +46,10 @@ impl CategoricalToArrowConverter {
 
         match arrow_field.dtype() {
             ArrowDataType::Dictionary(arrow_key_type, values_type, _) => {
-                let expected_key_type: IntegerType = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |$C| {
-                    <<$C as PolarsCategoricalType>::Native as DictionaryKey>::KEY_TYPE
-                });
+                let expected_key_type: IntegerType =
+                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+                        <<C as PolarsCategoricalType>::Native as DictionaryKey>::KEY_TYPE
+                    });
 
                 if *arrow_key_type != expected_key_type {
                     bail_unhandled_arrow_conversion_dtype_pair!(dtype, arrow_field)
@@ -75,15 +76,16 @@ impl CategoricalToArrowConverter {
             },
         }
 
-        let out = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |$C| {
-            let keys_arr: &PrimitiveArray<<$C as PolarsCategoricalType>::Native> = keys_arr.as_any().downcast_ref().unwrap();
+        let out = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+            let keys_arr: &PrimitiveArray<<C as PolarsCategoricalType>::Native> =
+                keys_arr.as_any().downcast_ref().unwrap();
 
             converter.array_to_arrow(
                 keys_arr,
                 dtype,
                 self.persist_remap,
                 output_keys_only,
-                use_view_type
+                use_view_type,
             )
         });
 
@@ -99,16 +101,16 @@ impl CategoricalToArrowConverter {
                 let key = Arc::as_ptr(mapping) as *const () as usize;
 
                 if !self.converters.contains_key(&key) {
-                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |$C| {
+                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
                         self.converters.insert(
                             key,
                             CategoricalArrayToArrowConverter::Categorical {
                                 mapping: mapping.clone(),
-                                key_remap: CategoricalKeyRemap::from(
-                                    PlIndexSet::<<$C as PolarsCategoricalType>::Native>::with_capacity(
-                                        mapping.num_cats_upper_bound()
-                                    )
-                                ),
+                                key_remap: CategoricalKeyRemap::from(PlIndexSet::<
+                                    <C as PolarsCategoricalType>::Native,
+                                >::with_capacity(
+                                    mapping.num_cats_upper_bound(),
+                                )),
                             },
                         );
                     })

--- a/crates/polars-core/src/series/arrow_export/categorical.rs
+++ b/crates/polars-core/src/series/arrow_export/categorical.rs
@@ -46,10 +46,9 @@ impl CategoricalToArrowConverter {
 
         match arrow_field.dtype() {
             ArrowDataType::Dictionary(arrow_key_type, values_type, _) => {
-                let expected_key_type: IntegerType =
-                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
-                        <<C as PolarsCategoricalType>::Native as DictionaryKey>::KEY_TYPE
-                    });
+                let expected_key_type: IntegerType = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), impl<C> {
+                    <<C as PolarsCategoricalType>::Native as DictionaryKey>::KEY_TYPE
+                });
 
                 if *arrow_key_type != expected_key_type {
                     bail_unhandled_arrow_conversion_dtype_pair!(dtype, arrow_field)
@@ -76,7 +75,7 @@ impl CategoricalToArrowConverter {
             },
         }
 
-        let out = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+        let out = with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), impl<C> {
             let keys_arr: &PrimitiveArray<<C as PolarsCategoricalType>::Native> =
                 keys_arr.as_any().downcast_ref().unwrap();
 
@@ -101,7 +100,7 @@ impl CategoricalToArrowConverter {
                 let key = Arc::as_ptr(mapping) as *const () as usize;
 
                 if !self.converters.contains_key(&key) {
-                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+                    with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), impl<C> {
                         self.converters.insert(
                             key,
                             CategoricalArrayToArrowConverter::Categorical {

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -27,27 +27,27 @@ macro_rules! impl_eq_compare {
             #[cfg(feature = "dtype-categorical")]
             (Categorical(lcats, _), Categorical(rcats, _)) => {
                 ensure_same_categories(lcats, rcats)?;
-                return with_match_categorical_physical_type!(lcats.physical(), |$C| {
-                    lhs.cat::<$C>().unwrap().$method(rhs.cat::<$C>().unwrap())
+                return with_match_categorical_physical_type!(lcats.physical(), |C| {
+                    lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Enum(lfcats, _), Enum(rfcats, _)) => {
                 ensure_same_frozen_categories(lfcats, rfcats)?;
-                return with_match_categorical_physical_type!(lfcats.physical(), |$C| {
-                    lhs.cat::<$C>().unwrap().$method(rhs.cat::<$C>().unwrap())
+                return with_match_categorical_physical_type!(lfcats.physical(), |C| {
+                    lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(_, _) | Enum(_, _), String) => {
-                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |$C| {
-                    Ok(lhs.cat::<$C>().unwrap().$method(rhs.str().unwrap()))
+                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |C| {
+                    Ok(lhs.cat::<C>().unwrap().$method(rhs.str().unwrap()))
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (String, Categorical(_, _) | Enum(_, _)) => {
-                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |$C| {
-                    Ok(rhs.cat::<$C>().unwrap().$method(lhs.str().unwrap()))
+                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |C| {
+                    Ok(rhs.cat::<C>().unwrap().$method(lhs.str().unwrap()))
                 })
             },
             #[cfg(feature = "dtype-map")]
@@ -151,28 +151,28 @@ macro_rules! impl_ineq_compare {
             #[cfg(feature = "dtype-categorical")]
             (Categorical(lcats, _), Categorical(rcats, _)) => {
                 ensure_same_categories(lcats, rcats)?;
-                return with_match_categorical_physical_type!(lcats.physical(), |$C| {
-                    lhs.cat::<$C>().unwrap().$method(rhs.cat::<$C>().unwrap())
+                return with_match_categorical_physical_type!(lcats.physical(), |C| {
+                    lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Enum(lfcats, _), Enum(rfcats, _)) => {
                 ensure_same_frozen_categories(lfcats, rfcats)?;
-                return with_match_categorical_physical_type!(lfcats.physical(), |$C| {
-                    lhs.cat::<$C>().unwrap().$method(rhs.cat::<$C>().unwrap())
+                return with_match_categorical_physical_type!(lfcats.physical(), |C| {
+                    lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(_, _) | Enum(_, _), String) => {
-                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |$C| {
-                    lhs.cat::<$C>().unwrap().$method(rhs.str().unwrap())
+                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |C| {
+                    lhs.cat::<C>().unwrap().$method(rhs.str().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (String, Categorical(_, _) | Enum(_, _)) => {
-                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |$C| {
+                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |C| {
                     // We use the reverse method as string <-> enum comparisons are only implemented one-way.
-                    rhs.cat::<$C>().unwrap().$rev_method(lhs.str().unwrap())
+                    rhs.cat::<C>().unwrap().$rev_method(lhs.str().unwrap())
                 })
             },
             // Delegating to the storage would report the `List(Struct)` dtypes.
@@ -383,8 +383,8 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().equal(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().equal(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -399,8 +399,8 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().equal_missing(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().equal_missing(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -419,8 +419,8 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().not_equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().not_equal(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().not_equal(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -435,8 +435,8 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().not_equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().not_equal_missing(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().not_equal_missing(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -455,8 +455,8 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().gt(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().gt(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().gt(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -473,8 +473,8 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().gt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().gt_eq(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().gt_eq(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -491,8 +491,8 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().lt(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().lt(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().lt(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]
@@ -509,8 +509,8 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().lt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    self.cat::<$C>().unwrap().lt_eq(rhs)
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    self.cat::<C>().unwrap().lt_eq(rhs)
                 }),
             ),
             #[cfg(feature = "dtype-extension")]

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -27,26 +27,26 @@ macro_rules! impl_eq_compare {
             #[cfg(feature = "dtype-categorical")]
             (Categorical(lcats, _), Categorical(rcats, _)) => {
                 ensure_same_categories(lcats, rcats)?;
-                return with_match_categorical_physical_type!(lcats.physical(), |C| {
+                return with_match_categorical_physical_type!(lcats.physical(), impl<C> {
                     lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Enum(lfcats, _), Enum(rfcats, _)) => {
                 ensure_same_frozen_categories(lfcats, rfcats)?;
-                return with_match_categorical_physical_type!(lfcats.physical(), |C| {
+                return with_match_categorical_physical_type!(lfcats.physical(), impl<C> {
                     lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(_, _) | Enum(_, _), String) => {
-                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |C| {
+                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), impl<C> {
                     Ok(lhs.cat::<C>().unwrap().$method(rhs.str().unwrap()))
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (String, Categorical(_, _) | Enum(_, _)) => {
-                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |C| {
+                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), impl<C> {
                     Ok(rhs.cat::<C>().unwrap().$method(lhs.str().unwrap()))
                 })
             },
@@ -151,26 +151,26 @@ macro_rules! impl_ineq_compare {
             #[cfg(feature = "dtype-categorical")]
             (Categorical(lcats, _), Categorical(rcats, _)) => {
                 ensure_same_categories(lcats, rcats)?;
-                return with_match_categorical_physical_type!(lcats.physical(), |C| {
+                return with_match_categorical_physical_type!(lcats.physical(), impl<C> {
                     lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Enum(lfcats, _), Enum(rfcats, _)) => {
                 ensure_same_frozen_categories(lfcats, rfcats)?;
-                return with_match_categorical_physical_type!(lfcats.physical(), |C| {
+                return with_match_categorical_physical_type!(lfcats.physical(), impl<C> {
                     lhs.cat::<C>().unwrap().$method(rhs.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(_, _) | Enum(_, _), String) => {
-                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), |C| {
+                return with_match_categorical_physical_type!(lhs.dtype().cat_physical().unwrap(), impl<C> {
                     lhs.cat::<C>().unwrap().$method(rhs.str().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
             (String, Categorical(_, _) | Enum(_, _)) => {
-                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), |C| {
+                return with_match_categorical_physical_type!(rhs.dtype().cat_physical().unwrap(), impl<C> {
                     // We use the reverse method as string <-> enum comparisons are only implemented one-way.
                     rhs.cat::<C>().unwrap().$rev_method(lhs.str().unwrap())
                 })
@@ -383,7 +383,7 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().equal(rhs)
                 }),
             ),
@@ -399,7 +399,7 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().equal_missing(rhs)
                 }),
             ),
@@ -419,7 +419,7 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().not_equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().not_equal(rhs)
                 }),
             ),
@@ -435,7 +435,7 @@ impl ChunkCompareEq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().not_equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().not_equal_missing(rhs)
                 }),
             ),
@@ -455,7 +455,7 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().gt(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().gt(rhs)
                 }),
             ),
@@ -473,7 +473,7 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().gt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().gt_eq(rhs)
                 }),
             ),
@@ -491,7 +491,7 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().lt(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().lt(rhs)
                 }),
             ),
@@ -509,7 +509,7 @@ impl ChunkCompareIneq<&str> for Series {
             DataType::String => Ok(self.str().unwrap().lt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_, _) | DataType::Enum(_, _) => Ok(
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     self.cat::<C>().unwrap().lt_eq(rhs)
                 }),
             ),

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -107,9 +107,10 @@ impl Series {
             Binary => BinaryChunked::from_chunks(name, chunks).into_series(),
             #[cfg(feature = "dtype-categorical")]
             dt @ (Categorical(_, _) | Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
                     let phys = ChunkedArray::from_chunks(name, chunks);
-                    CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(phys, dt.clone()).into_series()
+                    CategoricalChunked::<C>::from_cats_and_dtype_unchecked(phys, dt.clone())
+                        .into_series()
                 })
             },
             Boolean => BooleanChunked::from_chunks(name, chunks).into_series(),
@@ -629,11 +630,11 @@ impl Series {
             casted = Cow::Owned(cats.cast(&phys_dtype)?);
         }
 
-        let out = with_match_categorical_physical_type!(phys, |$C| {
+        let out = with_match_categorical_physical_type!(phys, |C| {
             // SAFETY: we are guarded by the type system.
-            type PhysCa = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+            type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
             let ca: &PhysCa = casted.as_ref().as_ref().as_ref();
-            CategoricalChunked::<$C>::from_cats_and_dtype(ca.clone(), dtype.clone()).into_series()
+            CategoricalChunked::<C>::from_cats_and_dtype(ca.clone(), dtype.clone()).into_series()
         });
 
         if strict && out.null_count() != casted.null_count() {
@@ -858,8 +859,8 @@ unsafe fn import_arrow_dictionary_array(
                 let values = arr.values();
                 let values = cast(&**values, &ArrowDataType::Utf8View)?;
                 let values = values.as_any().downcast_ref::<Utf8ViewArray>().unwrap();
-                with_match_categorical_physical_type!(polars_dtype.cat_physical().unwrap(), |$C| {
-                    let ca = CategoricalChunked::<$C>::from_str_iter(
+                with_match_categorical_physical_type!(polars_dtype.cat_physical().unwrap(), |C| {
+                    let ca = CategoricalChunked::<C>::from_str_iter(
                         name,
                         polars_dtype.clone(),
                         keys.iter().map(|k| {

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -107,7 +107,7 @@ impl Series {
             Binary => BinaryChunked::from_chunks(name, chunks).into_series(),
             #[cfg(feature = "dtype-categorical")]
             dt @ (Categorical(_, _) | Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     let phys = ChunkedArray::from_chunks(name, chunks);
                     CategoricalChunked::<C>::from_cats_and_dtype_unchecked(phys, dt.clone())
                         .into_series()
@@ -630,7 +630,7 @@ impl Series {
             casted = Cow::Owned(cats.cast(&phys_dtype)?);
         }
 
-        let out = with_match_categorical_physical_type!(phys, |C| {
+        let out = with_match_categorical_physical_type!(phys, impl<C> {
             // SAFETY: we are guarded by the type system.
             type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
             let ca: &PhysCa = casted.as_ref().as_ref().as_ref();
@@ -859,7 +859,7 @@ unsafe fn import_arrow_dictionary_array(
                 let values = arr.values();
                 let values = cast(&**values, &ArrowDataType::Utf8View)?;
                 let values = values.as_any().downcast_ref::<Utf8ViewArray>().unwrap();
-                with_match_categorical_physical_type!(polars_dtype.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(polars_dtype.cat_physical().unwrap(), impl<C> {
                     let ca = CategoricalChunked::<C>::from_str_iter(
                         name,
                         polars_dtype.clone(),

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -4,9 +4,12 @@ use crate::prelude::*;
 unsafe impl<T: PolarsCategoricalType> IntoSeries for CategoricalChunked<T> {
     fn into_series(self) -> Series {
         // We do this hack to go from generic T to concrete T to avoid adding bounds on IntoSeries.
-        with_match_categorical_physical_type!(T::physical(), |$C| {
+        with_match_categorical_physical_type!(T::physical(), |C| {
             unsafe {
-                Series(Arc::new(SeriesWrap(core::mem::transmute::<Self, CategoricalChunked<$C>>(self))))
+                Series(Arc::new(SeriesWrap(core::mem::transmute::<
+                    Self,
+                    CategoricalChunked<C>,
+                >(self))))
             }
         })
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 unsafe impl<T: PolarsCategoricalType> IntoSeries for CategoricalChunked<T> {
     fn into_series(self) -> Series {
         // We do this hack to go from generic T to concrete T to avoid adding bounds on IntoSeries.
-        with_match_categorical_physical_type!(T::physical(), |C| {
+        with_match_categorical_physical_type!(T::physical(), impl<C> {
             unsafe {
                 Series(Arc::new(SeriesWrap(core::mem::transmute::<
                     Self,

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -100,22 +100,19 @@ impl Series {
 
         if phys_dtype.is_primitive_numeric() {
             if arr.null_count() == 0 {
-                with_match_physical_numeric_type!(phys_dtype, |$T| {
-                        let arr = arr.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
-                        let values = arr.values().as_slice();
-                        Box::new(values.iter().map(|&value| AnyValue::from(value))) as Box<dyn ExactSizeIterator<Item=AnyValue<'_>> + '_>
+                with_match_physical_numeric_type!(phys_dtype, |T| {
+                    let arr = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+                    let values = arr.values().as_slice();
+                    Box::new(values.iter().map(|&value| AnyValue::from(value)))
+                        as Box<dyn ExactSizeIterator<Item = AnyValue<'_>> + '_>
                 })
             } else {
-                with_match_physical_numeric_type!(phys_dtype, |$T| {
-                        let arr = arr.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
-                        Box::new(arr.iter().map(|value| {
-
-                        match value {
-                            Some(value) => AnyValue::from(*value),
-                            None => AnyValue::Null
-                        }
-
-                    })) as Box<dyn ExactSizeIterator<Item=AnyValue<'_>> + '_>
+                with_match_physical_numeric_type!(phys_dtype, |T| {
+                    let arr = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+                    Box::new(arr.iter().map(|value| match value {
+                        Some(value) => AnyValue::from(*value),
+                        None => AnyValue::Null,
+                    })) as Box<dyn ExactSizeIterator<Item = AnyValue<'_>> + '_>
                 })
             }
         } else {

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -100,14 +100,14 @@ impl Series {
 
         if phys_dtype.is_primitive_numeric() {
             if arr.null_count() == 0 {
-                with_match_physical_numeric_type!(phys_dtype, |T| {
+                with_match_physical_numeric_type!(phys_dtype, impl<T> {
                     let arr = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
                     let values = arr.values().as_slice();
                     Box::new(values.iter().map(|&value| AnyValue::from(value)))
                         as Box<dyn ExactSizeIterator<Item = AnyValue<'_>> + '_>
                 })
             } else {
-                with_match_physical_numeric_type!(phys_dtype, |T| {
+                with_match_physical_numeric_type!(phys_dtype, impl<T> {
                     let arr = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
                     Box::new(arr.iter().map(|value| match value {
                         Some(value) => AnyValue::from(*value),

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -518,7 +518,7 @@ impl Series {
             DataType::Struct(_) => self.struct_().unwrap().cast_unchecked(dtype),
             DataType::List(_) => self.list().unwrap().cast_unchecked(dtype),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt, |T| {
+                with_match_physical_numeric_polars_type!(dt, impl<T> {
                     let ca: &ChunkedArray<T> = self.as_ref().as_ref();
                     ca.cast_unchecked(dtype)
                 })
@@ -553,7 +553,7 @@ impl Series {
 
             #[cfg(feature = "dtype-categorical")]
             (phys, D::Categorical(cats, _)) if &cats.physical().dtype() == phys => {
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     type CA = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = self.as_ref().as_any().downcast_ref::<CA>().unwrap();
                     Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
@@ -565,7 +565,7 @@ impl Series {
             },
             #[cfg(feature = "dtype-categorical")]
             (phys, D::Enum(fcats, _)) if &fcats.physical().dtype() == phys => {
-                with_match_categorical_physical_type!(fcats.physical(), |C| {
+                with_match_categorical_physical_type!(fcats.physical(), impl<C> {
                     type CA = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = self.as_ref().as_any().downcast_ref::<CA>().unwrap();
                     Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
@@ -790,7 +790,7 @@ impl Series {
             Time => Cow::Owned(self.time().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-categorical")]
             dt @ (Categorical(_, _) | Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     let ca = self.cat::<C>().unwrap();
                     Cow::Owned(ca.physical().clone().into_series())
                 })

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -518,9 +518,9 @@ impl Series {
             DataType::Struct(_) => self.struct_().unwrap().cast_unchecked(dtype),
             DataType::List(_) => self.list().unwrap().cast_unchecked(dtype),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt, |$T| {
-                    let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                        ca.cast_unchecked(dtype)
+                with_match_physical_numeric_polars_type!(dt, |T| {
+                    let ca: &ChunkedArray<T> = self.as_ref().as_ref();
+                    ca.cast_unchecked(dtype)
                 })
             },
             DataType::Binary => self.binary().unwrap().cast_unchecked(dtype),
@@ -553,10 +553,10 @@ impl Series {
 
             #[cfg(feature = "dtype-categorical")]
             (phys, D::Categorical(cats, _)) if &cats.physical().dtype() == phys => {
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
-                    type CA = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+                with_match_categorical_physical_type!(cats.physical(), |C| {
+                    type CA = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = self.as_ref().as_any().downcast_ref::<CA>().unwrap();
-                    Ok(CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(
+                    Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
                         ca.clone(),
                         dtype.clone(),
                     )
@@ -565,10 +565,10 @@ impl Series {
             },
             #[cfg(feature = "dtype-categorical")]
             (phys, D::Enum(fcats, _)) if &fcats.physical().dtype() == phys => {
-                with_match_categorical_physical_type!(fcats.physical(), |$C| {
-                    type CA = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+                with_match_categorical_physical_type!(fcats.physical(), |C| {
+                    type CA = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
                     let ca = self.as_ref().as_any().downcast_ref::<CA>().unwrap();
-                    Ok(CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(
+                    Ok(CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
                         ca.clone(),
                         dtype.clone(),
                     )
@@ -790,8 +790,8 @@ impl Series {
             Time => Cow::Owned(self.time().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-categorical")]
             dt @ (Categorical(_, _) | Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                    let ca = self.cat::<$C>().unwrap();
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                    let ca = self.cat::<C>().unwrap();
                     Cow::Owned(ca.physical().clone().into_series())
                 })
             },

--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -19,12 +19,8 @@ impl Series {
             },
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                    CategoricalChunked::<$C>::full_null_with_dtype(
-                        name,
-                        size,
-                        dtype.clone()
-                    )
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                    CategoricalChunked::<C>::full_null_with_dtype(name, size, dtype.clone())
                         .into_series()
                 })
             },

--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -19,7 +19,7 @@ impl Series {
             },
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     CategoricalChunked::<C>::full_null_with_dtype(name, size, dtype.clone())
                         .into_series()
                 })

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -465,165 +465,158 @@ macro_rules! match_arrow_dtype_apply_macro_ca {
 
 #[macro_export]
 macro_rules! with_match_physical_numeric_type {(
-    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
+    $dtype:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     #[cfg(feature = "dtype-f16")]
     use polars_utils::float16::pf16;
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-i8")]
-        Int8 => __with_ty__! { i8 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => __with_ty__! { i128 },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => __with_ty__! { u8 },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => __with_ty__! { u128 },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        Float16 => __with_ty__! { pf16 },
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
+        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_physical_integer_type {(
-    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
+    $dtype:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     #[cfg(feature = "dtype-f16")]
     use polars_utils::float16::pf16;
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-i8")]
-        Int8 => __with_ty__! { i8 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => __with_ty__! { i128 },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => __with_ty__! { u8 },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => __with_ty__! { u128 },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_physical_float_type {(
-    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
+    $dtype:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use polars_utils::float16::pf16;
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-f16")]
-        Float16 => __with_ty__! { pf16 },
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
+        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_physical_float_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
     match $key_type {
         #[cfg(feature = "dtype-f16")]
-        Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
+        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
     match $key_type {
             #[cfg(feature = "dtype-i8")]
-        Int8 => __with_ty__! { Int8Type },
+        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
             #[cfg(feature = "dtype-i16")]
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
+        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
             #[cfg(feature = "dtype-i128")]
-        Int128 => __with_ty__! { Int128Type },
+        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
             #[cfg(feature = "dtype-u8")]
-        UInt8 => __with_ty__! { UInt8Type },
+        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
             #[cfg(feature = "dtype-u16")]
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
+        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
             #[cfg(feature = "dtype-u128")]
-        UInt128 => __with_ty__! { UInt128Type },
+        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
             #[cfg(feature = "dtype-f16")]
-        Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
+        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_physical_integer_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
     use $crate::datatypes::*;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        Int8 => __with_ty__! { Int8Type },
+        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
+        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => __with_ty__! { Int128Type },
+        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => __with_ty__! { UInt8Type },
+        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
+        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => __with_ty__! { UInt128Type },
+        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
 
 #[macro_export]
 macro_rules! with_match_categorical_physical_type {(
-    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
+    $dtype:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     match $dtype {
-        CategoricalPhysical::U8 => __with_ty__! { Categorical8Type },
-        CategoricalPhysical::U16 => __with_ty__! { Categorical16Type },
-        CategoricalPhysical::U32 => __with_ty__! { Categorical32Type },
+        CategoricalPhysical::U8 => { #[allow(dead_code)] type $T = Categorical8Type; $($body)* },
+        CategoricalPhysical::U16 => { #[allow(dead_code)] type $T = Categorical16Type; $($body)* },
+        CategoricalPhysical::U32 => { #[allow(dead_code)] type $T = Categorical32Type; $($body)* },
     }
 })}
 

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -465,7 +465,7 @@ macro_rules! match_arrow_dtype_apply_macro_ca {
 
 #[macro_export]
 macro_rules! with_match_physical_numeric_type {(
-    $dtype:expr, |$T:ident| $($body:tt)*
+    $dtype:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     #[cfg(feature = "dtype-f16")]
     use polars_utils::float16::pf16;
@@ -497,7 +497,7 @@ macro_rules! with_match_physical_numeric_type {(
 
 #[macro_export]
 macro_rules! with_match_physical_integer_type {(
-    $dtype:expr, |$T:ident| $($body:tt)*
+    $dtype:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     #[cfg(feature = "dtype-f16")]
     use polars_utils::float16::pf16;
@@ -525,7 +525,7 @@ macro_rules! with_match_physical_integer_type {(
 
 #[macro_export]
 macro_rules! with_match_physical_float_type {(
-    $dtype:expr, |$T:ident| $($body:tt)*
+    $dtype:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use polars_utils::float16::pf16;
     use $crate::datatypes::DataType::*;
@@ -540,7 +540,7 @@ macro_rules! with_match_physical_float_type {(
 
 #[macro_export]
 macro_rules! with_match_physical_float_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use $crate::datatypes::DataType::*;
     match $key_type {
@@ -554,7 +554,7 @@ macro_rules! with_match_physical_float_polars_type {(
 
 #[macro_export]
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use $crate::datatypes::DataType::*;
     match $key_type {
@@ -584,7 +584,7 @@ macro_rules! with_match_physical_numeric_polars_type {(
 
 #[macro_export]
 macro_rules! with_match_physical_integer_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use $crate::datatypes::DataType::*;
     use $crate::datatypes::*;
@@ -611,7 +611,7 @@ macro_rules! with_match_physical_integer_polars_type {(
 
 #[macro_export]
 macro_rules! with_match_categorical_physical_type {(
-    $dtype:expr, |$T:ident| $($body:tt)*
+    $dtype:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     match $dtype {
         CategoricalPhysical::U8 => { #[allow(dead_code)] type $T = Categorical8Type; $($body)* },

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -472,25 +472,25 @@ macro_rules! with_match_physical_numeric_type {(
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-i8")]
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
+        Float16 => { type $T = pf16; $($body)* },
+        Float32 => { type $T = f32; $($body)* },
+        Float64 => { type $T = f64; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -504,21 +504,21 @@ macro_rules! with_match_physical_integer_type {(
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-i8")]
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -531,9 +531,9 @@ macro_rules! with_match_physical_float_type {(
     use $crate::datatypes::DataType::*;
     match $dtype {
         #[cfg(feature = "dtype-f16")]
-        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
+        Float16 => { type $T = pf16; $($body)* },
+        Float32 => { type $T = f32; $($body)* },
+        Float64 => { type $T = f64; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -545,9 +545,9 @@ macro_rules! with_match_physical_float_polars_type {(
     use $crate::datatypes::DataType::*;
     match $key_type {
         #[cfg(feature = "dtype-f16")]
-        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
+        Float16 => { type $T = Float16Type; $($body)* },
+        Float32 => { type $T = Float32Type; $($body)* },
+        Float64 => { type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -559,25 +559,25 @@ macro_rules! with_match_physical_numeric_polars_type {(
     use $crate::datatypes::DataType::*;
     match $key_type {
             #[cfg(feature = "dtype-i8")]
-        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
+        Int8 => { type $T = Int8Type; $($body)* },
             #[cfg(feature = "dtype-i16")]
-        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
+        Int16 => { type $T = Int16Type; $($body)* },
+        Int32 => { type $T = Int32Type; $($body)* },
+        Int64 => { type $T = Int64Type; $($body)* },
             #[cfg(feature = "dtype-i128")]
-        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
+        Int128 => { type $T = Int128Type; $($body)* },
             #[cfg(feature = "dtype-u8")]
-        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
+        UInt8 => { type $T = UInt8Type; $($body)* },
             #[cfg(feature = "dtype-u16")]
-        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
+        UInt16 => { type $T = UInt16Type; $($body)* },
+        UInt32 => { type $T = UInt32Type; $($body)* },
+        UInt64 => { type $T = UInt64Type; $($body)* },
             #[cfg(feature = "dtype-u128")]
-        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
+        UInt128 => { type $T = UInt128Type; $($body)* },
             #[cfg(feature = "dtype-f16")]
-        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
+        Float16 => { type $T = Float16Type; $($body)* },
+        Float32 => { type $T = Float32Type; $($body)* },
+        Float64 => { type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -590,21 +590,21 @@ macro_rules! with_match_physical_integer_polars_type {(
     use $crate::datatypes::*;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
+        Int8 => { type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
+        Int16 => { type $T = Int16Type; $($body)* },
+        Int32 => { type $T = Int32Type; $($body)* },
+        Int64 => { type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
+        Int128 => { type $T = Int128Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
+        UInt8 => { type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
+        UInt16 => { type $T = UInt16Type; $($body)* },
+        UInt32 => { type $T = UInt32Type; $($body)* },
+        UInt64 => { type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
+        UInt128 => { type $T = UInt128Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -614,9 +614,9 @@ macro_rules! with_match_categorical_physical_type {(
     $dtype:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     match $dtype {
-        CategoricalPhysical::U8 => { #[allow(dead_code)] type $T = Categorical8Type; $($body)* },
-        CategoricalPhysical::U16 => { #[allow(dead_code)] type $T = Categorical16Type; $($body)* },
-        CategoricalPhysical::U32 => { #[allow(dead_code)] type $T = Categorical32Type; $($body)* },
+        CategoricalPhysical::U8 => { type $T = Categorical8Type; $($body)* },
+        CategoricalPhysical::U16 => { type $T = Categorical16Type; $($body)* },
+        CategoricalPhysical::U32 => { type $T = Categorical32Type; $($body)* },
     }
 })}
 

--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -536,10 +536,12 @@ pub(super) fn sign(s: &Column) -> PolarsResult<Column> {
     let dtype = s.dtype();
     use polars_core::datatypes::*;
     match dtype {
-        _ if dtype.is_primitive_numeric() => with_match_physical_numeric_polars_type!(dtype, |T| {
-            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
-            Ok(sign_impl(ca))
-        }),
+        _ if dtype.is_primitive_numeric() => {
+            with_match_physical_numeric_polars_type!(dtype, impl<T> {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+                Ok(sign_impl(ca))
+            })
+        },
         DataType::Decimal(_, scale) => {
             use polars_core::prelude::ChunkApply;
 

--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -536,8 +536,8 @@ pub(super) fn sign(s: &Column) -> PolarsResult<Column> {
     let dtype = s.dtype();
     use polars_core::datatypes::*;
     match dtype {
-        _ if dtype.is_primitive_numeric() => with_match_physical_numeric_polars_type!(dtype, |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref();
+        _ if dtype.is_primitive_numeric() => with_match_physical_numeric_polars_type!(dtype, |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             Ok(sign_impl(ca))
         }),
         DataType::Decimal(_, scale) => {

--- a/crates/polars-expr/src/dispatch/pow.rs
+++ b/crates/polars-expr/src/dispatch/pow.rs
@@ -6,7 +6,7 @@ use polars_core::prelude::{
     ChunkApply, ChunkedArray, Column, DataType, IntoColumn, PolarsFloatType, PolarsIntegerType,
     PolarsNumericType,
 };
-use polars_core::with_match_physical_integer_type;
+use polars_core::with_match_physical_integer_polars_type;
 
 fn pow_on_chunked_arrays<T, F>(
     base: &ChunkedArray<T>,
@@ -119,7 +119,7 @@ fn pow_on_series(base: &Column, exponent: &Column) -> PolarsResult<Column> {
 
     // if false, dtype is float
     if base_dtype.is_integer() {
-        with_match_physical_integer_type!(base_dtype, |$native_type| {
+        with_match_physical_integer_polars_type!(base_dtype, |T| {
             if exponent_dtype.is_float() {
                 match exponent_dtype {
                     #[cfg(feature = "dtype-f16")]
@@ -139,7 +139,11 @@ fn pow_on_series(base: &Column, exponent: &Column) -> PolarsResult<Column> {
                     _ => unreachable!(),
                 }
             } else {
-                let ca = base.$native_type().unwrap();
+                let ca: &ChunkedArray<T> = base
+                    .as_materialized_series()
+                    .as_any()
+                    .downcast_ref()
+                    .unwrap();
                 let exponent = exponent.strict_cast(&DataType::UInt32).map_err(|err| polars_err!(
                     InvalidOperation:
                     "{}\n\nHint: if you were trying to raise an integer to a negative integer power, please cast your base or exponent to float first.",

--- a/crates/polars-expr/src/dispatch/pow.rs
+++ b/crates/polars-expr/src/dispatch/pow.rs
@@ -119,7 +119,7 @@ fn pow_on_series(base: &Column, exponent: &Column) -> PolarsResult<Column> {
 
     // if false, dtype is float
     if base_dtype.is_integer() {
-        with_match_physical_integer_polars_type!(base_dtype, |T| {
+        with_match_physical_integer_polars_type!(base_dtype, impl<T> {
             if exponent_dtype.is_float() {
                 match exponent_dtype {
                     #[cfg(feature = "dtype-f16")]

--- a/crates/polars-expr/src/dispatch/range/int_range.rs
+++ b/crates/polars-expr/src/dispatch/range/int_range.rs
@@ -18,10 +18,10 @@ pub(super) fn int_range(s: &[Column], step: i64, dtype: DataType) -> PolarsResul
     assert_eq!(start.dtype(), &dtype);
     assert_eq!(end.dtype(), &dtype);
 
-    with_match_physical_integer_polars_type!(dtype, |$T| {
-        let start_v = get_first_series_value::<$T>(start)?;
-        let end_v = get_first_series_value::<$T>(end)?;
-        new_int_range::<$T>(start_v, end_v, step, name.clone()).map(Column::from)
+    with_match_physical_integer_polars_type!(dtype, |T| {
+        let start_v = get_first_series_value::<T>(start)?;
+        let end_v = get_first_series_value::<T>(end)?;
+        new_int_range::<T>(start_v, end_v, step, name.clone()).map(Column::from)
     })
 }
 

--- a/crates/polars-expr/src/dispatch/range/int_range.rs
+++ b/crates/polars-expr/src/dispatch/range/int_range.rs
@@ -18,7 +18,7 @@ pub(super) fn int_range(s: &[Column], step: i64, dtype: DataType) -> PolarsResul
     assert_eq!(start.dtype(), &dtype);
     assert_eq!(end.dtype(), &dtype);
 
-    with_match_physical_integer_polars_type!(dtype, |T| {
+    with_match_physical_integer_polars_type!(dtype, impl<T> {
         let start_v = get_first_series_value::<T>(start)?;
         let end_v = get_first_series_value::<T>(end)?;
         new_int_range::<T>(start_v, end_v, step, name.clone()).map(Column::from)

--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -77,7 +77,7 @@ pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
         let (_name, dt) = key_schema.get_at_index(0).unwrap();
         match dt {
             dt if dt.is_primitive_numeric() | dt.is_temporal() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                with_match_physical_numeric_polars_type!(dt.to_physical(), impl<T> {
                     Box::new(single_key::SingleKeyHashGrouper::<T>::new())
                 })
             },
@@ -88,7 +88,7 @@ pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
             },
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     Box::new(single_key::SingleKeyHashGrouper::<
                         <C as PolarsCategoricalType>::PolarsPhysical,
                     >::new())

--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -77,8 +77,8 @@ pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
         let (_name, dt) = key_schema.get_at_index(0).unwrap();
         match dt {
             dt if dt.is_primitive_numeric() | dt.is_temporal() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |$T| {
-                    Box::new(single_key::SingleKeyHashGrouper::<$T>::new())
+                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                    Box::new(single_key::SingleKeyHashGrouper::<T>::new())
                 })
             },
 
@@ -88,8 +88,10 @@ pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
             },
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                    Box::new(single_key::SingleKeyHashGrouper::<<$C as PolarsCategoricalType>::PolarsPhysical>::new())
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                    Box::new(single_key::SingleKeyHashGrouper::<
+                        <C as PolarsCategoricalType>::PolarsPhysical,
+                    >::new())
                 })
             },
 

--- a/crates/polars-expr/src/hot_groups/mod.rs
+++ b/crates/polars-expr/src/hot_groups/mod.rs
@@ -88,8 +88,11 @@ pub fn new_hash_hot_grouper(key_schema: Arc<Schema>, num_groups: usize) -> Box<d
             DataType::Decimal(_, _) => Box::new(SK::<Int128Type>::new(dt, ng)),
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                    Box::new(SK::<<$C as PolarsCategoricalType>::PolarsPhysical>::new(dt.clone(), ng))
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                    Box::new(SK::<<C as PolarsCategoricalType>::PolarsPhysical>::new(
+                        dt.clone(),
+                        ng,
+                    ))
                 })
             },
 

--- a/crates/polars-expr/src/hot_groups/mod.rs
+++ b/crates/polars-expr/src/hot_groups/mod.rs
@@ -88,7 +88,7 @@ pub fn new_hash_hot_grouper(key_schema: Arc<Schema>, num_groups: usize) -> Box<d
             DataType::Decimal(_, _) => Box::new(SK::<Int128Type>::new(dt, ng)),
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     Box::new(SK::<<C as PolarsCategoricalType>::PolarsPhysical>::new(
                         dt.clone(),
                         ng,

--- a/crates/polars-expr/src/idx_table/mod.rs
+++ b/crates/polars-expr/src/idx_table/mod.rs
@@ -109,8 +109,8 @@ pub fn new_idx_table(key_schema: Arc<Schema>) -> Box<dyn IdxTable> {
             DataType::Decimal(_, _) => Box::new(SKIT::<Int128Type>::new()),
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                    Box::new(SKIT::<<$C as PolarsCategoricalType>::PolarsPhysical>::new())
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                    Box::new(SKIT::<<C as PolarsCategoricalType>::PolarsPhysical>::new())
                 })
             },
 

--- a/crates/polars-expr/src/idx_table/mod.rs
+++ b/crates/polars-expr/src/idx_table/mod.rs
@@ -109,7 +109,7 @@ pub fn new_idx_table(key_schema: Arc<Schema>) -> Box<dyn IdxTable> {
             DataType::Decimal(_, _) => Box::new(SKIT::<Int128Type>::new()),
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Enum(_, _) | DataType::Categorical(_, _)) => {
-                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                     Box::new(SKIT::<<C as PolarsCategoricalType>::PolarsPhysical>::new())
                 })
             },

--- a/crates/polars-expr/src/reduce/approx_n_unique.rs
+++ b/crates/polars-expr/src/reduce/approx_n_unique.rs
@@ -14,7 +14,7 @@ pub fn new_approx_n_unique_reduction(dtype: DataType) -> PolarsResult<Box<dyn Gr
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, R::<BooleanType>::default())),
         _ if dtype.is_primitive_numeric() || dtype.is_temporal() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(dtype, R::<T>::default()))
             })
         },

--- a/crates/polars-expr/src/reduce/approx_n_unique.rs
+++ b/crates/polars-expr/src/reduce/approx_n_unique.rs
@@ -14,8 +14,8 @@ pub fn new_approx_n_unique_reduction(dtype: DataType) -> PolarsResult<Box<dyn Gr
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, R::<BooleanType>::default())),
         _ if dtype.is_primitive_numeric() || dtype.is_temporal() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, R::<$T>::default()))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(dtype, R::<T>::default()))
             })
         },
         String => Box::new(VGR::new(dtype, R::<StringType>::default())),

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -15,8 +15,8 @@ pub fn new_bitwise_and_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolMinGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<$T>>::new()))
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<T>>::new()))
             })
         },
         _ => unimplemented!(),
@@ -29,8 +29,8 @@ pub fn new_bitwise_or_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolMaxGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<$T>>::new()))
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<T>>::new()))
             })
         },
         _ => unimplemented!(),
@@ -43,8 +43,8 @@ pub fn new_bitwise_xor_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolXorGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<$T>>::new()))
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<T>>::new()))
             })
         },
         _ => unimplemented!(),

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -15,7 +15,7 @@ pub fn new_bitwise_and_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolMinGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<T>>::new()))
             })
         },
@@ -29,7 +29,7 @@ pub fn new_bitwise_or_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolMaxGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<T>>::new()))
             })
         },
@@ -43,7 +43,7 @@ pub fn new_bitwise_xor_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
     match dtype {
         Boolean => Box::new(BoolXorGroupedReduction::default()),
         _ if dtype.is_integer() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<T>>::new()))
             })
         },

--- a/crates/polars-expr/src/reduce/first_last.rs
+++ b/crates/polars-expr/src/reduce/first_last.rs
@@ -36,8 +36,11 @@ fn new_reduction_with_policy<P: Policy + 'static>(
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, NumFirstLastReducer::<_, $T>(policy, PhantomData)))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    NumFirstLastReducer::<_, T>(policy, PhantomData),
+                ))
             })
         },
         String | Binary => Box::new(VecGroupedReduction::new(

--- a/crates/polars-expr/src/reduce/first_last.rs
+++ b/crates/polars-expr/src/reduce/first_last.rs
@@ -36,7 +36,7 @@ fn new_reduction_with_policy<P: Policy + 'static>(
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     NumFirstLastReducer::<_, T>(policy, PhantomData),

--- a/crates/polars-expr/src/reduce/first_last_nonnull.rs
+++ b/crates/polars-expr/src/reduce/first_last_nonnull.rs
@@ -29,7 +29,7 @@ fn new_nonnull_reduction_with_policy<P: NonNullPolicy + 'static>(
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     NumFirstLastNonNullReducer::<_, T>(policy, PhantomData),

--- a/crates/polars-expr/src/reduce/first_last_nonnull.rs
+++ b/crates/polars-expr/src/reduce/first_last_nonnull.rs
@@ -29,8 +29,11 @@ fn new_nonnull_reduction_with_policy<P: NonNullPolicy + 'static>(
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, NumFirstLastNonNullReducer::<_, $T>(policy, PhantomData)))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    NumFirstLastNonNullReducer::<_, T>(policy, PhantomData),
+                ))
             })
         },
         String | Binary => Box::new(VecGroupedReduction::new(

--- a/crates/polars-expr/src/reduce/implode.rs
+++ b/crates/polars-expr/src/reduce/implode.rs
@@ -24,8 +24,11 @@ pub fn new_unordered_implode_reduction(dtype: DataType) -> Box<dyn GroupedReduct
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, NumUnorderedImplodeReducer::<$T>(PhantomData)))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    NumUnorderedImplodeReducer::<T>(PhantomData),
+                ))
             })
         },
         String | Binary => Box::new(VGR::new(dtype, BinaryUnorderedImplodeReducer)),

--- a/crates/polars-expr/src/reduce/implode.rs
+++ b/crates/polars-expr/src/reduce/implode.rs
@@ -24,7 +24,7 @@ pub fn new_unordered_implode_reduction(dtype: DataType) -> Box<dyn GroupedReduct
             || dtype.is_categorical()
             || dtype.is_enum() =>
         {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     NumUnorderedImplodeReducer::<T>(PhantomData),

--- a/crates/polars-expr/src/reduce/mean.rs
+++ b/crates/polars-expr/src/reduce/mean.rs
@@ -13,8 +13,8 @@ pub fn new_mean_reduction(dtype: DataType) -> PolarsResult<Box<dyn GroupedReduct
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolMeanReducer)),
         _ if dtype.is_primitive_numeric() || dtype.is_temporal() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, NumMeanReducer::<$T>(PhantomData)))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(dtype, NumMeanReducer::<T>(PhantomData)))
             })
         },
         #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-expr/src/reduce/mean.rs
+++ b/crates/polars-expr/src/reduce/mean.rs
@@ -13,7 +13,7 @@ pub fn new_mean_reduction(dtype: DataType) -> PolarsResult<Box<dyn GroupedReduct
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolMeanReducer)),
         _ if dtype.is_primitive_numeric() || dtype.is_temporal() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(dtype, NumMeanReducer::<T>(PhantomData)))
             })
         },

--- a/crates/polars-expr/src/reduce/min_max.rs
+++ b/crates/polars-expr/src/reduce/min_max.rs
@@ -41,15 +41,18 @@ pub fn new_min_reduction(
         Null => Box::new(NullGroupedReduction::default()),
         String | Binary => Box::new(VecGroupedReduction::new(dtype, BinaryMinReducer)),
         _ if dtype.is_integer() || dtype.is_temporal() || dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VMGR::new(dtype, NumReducer::<Min<$T>>::new()))
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VMGR::new(dtype, NumReducer::<Min<T>>::new()))
             })
         },
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => Box::new(VMGR::new(dtype, NumReducer::<Min<Int128Type>>::new())),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |$C| {
-            Box::new(VMGR::new(dtype.clone(), CatMinReducer::<$C>(map.clone(), PhantomData)))
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+            Box::new(VMGR::new(
+                dtype.clone(),
+                CatMinReducer::<C>(map.clone(), PhantomData),
+            ))
         }),
         _ => polars_bail!(InvalidOperation: "`min` operation not supported for dtype `{dtype}`"),
     })
@@ -83,15 +86,18 @@ pub fn new_max_reduction(
         Null => Box::new(NullGroupedReduction::default()),
         String | Binary => Box::new(VecGroupedReduction::new(dtype, BinaryMaxReducer)),
         _ if dtype.is_integer() || dtype.is_temporal() || dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VMGR::new(dtype, NumReducer::<Max<$T>>::new()))
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VMGR::new(dtype, NumReducer::<Max<T>>::new()))
             })
         },
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => Box::new(VMGR::new(dtype, NumReducer::<Max<Int128Type>>::new())),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |$C| {
-            Box::new(VMGR::new(dtype.clone(), CatMaxReducer::<$C>(map.clone(), PhantomData)))
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+            Box::new(VMGR::new(
+                dtype.clone(),
+                CatMaxReducer::<C>(map.clone(), PhantomData),
+            ))
         }),
         _ => polars_bail!(InvalidOperation: "`max` operation not supported for dtype `{dtype}`"),
     })

--- a/crates/polars-expr/src/reduce/min_max.rs
+++ b/crates/polars-expr/src/reduce/min_max.rs
@@ -41,14 +41,14 @@ pub fn new_min_reduction(
         Null => Box::new(NullGroupedReduction::default()),
         String | Binary => Box::new(VecGroupedReduction::new(dtype, BinaryMinReducer)),
         _ if dtype.is_integer() || dtype.is_temporal() || dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VMGR::new(dtype, NumReducer::<Min<T>>::new()))
             })
         },
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => Box::new(VMGR::new(dtype, NumReducer::<Min<Int128Type>>::new())),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), impl<C> {
             Box::new(VMGR::new(
                 dtype.clone(),
                 CatMinReducer::<C>(map.clone(), PhantomData),
@@ -86,14 +86,14 @@ pub fn new_max_reduction(
         Null => Box::new(NullGroupedReduction::default()),
         String | Binary => Box::new(VecGroupedReduction::new(dtype, BinaryMaxReducer)),
         _ if dtype.is_integer() || dtype.is_temporal() || dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VMGR::new(dtype, NumReducer::<Max<T>>::new()))
             })
         },
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => Box::new(VMGR::new(dtype, NumReducer::<Max<Int128Type>>::new())),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), impl<C> {
             Box::new(VMGR::new(
                 dtype.clone(),
                 CatMaxReducer::<C>(map.clone(), PhantomData),

--- a/crates/polars-expr/src/reduce/min_max_by.rs
+++ b/crates/polars-expr/src/reduce/min_max_by.rs
@@ -46,8 +46,8 @@ pub fn new_min_by_reduction(
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMinSelector, payload)),
         BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMinSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |$T| {
-                Box::new(SPGR::new(by_dtype, MinSelector::<$T>(PhantomData), payload))
+            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |T| {
+                Box::new(SPGR::new(by_dtype, MinSelector::<T>(PhantomData), payload))
             })
         },
         #[cfg(feature = "dtype-decimal")]
@@ -57,9 +57,13 @@ pub fn new_min_by_reduction(
             payload,
         )),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |$C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
             let map = map.clone();
-            Box::new(SPGR::new(by_dtype, CatMinSelector::<$C>(map, PhantomData), payload))
+            Box::new(SPGR::new(
+                by_dtype,
+                CatMinSelector::<C>(map, PhantomData),
+                payload,
+            ))
         }),
         _ => {
             polars_bail!(InvalidOperation: "`min_by` operation not supported for by dtype `{by_dtype}`")
@@ -98,8 +102,8 @@ pub fn new_max_by_reduction(
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMaxSelector, payload)),
         BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMaxSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |$T| {
-                Box::new(SPGR::new(by_dtype, MaxSelector::<$T>(PhantomData), payload))
+            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |T| {
+                Box::new(SPGR::new(by_dtype, MaxSelector::<T>(PhantomData), payload))
             })
         },
         #[cfg(feature = "dtype-decimal")]
@@ -109,9 +113,13 @@ pub fn new_max_by_reduction(
             payload,
         )),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |$C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
             let map = map.clone();
-            Box::new(SPGR::new(by_dtype, CatMaxSelector::<$C>(map, PhantomData), payload))
+            Box::new(SPGR::new(
+                by_dtype,
+                CatMaxSelector::<C>(map, PhantomData),
+                payload,
+            ))
         }),
         _ => {
             polars_bail!(InvalidOperation: "`max_by` operation not supported for by dtype `{by_dtype}`")

--- a/crates/polars-expr/src/reduce/min_max_by.rs
+++ b/crates/polars-expr/src/reduce/min_max_by.rs
@@ -46,7 +46,7 @@ pub fn new_min_by_reduction(
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMinSelector, payload)),
         BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMinSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(by_dtype.to_physical(), impl<T> {
                 Box::new(SPGR::new(by_dtype, MinSelector::<T>(PhantomData), payload))
             })
         },
@@ -57,7 +57,7 @@ pub fn new_min_by_reduction(
             payload,
         )),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), impl<C> {
             let map = map.clone();
             Box::new(SPGR::new(
                 by_dtype,
@@ -102,7 +102,7 @@ pub fn new_max_by_reduction(
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMaxSelector, payload)),
         BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMaxSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
-            with_match_physical_integer_polars_type!(by_dtype.to_physical(), |T| {
+            with_match_physical_integer_polars_type!(by_dtype.to_physical(), impl<T> {
                 Box::new(SPGR::new(by_dtype, MaxSelector::<T>(PhantomData), payload))
             })
         },
@@ -113,7 +113,7 @@ pub fn new_max_by_reduction(
             payload,
         )),
         #[cfg(feature = "dtype-categorical")]
-        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), |C| {
+        Categorical(cats, map) => with_match_categorical_physical_type!(cats.physical(), impl<C> {
             let map = map.clone();
             Box::new(SPGR::new(
                 by_dtype,

--- a/crates/polars-expr/src/reduce/skew_kurtosis.rs
+++ b/crates/polars-expr/src/reduce/skew_kurtosis.rs
@@ -11,12 +11,15 @@ pub fn new_skew_reduction(dtype: DataType, bias: bool) -> PolarsResult<Box<dyn G
     use VecGroupedReduction as VGR;
     Ok(match dtype {
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, SkewReducer::<$T> {
-                    bias,
-                    needs_cast: false,
-                    _phantom: PhantomData,
-                }))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    SkewReducer::<T> {
+                        bias,
+                        needs_cast: false,
+                        _phantom: PhantomData,
+                    },
+                ))
             })
         },
         #[cfg(feature = "dtype-decimal")]
@@ -46,13 +49,16 @@ pub fn new_kurtosis_reduction(
     use VecGroupedReduction as VGR;
     Ok(match dtype {
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, KurtosisReducer::<$T> {
-                    fisher,
-                    bias,
-                    needs_cast: false,
-                    _phantom: PhantomData,
-                }))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    KurtosisReducer::<T> {
+                        fisher,
+                        bias,
+                        needs_cast: false,
+                        _phantom: PhantomData,
+                    },
+                ))
             })
         },
         #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-expr/src/reduce/skew_kurtosis.rs
+++ b/crates/polars-expr/src/reduce/skew_kurtosis.rs
@@ -11,7 +11,7 @@ pub fn new_skew_reduction(dtype: DataType, bias: bool) -> PolarsResult<Box<dyn G
     use VecGroupedReduction as VGR;
     Ok(match dtype {
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     SkewReducer::<T> {
@@ -49,7 +49,7 @@ pub fn new_kurtosis_reduction(
     use VecGroupedReduction as VGR;
     Ok(match dtype {
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     KurtosisReducer::<T> {

--- a/crates/polars-expr/src/reduce/sum.rs
+++ b/crates/polars-expr/src/reduce/sum.rs
@@ -19,8 +19,8 @@ pub fn new_sum_reduction(dtype: DataType) -> PolarsResult<Box<dyn GroupedReducti
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolSumReducer)),
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, NumSumReducer::<$T>(PhantomData)))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(dtype, NumSumReducer::<T>(PhantomData)))
             })
         },
         #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-expr/src/reduce/sum.rs
+++ b/crates/polars-expr/src/reduce/sum.rs
@@ -19,7 +19,7 @@ pub fn new_sum_reduction(dtype: DataType) -> PolarsResult<Box<dyn GroupedReducti
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolSumReducer)),
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(dtype, NumSumReducer::<T>(PhantomData)))
             })
         },

--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -18,13 +18,16 @@ pub fn new_var_std_reduction(
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolVarStdReducer { is_std, ddof })),
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
-                Box::new(VGR::new(dtype, VarStdReducer::<$T> {
-                    is_std,
-                    ddof,
-                    needs_cast: false,
-                    _phantom: PhantomData,
-                }))
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+                Box::new(VGR::new(
+                    dtype,
+                    VarStdReducer::<T> {
+                        is_std,
+                        ddof,
+                        needs_cast: false,
+                        _phantom: PhantomData,
+                    },
+                ))
             })
         },
         #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -18,7 +18,7 @@ pub fn new_var_std_reduction(
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, BoolVarStdReducer { is_std, ddof })),
         _ if dtype.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dtype.to_physical(), |T| {
+            with_match_physical_numeric_polars_type!(dtype.to_physical(), impl<T> {
                 Box::new(VGR::new(
                     dtype,
                     VarStdReducer::<T> {

--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -874,16 +874,17 @@ pub(super) fn serializer_for<'a>(
         ),
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_, mapping) | DataType::Enum(_, mapping) => {
-            polars_core::with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |$C| {
+            polars_core::with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
                 string_serializer(
                     |iter| {
-                        let &idx: &<$C as PolarsCategoricalType>::Native = Iterator::next(iter).expect(TOO_MANY_MSG)?;
+                        let &idx: &<C as PolarsCategoricalType>::Native =
+                            Iterator::next(iter).expect(TOO_MANY_MSG)?;
                         Some(unsafe { mapping.cat_to_str_unchecked(idx.as_cat()) })
                     },
                     options,
                     |arr| {
                         arr.as_any()
-                            .downcast_ref::<PrimitiveArray<<$C as PolarsCategoricalType>::Native>>()
+                            .downcast_ref::<PrimitiveArray<<C as PolarsCategoricalType>::Native>>()
                             .expect(ARRAY_MISMATCH_MSG)
                             .iter()
                     },

--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -874,7 +874,7 @@ pub(super) fn serializer_for<'a>(
         ),
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_, mapping) | DataType::Enum(_, mapping) => {
-            polars_core::with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), |C| {
+            polars_core::with_match_categorical_physical_type!(dtype.cat_physical().unwrap(), impl<C> {
                 string_serializer(
                     |iter| {
                         let &idx: &<C as PolarsCategoricalType>::Native =

--- a/crates/polars-ops/src/chunked_array/array/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/array/min_max.rs
@@ -73,7 +73,7 @@ pub(super) fn array_dispatch(
     width: usize,
     agg_type: AggType,
 ) -> Series {
-    let chunks: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(values.dtype(), |T| {
+    let chunks: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(values.dtype(), impl<T> {
         let ca: &ChunkedArray<T> = values.as_ref().as_ref();
         ca.downcast_iter()
             .map(|arr| match agg_type {

--- a/crates/polars-ops/src/chunked_array/array/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/array/min_max.rs
@@ -73,14 +73,14 @@ pub(super) fn array_dispatch(
     width: usize,
     agg_type: AggType,
 ) -> Series {
-    let chunks: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(values.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = values.as_ref().as_ref().as_ref();
-        ca.downcast_iter().map(|arr| {
-            match agg_type {
+    let chunks: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(values.dtype(), |T| {
+        let ca: &ChunkedArray<T> = values.as_ref().as_ref();
+        ca.downcast_iter()
+            .map(|arr| match agg_type {
                 AggType::Min => Box::new(agg_min(arr, width)) as ArrayRef,
                 AggType::Max => Box::new(agg_max(arr, width)) as ArrayRef,
-            }
-        }).collect()
+            })
+            .collect()
     });
     Series::try_from((name, chunks)).unwrap()
 }

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -215,7 +215,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 let arrow_data_type = dtype
                     .to_arrow(CompatLevel::newest())
                     .underlying_physical_type();
-                with_match_physical_numeric_polars_type!(dtype, |T| {
+                with_match_physical_numeric_polars_type!(dtype, impl<T> {
                     ca.chunks()
                         .iter()
                         .map(|chunk| {
@@ -233,19 +233,18 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 if inner_dtype.is_primitive_numeric() || inner_dtype.is_temporal() =>
             {
                 let inner_dtype = inner_dtype.to_physical();
-                let result: Vec<ArrayRef> =
-                    with_match_physical_numeric_polars_type!(inner_dtype, |T| {
-                        ca.chunks()
-                            .iter()
-                            .map(|chunk| {
-                                binview_to_fixed_size_list_dyn::<<T as PolarsNumericType>::Native>(
-                                    &**chunk,
-                                    *array_width,
-                                    is_little_endian,
-                                )
-                            })
-                            .collect::<Result<Vec<ArrayRef>, _>>()
-                    })?;
+                let result: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(inner_dtype, impl<T> {
+                    ca.chunks()
+                        .iter()
+                        .map(|chunk| {
+                            binview_to_fixed_size_list_dyn::<<T as PolarsNumericType>::Native>(
+                                &**chunk,
+                                *array_width,
+                                is_little_endian,
+                            )
+                        })
+                        .collect::<Result<Vec<ArrayRef>, _>>()
+                })?;
                 Ok(result)
             },
             _ => Err(

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -215,16 +215,17 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 let arrow_data_type = dtype
                     .to_arrow(CompatLevel::newest())
                     .underlying_physical_type();
-                with_match_physical_numeric_polars_type!(dtype, |$T| {
-                    unsafe {
-                        ca.chunks().iter().map(|chunk| {
-                            binview_to_primitive_dyn::<<$T as PolarsNumericType>::Native>(
+                with_match_physical_numeric_polars_type!(dtype, |T| {
+                    ca.chunks()
+                        .iter()
+                        .map(|chunk| {
+                            binview_to_primitive_dyn::<<T as PolarsNumericType>::Native>(
                                 &**chunk,
                                 &arrow_data_type,
                                 is_little_endian,
                             )
-                        }).collect()
-                    }
+                        })
+                        .collect()
                 })
             },
             #[cfg(feature = "dtype-array")]
@@ -232,17 +233,19 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 if inner_dtype.is_primitive_numeric() || inner_dtype.is_temporal() =>
             {
                 let inner_dtype = inner_dtype.to_physical();
-                let result: Vec<ArrayRef> = with_match_physical_numeric_polars_type!(inner_dtype, |$T| {
-                    unsafe {
-                        ca.chunks().iter().map(|chunk| {
-                            binview_to_fixed_size_list_dyn::<<$T as PolarsNumericType>::Native>(
-                                &**chunk,
-                                *array_width,
-                                is_little_endian
-                            )
-                        }).collect::<Result<Vec<ArrayRef>, _>>()
-                    }
-                })?;
+                let result: Vec<ArrayRef> =
+                    with_match_physical_numeric_polars_type!(inner_dtype, |T| {
+                        ca.chunks()
+                            .iter()
+                            .map(|chunk| {
+                                binview_to_fixed_size_list_dyn::<<T as PolarsNumericType>::Native>(
+                                    &**chunk,
+                                    *array_width,
+                                    is_little_endian,
+                                )
+                            })
+                            .collect::<Result<Vec<ArrayRef>, _>>()
+                    })?;
                 Ok(result)
             },
             _ => Err(

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -143,7 +143,7 @@ impl TakeChunked for Series {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(self.dtype(), |T| {
+                with_match_physical_numeric_polars_type!(self.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = self.as_ref().as_ref();
                     ca.take_chunked_unchecked(by, sorted, avoid_sharing)
                         .into_series()
@@ -221,7 +221,7 @@ impl TakeChunked for Series {
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) | Enum(_, _) => {
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     let ca = self.cat::<C>().unwrap();
                     CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
                         ca.physical()
@@ -245,7 +245,7 @@ impl TakeChunked for Series {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(self.dtype(), |T| {
+                with_match_physical_numeric_polars_type!(self.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = self.as_ref().as_ref();
                     ca.take_opt_chunked_unchecked(by, avoid_sharing)
                         .into_series()
@@ -323,7 +323,7 @@ impl TakeChunked for Series {
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) | Enum(_, _) => {
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), impl<C> {
                     let ca = self.cat::<C>().unwrap();
                     CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
                         ca.physical().take_opt_chunked_unchecked(by, avoid_sharing),

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -143,9 +143,10 @@ impl TakeChunked for Series {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(self.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                    ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
+                with_match_physical_numeric_polars_type!(self.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = self.as_ref().as_ref();
+                    ca.take_chunked_unchecked(by, sorted, avoid_sharing)
+                        .into_series()
                 })
             },
             Boolean => {
@@ -220,11 +221,12 @@ impl TakeChunked for Series {
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) | Enum(_, _) => {
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    let ca = self.cat::<$C>().unwrap();
-                    CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(
-                        ca.physical().take_chunked_unchecked(by, sorted, avoid_sharing),
-                        self.dtype().clone()
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    let ca = self.cat::<C>().unwrap();
+                    CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
+                        ca.physical()
+                            .take_chunked_unchecked(by, sorted, avoid_sharing),
+                        self.dtype().clone(),
                     )
                     .into_series()
                 })
@@ -243,9 +245,10 @@ impl TakeChunked for Series {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(self.dtype(), |$T| {
-                 let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                 ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
+                with_match_physical_numeric_polars_type!(self.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = self.as_ref().as_ref();
+                    ca.take_opt_chunked_unchecked(by, avoid_sharing)
+                        .into_series()
                 })
             },
             Boolean => {
@@ -320,11 +323,11 @@ impl TakeChunked for Series {
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) | Enum(_, _) => {
-                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |$C| {
-                    let ca = self.cat::<$C>().unwrap();
-                    CategoricalChunked::<$C>::from_cats_and_dtype_unchecked(
+                with_match_categorical_physical_type!(self.dtype().cat_physical().unwrap(), |C| {
+                    let ca = self.cat::<C>().unwrap();
+                    CategoricalChunked::<C>::from_cats_and_dtype_unchecked(
                         ca.physical().take_opt_chunked_unchecked(by, avoid_sharing),
-                        self.dtype().clone()
+                        self.dtype().clone(),
                     )
                     .into_series()
                 })

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -253,9 +253,15 @@ pub fn hist_series(
     };
     polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
-    let out = with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-         let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-         compute_hist(ca, bin_count, bins_arg, include_category, include_breakpoint)?
+    let out = with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+        compute_hist(
+            ca,
+            bin_count,
+            bins_arg,
+            include_category,
+            include_breakpoint,
+        )?
     });
     Ok(out)
 }

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -253,7 +253,7 @@ pub fn hist_series(
     };
     polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
-    let out = with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+    let out = with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
         let ca: &ChunkedArray<T> = s.as_ref().as_ref();
         compute_hist(
             ca,

--- a/crates/polars-ops/src/chunked_array/list/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/list/min_max.rs
@@ -82,7 +82,7 @@ pub(super) fn list_min_function(ca: &ListChunked) -> PolarsResult<Series> {
                 Ok(out.into_series())
             },
             dt if dt.to_physical().is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                with_match_physical_numeric_polars_type!(dt.to_physical(), impl<T> {
                     let out: ChunkedArray<T> =
                         ca.to_physical_repr().apply_amortized_generic(|opt_s| {
                             let s = opt_s?;
@@ -201,7 +201,7 @@ pub(super) fn list_max_function(ca: &ListChunked) -> PolarsResult<Series> {
                 Ok(out.into_series())
             },
             dt if dt.to_physical().is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                with_match_physical_numeric_polars_type!(dt.to_physical(), impl<T> {
                     let out: ChunkedArray<T> =
                         ca.to_physical_repr().apply_amortized_generic(|opt_s| {
                             let s = opt_s?;

--- a/crates/polars-ops/src/chunked_array/list/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/list/min_max.rs
@@ -82,12 +82,13 @@ pub(super) fn list_min_function(ca: &ListChunked) -> PolarsResult<Series> {
                 Ok(out.into_series())
             },
             dt if dt.to_physical().is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |$T| {
-                    let out: ChunkedArray<$T> = ca.to_physical_repr().apply_amortized_generic(|opt_s| {
+                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                    let out: ChunkedArray<T> =
+                        ca.to_physical_repr().apply_amortized_generic(|opt_s| {
                             let s = opt_s?;
-                            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                            let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                             ca.min()
-                    });
+                        });
                     // restore logical type
                     unsafe { out.into_series().from_physical_unchecked(dt) }
                 })
@@ -200,12 +201,13 @@ pub(super) fn list_max_function(ca: &ListChunked) -> PolarsResult<Series> {
                 Ok(out.into_series())
             },
             dt if dt.to_physical().is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(dt.to_physical(), |$T| {
-                    let out: ChunkedArray<$T> = ca.to_physical_repr().apply_amortized_generic(|opt_s| {
+                with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                    let out: ChunkedArray<T> =
+                        ca.to_physical_repr().apply_amortized_generic(|opt_s| {
                             let s = opt_s?;
-                            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                            let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                             ca.max()
-                    });
+                        });
                     // restore logical type
                     unsafe { out.into_series().from_physical_unchecked(dt) }
                 })

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -377,11 +377,17 @@ fn array_set_operation(
             polars_bail!(InvalidOperation: "boolean type not yet supported in list 'set' operations")
         },
         _ => {
-            with_match_physical_numeric_type!(DataType::from_arrow_dtype(dtype), |$T| {
-                let a = values_a.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
-                let b = values_b.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
+            with_match_physical_numeric_type!(DataType::from_arrow_dtype(dtype), |T| {
+                let a = values_a
+                    .as_any()
+                    .downcast_ref::<PrimitiveArray<T>>()
+                    .unwrap();
+                let b = values_b
+                    .as_any()
+                    .downcast_ref::<PrimitiveArray<T>>()
+                    .unwrap();
 
-                primitive(&a, &b, offsets_a, offsets_b, set_op, validity)
+                primitive(a, b, offsets_a, offsets_b, set_op, validity)
             })
         },
     }

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -377,7 +377,7 @@ fn array_set_operation(
             polars_bail!(InvalidOperation: "boolean type not yet supported in list 'set' operations")
         },
         _ => {
-            with_match_physical_numeric_type!(DataType::from_arrow_dtype(dtype), |T| {
+            with_match_physical_numeric_type!(DataType::from_arrow_dtype(dtype), impl<T> {
                 let a = values_a
                     .as_any()
                     .downcast_ref::<PrimitiveArray<T>>()

--- a/crates/polars-ops/src/chunked_array/peaks.rs
+++ b/crates/polars-ops/src/chunked_array/peaks.rs
@@ -17,15 +17,16 @@ pub fn peak_min_max(
             peak_min_max(&column, start, end, is_peak_max)
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
-                let ca: &ChunkedArray<$T> = column.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(dt, |T| {
+                let ca: &ChunkedArray<T> = column.as_ref().as_ref();
                 let start = start.extract();
                 let end = end.extract();
                 Ok(if is_peak_max {
                     peak_max_with_start_end(ca, start, end)
                 } else {
                     peak_min_with_start_end(ca, start, end)
-                }.with_name(name))
+                }
+                .with_name(name))
             })
         },
         dt => polars_bail!(opq = peak_max, dt),

--- a/crates/polars-ops/src/chunked_array/peaks.rs
+++ b/crates/polars-ops/src/chunked_array/peaks.rs
@@ -17,7 +17,7 @@ pub fn peak_min_max(
             peak_min_max(&column, start, end, is_peak_max)
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 let ca: &ChunkedArray<T> = column.as_ref().as_ref();
                 let start = start.extract();
                 let end = end.extract();

--- a/crates/polars-ops/src/chunked_array/repeat_by.rs
+++ b/crates/polars-ops/src/chunked_array/repeat_by.rs
@@ -163,7 +163,7 @@ pub fn repeat_by(s: &Series, by: &IdxCa) -> PolarsResult<ListChunked> {
         },
         D::Binary => repeat_by_binary(s_phys.binary().unwrap(), by),
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 let ca: &ChunkedArray<T> = s_phys.as_ref().as_ref().as_ref();
                 repeat_by_primitive(ca, by)
             })

--- a/crates/polars-ops/src/chunked_array/repeat_by.rs
+++ b/crates/polars-ops/src/chunked_array/repeat_by.rs
@@ -163,8 +163,8 @@ pub fn repeat_by(s: &Series, by: &IdxCa) -> PolarsResult<ListChunked> {
         },
         D::Binary => repeat_by_binary(s_phys.binary().unwrap(), by),
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
-                let ca: &ChunkedArray<$T> = s_phys.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(dt, |T| {
+                let ca: &ChunkedArray<T> = s_phys.as_ref().as_ref().as_ref();
                 repeat_by_primitive(ca, by)
             })
         },

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -252,7 +252,7 @@ where
                 )
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(left_by_s.dtype(), |B| {
+                with_match_physical_float_polars_type!(left_by_s.dtype(), impl<B> {
                     let left_by: &ChunkedArray<B> =
                         left_by_s.as_materialized_series().as_ref().as_ref();
                     let right_by: &ChunkedArray<B> =

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -252,11 +252,13 @@ where
                 )
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(left_by_s.dtype(), |$T| {
-                    let left_by: &ChunkedArray<$T> = left_by_s.as_materialized_series().as_ref().as_ref().as_ref();
-                    let right_by: &ChunkedArray<$T> = right_by_s.as_materialized_series().as_ref().as_ref().as_ref();
-                    asof_join_by_numeric::<T, $T, A, F>(
-                        left_by, right_by, left_asof, right_asof, filter, allow_eq
+                with_match_physical_float_polars_type!(left_by_s.dtype(), |B| {
+                    let left_by: &ChunkedArray<B> =
+                        left_by_s.as_materialized_series().as_ref().as_ref();
+                    let right_by: &ChunkedArray<B> =
+                        right_by_s.as_materialized_series().as_ref().as_ref();
+                    asof_join_by_numeric::<T, B, A, F>(
+                        left_by, right_by, left_asof, right_asof, filter, allow_eq,
                     )?
                 })
             },

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -85,7 +85,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_left(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                with_match_physical_float_polars_type!(lhs.dtype(), impl<T> {
                     let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
                     let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     num_group_join_left(lhs, rhs, validate, nulls_equal)
@@ -188,7 +188,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_semi_anti(rhs, anti, nulls_equal)?
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                with_match_physical_float_polars_type!(lhs.dtype(), impl<T> {
                     let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
                     let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     num_group_join_anti_semi(lhs, rhs, anti, nulls_equal)
@@ -314,7 +314,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_inner(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                with_match_physical_float_polars_type!(lhs.dtype(), impl<T> {
                     let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
                     let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     group_join_inner::<T>(lhs, rhs, validate, nulls_equal)
@@ -409,7 +409,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_outer(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                with_match_physical_float_polars_type!(lhs.dtype(), impl<T> {
                     let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
                     let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     hash_join_outer(lhs, rhs, validate, nulls_equal)

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -85,9 +85,9 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_left(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                    let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     num_group_join_left(lhs, rhs, validate, nulls_equal)
                 })
             },
@@ -188,9 +188,9 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_semi_anti(rhs, anti, nulls_equal)?
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                    let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     num_group_join_anti_semi(lhs, rhs, anti, nulls_equal)
                 })
             },
@@ -314,10 +314,10 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_inner(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
-                    group_join_inner::<$T>(lhs, rhs, validate, nulls_equal)
+                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                    let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
+                    group_join_inner::<T>(lhs, rhs, validate, nulls_equal)
                 })
             },
             _ => {
@@ -409,9 +409,9 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 lhs.hash_join_outer(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
-                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                with_match_physical_float_polars_type!(lhs.dtype(), |T| {
+                    let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
                     hash_join_outer(lhs, rhs, validate, nulls_equal)
                 })
             },

--- a/crates/polars-ops/src/frame/join/iejoin/l1_l2.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/l1_l2.rs
@@ -46,7 +46,7 @@ where
 }
 
 pub(super) fn build_l2_array(s: &Series, order: &[IdxSize]) -> PolarsResult<Vec<L2Item>> {
-    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+    with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
         build_l2_array_impl::<T>(s.as_ref().as_ref(), order)
     })
 }

--- a/crates/polars-ops/src/frame/join/iejoin/l1_l2.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/l1_l2.rs
@@ -46,8 +46,8 @@ where
 }
 
 pub(super) fn build_l2_array(s: &Series, order: &[IdxSize]) -> PolarsResult<Vec<L2Item>> {
-    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-        build_l2_array_impl::<$T>(s.as_ref().as_ref(), order)
+    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        build_l2_array_impl::<T>(s.as_ref().as_ref(), order)
     })
 }
 

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -638,7 +638,7 @@ fn iejoin_tuples(
     let l2_order = l2_order.rechunk();
     let l2_order = l2_order.downcast_as_array().values().as_slice();
 
-    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(x.dtype(), |T| {
+    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(x.dtype(), impl<T> {
         ie_join_impl_t::<T>(
             slice,
             l1_order,
@@ -748,43 +748,42 @@ fn piecewise_merge_join_tuples(
         .as_ref()
         .map(|order| order.downcast_get(0).unwrap().values().as_slice());
 
-    let (left_row_idx, right_row_idx) =
-        with_match_physical_numeric_polars_type!(left_ordered.dtype(), |T| {
-            match op {
-                InequalityOperator::Lt => piecewise_merge_join_impl_t::<T, _>(
-                    slice,
-                    left_order,
-                    right_order,
-                    left_ordered,
-                    right_ordered,
-                    |l, r| l.tot_lt(r),
-                ),
-                InequalityOperator::LtEq => piecewise_merge_join_impl_t::<T, _>(
-                    slice,
-                    left_order,
-                    right_order,
-                    left_ordered,
-                    right_ordered,
-                    |l, r| l.tot_le(r),
-                ),
-                InequalityOperator::Gt => piecewise_merge_join_impl_t::<T, _>(
-                    slice,
-                    left_order,
-                    right_order,
-                    left_ordered,
-                    right_ordered,
-                    |l, r| l.tot_gt(r),
-                ),
-                InequalityOperator::GtEq => piecewise_merge_join_impl_t::<T, _>(
-                    slice,
-                    left_order,
-                    right_order,
-                    left_ordered,
-                    right_ordered,
-                    |l, r| l.tot_ge(r),
-                ),
-            }
-        })?;
+    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(left_ordered.dtype(), impl<T> {
+        match op {
+            InequalityOperator::Lt => piecewise_merge_join_impl_t::<T, _>(
+                slice,
+                left_order,
+                right_order,
+                left_ordered,
+                right_ordered,
+                |l, r| l.tot_lt(r),
+            ),
+            InequalityOperator::LtEq => piecewise_merge_join_impl_t::<T, _>(
+                slice,
+                left_order,
+                right_order,
+                left_ordered,
+                right_ordered,
+                |l, r| l.tot_le(r),
+            ),
+            InequalityOperator::Gt => piecewise_merge_join_impl_t::<T, _>(
+                slice,
+                left_order,
+                right_order,
+                left_ordered,
+                right_ordered,
+                |l, r| l.tot_gt(r),
+            ),
+            InequalityOperator::GtEq => piecewise_merge_join_impl_t::<T, _>(
+                slice,
+                left_order,
+                right_order,
+                left_ordered,
+                right_ordered,
+                |l, r| l.tot_ge(r),
+            ),
+        }
+    })?;
 
     debug_assert_eq!(left_row_idx.len(), right_row_idx.len());
     let left_row_idx = IdxCa::from_vec("".into(), left_row_idx);

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -638,8 +638,8 @@ fn iejoin_tuples(
     let l2_order = l2_order.rechunk();
     let l2_order = l2_order.downcast_as_array().values().as_slice();
 
-    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(x.dtype(), |$T| {
-         ie_join_impl_t::<$T>(
+    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(x.dtype(), |T| {
+        ie_join_impl_t::<T>(
             slice,
             l1_order,
             l2_order,
@@ -647,7 +647,7 @@ fn iejoin_tuples(
             op2,
             x,
             y_ordered_by_x,
-            left_height
+            left_height,
         )
     })?;
 
@@ -748,42 +748,43 @@ fn piecewise_merge_join_tuples(
         .as_ref()
         .map(|order| order.downcast_get(0).unwrap().values().as_slice());
 
-    let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(left_ordered.dtype(), |$T| {
-        match op {
-            InequalityOperator::Lt => piecewise_merge_join_impl_t::<$T, _>(
-                slice,
-                left_order,
-                right_order,
-                left_ordered,
-                right_ordered,
-                |l, r| l.tot_lt(r),
-            ),
-            InequalityOperator::LtEq => piecewise_merge_join_impl_t::<$T, _>(
-                slice,
-                left_order,
-                right_order,
-                left_ordered,
-                right_ordered,
-                |l, r| l.tot_le(r),
-            ),
-            InequalityOperator::Gt => piecewise_merge_join_impl_t::<$T, _>(
-                slice,
-                left_order,
-                right_order,
-                left_ordered,
-                right_ordered,
-                |l, r| l.tot_gt(r),
-            ),
-            InequalityOperator::GtEq => piecewise_merge_join_impl_t::<$T, _>(
-                slice,
-                left_order,
-                right_order,
-                left_ordered,
-                right_ordered,
-                |l, r| l.tot_ge(r),
-            ),
-        }
-    })?;
+    let (left_row_idx, right_row_idx) =
+        with_match_physical_numeric_polars_type!(left_ordered.dtype(), |T| {
+            match op {
+                InequalityOperator::Lt => piecewise_merge_join_impl_t::<T, _>(
+                    slice,
+                    left_order,
+                    right_order,
+                    left_ordered,
+                    right_ordered,
+                    |l, r| l.tot_lt(r),
+                ),
+                InequalityOperator::LtEq => piecewise_merge_join_impl_t::<T, _>(
+                    slice,
+                    left_order,
+                    right_order,
+                    left_ordered,
+                    right_ordered,
+                    |l, r| l.tot_le(r),
+                ),
+                InequalityOperator::Gt => piecewise_merge_join_impl_t::<T, _>(
+                    slice,
+                    left_order,
+                    right_order,
+                    left_ordered,
+                    right_ordered,
+                    |l, r| l.tot_gt(r),
+                ),
+                InequalityOperator::GtEq => piecewise_merge_join_impl_t::<T, _>(
+                    slice,
+                    left_order,
+                    right_order,
+                    left_ordered,
+                    right_ordered,
+                    |l, r| l.tot_ge(r),
+                ),
+            }
+        })?;
 
     debug_assert_eq!(left_row_idx.len(), right_row_idx.len());
     let left_row_idx = IdxCa::from_vec("".into(), left_row_idx);

--- a/crates/polars-ops/src/frame/join/merge_join.rs
+++ b/crates/polars-ops/src/frame/join/merge_join.rs
@@ -51,7 +51,7 @@ pub fn match_keys(
     assert_eq!(build_keys.dtype(), probe_keys.dtype());
     match build_keys.dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 type PhysCa = ChunkedArray<T>;
                 let build_keys_ca: &PhysCa = build_keys.as_ref().as_ref();
                 dispatch!(build_keys_ca)
@@ -62,7 +62,7 @@ pub fn match_keys(
         DataType::Binary => dispatch!(build_keys.binary().unwrap()),
         DataType::BinaryOffset => dispatch!(build_keys.binary_offset().unwrap()),
         #[cfg(feature = "dtype-categorical")]
-        DataType::Enum(cats, _) => with_match_categorical_physical_type!(cats.physical(), |C| {
+        DataType::Enum(cats, _) => with_match_categorical_physical_type!(cats.physical(), impl<C> {
             type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
             let build_keys_ca: &PhysCa = build_keys.as_ref().as_ref();
             dispatch!(build_keys_ca)

--- a/crates/polars-ops/src/frame/join/merge_join.rs
+++ b/crates/polars-ops/src/frame/join/merge_join.rs
@@ -51,9 +51,9 @@ pub fn match_keys(
     assert_eq!(build_keys.dtype(), probe_keys.dtype());
     match build_keys.dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
-                type PhysCa = ChunkedArray<$T>;
-                let build_keys_ca: &PhysCa  = build_keys.as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(dt, |T| {
+                type PhysCa = ChunkedArray<T>;
+                let build_keys_ca: &PhysCa = build_keys.as_ref().as_ref();
                 dispatch!(build_keys_ca)
             })
         },
@@ -62,8 +62,8 @@ pub fn match_keys(
         DataType::Binary => dispatch!(build_keys.binary().unwrap()),
         DataType::BinaryOffset => dispatch!(build_keys.binary_offset().unwrap()),
         #[cfg(feature = "dtype-categorical")]
-        DataType::Enum(cats, _) => with_match_categorical_physical_type!(cats.physical(), |$C| {
-            type PhysCa = ChunkedArray<<$C as PolarsCategoricalType>::PolarsPhysical>;
+        DataType::Enum(cats, _) => with_match_categorical_physical_type!(cats.physical(), |C| {
+            type PhysCa = ChunkedArray<<C as PolarsCategoricalType>::PolarsPhysical>;
             let build_keys_ca: &PhysCa = build_keys.as_ref().as_ref();
             dispatch!(build_keys_ca)
         }),

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -146,9 +146,9 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
                 .unwrap()
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
-                let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(dt, |T| {
+                let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref();
+                let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref();
                 merge_ca(lhs, rhs, merge_indicator).into_series()
             })
         },
@@ -190,9 +190,9 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> PolarsResult<Vec<boo
     #[cfg(feature = "dtype-categorical")]
     if lhs.dtype().is_categorical() || lhs.dtype().is_enum() {
         let cat_phys = lhs.dtype().cat_physical().unwrap();
-        with_match_categorical_physical_type!(cat_phys, |$C| {
-            let lhs = lhs.cat::<$C>().unwrap();
-            let rhs = rhs.cat::<$C>().unwrap();
+        with_match_categorical_physical_type!(cat_phys, |C| {
+            let lhs = lhs.cat::<C>().unwrap();
+            let rhs = rhs.cat::<C>().unwrap();
             return Ok(get_merge_indicator(lhs.iter_str(), rhs.iter_str()));
         })
     }
@@ -230,12 +230,11 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> PolarsResult<Vec<boo
             get_merge_indicator(lhs.iter(), rhs.iter())
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(lhs_s.dtype(), |$T| {
-                    let lhs: &ChunkedArray<$T> = lhs_s.as_ref().as_ref().as_ref();
-                    let rhs: &ChunkedArray<$T> = rhs_s.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(lhs_s.dtype(), |T| {
+                let lhs: &ChunkedArray<T> = lhs_s.as_ref().as_ref();
+                let rhs: &ChunkedArray<T> = rhs_s.as_ref().as_ref();
 
-                    get_merge_indicator(lhs.iter(), rhs.iter())
-
+                get_merge_indicator(lhs.iter(), rhs.iter())
             })
         },
         dt => polars_bail!(op = "merge_sorted", dt),

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -146,7 +146,7 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
                 .unwrap()
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 let lhs: &ChunkedArray<T> = lhs.as_ref().as_ref();
                 let rhs: &ChunkedArray<T> = rhs.as_ref().as_ref();
                 merge_ca(lhs, rhs, merge_indicator).into_series()
@@ -190,7 +190,7 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> PolarsResult<Vec<boo
     #[cfg(feature = "dtype-categorical")]
     if lhs.dtype().is_categorical() || lhs.dtype().is_enum() {
         let cat_phys = lhs.dtype().cat_physical().unwrap();
-        with_match_categorical_physical_type!(cat_phys, |C| {
+        with_match_categorical_physical_type!(cat_phys, impl<C> {
             let lhs = lhs.cat::<C>().unwrap();
             let rhs = rhs.cat::<C>().unwrap();
             return Ok(get_merge_indicator(lhs.iter_str(), rhs.iter_str()));
@@ -230,7 +230,7 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> PolarsResult<Vec<boo
             get_merge_indicator(lhs.iter(), rhs.iter())
         },
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(lhs_s.dtype(), |T| {
+            with_match_physical_numeric_polars_type!(lhs_s.dtype(), impl<T> {
                 let lhs: &ChunkedArray<T> = lhs_s.as_ref().as_ref();
                 let rhs: &ChunkedArray<T> = rhs_s.as_ref().as_ref();
 

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -18,7 +18,7 @@ pub trait ArgAgg {
 }
 
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use DataType::*;
     match $key_type {
@@ -53,7 +53,7 @@ impl ArgAgg for Series {
         match self.dtype() {
             #[cfg(feature = "dtype-categorical")]
             Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     arg_min_cat(self.cat::<C>().unwrap())
                 })
             },
@@ -67,7 +67,7 @@ impl ArgAgg for Series {
             BinaryOffset => arg_min_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_min_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(phys_s.dtype(), |T| {
+                with_match_physical_numeric_polars_type!(phys_s.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = phys_s.as_ref().as_ref().as_ref();
                     arg_min_numeric(ca)
                 })
@@ -87,7 +87,7 @@ impl ArgAgg for Series {
         match self.dtype() {
             #[cfg(feature = "dtype-categorical")]
             Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |C| {
+                with_match_categorical_physical_type!(cats.physical(), impl<C> {
                     arg_max_cat(self.cat::<C>().unwrap())
                 })
             },
@@ -101,7 +101,7 @@ impl ArgAgg for Series {
             BinaryOffset => arg_max_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_max_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(phys_s.dtype(), |T| {
+                with_match_physical_numeric_polars_type!(phys_s.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = phys_s.as_ref().as_ref().as_ref();
                     arg_max_numeric(ca)
                 })

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -23,25 +23,25 @@ macro_rules! with_match_physical_numeric_polars_type {(
     use DataType::*;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
+        Int8 => { type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
+        Int16 => { type $T = Int16Type; $($body)* },
+        Int32 => { type $T = Int32Type; $($body)* },
+        Int64 => { type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
+        Int128 => { type $T = Int128Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
+        UInt8 => { type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
+        UInt16 => { type $T = UInt16Type; $($body)* },
+        UInt32 => { type $T = UInt32Type; $($body)* },
+        UInt64 => { type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
+        UInt128 => { type $T = UInt128Type; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
+        Float16 => { type $T = Float16Type; $($body)* },
+        Float32 => { type $T = Float32Type; $($body)* },
+        Float64 => { type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -18,31 +18,30 @@ pub trait ArgAgg {
 }
 
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use DataType::*;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        Int8 => __with_ty__! { Int8Type },
+        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
+        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-i128")]
-        Int128 => __with_ty__! { Int128Type },
+        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        UInt8 => __with_ty__! { UInt8Type },
+        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
+        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-u128")]
-        UInt128 => __with_ty__! { UInt128Type },
+        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
+        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}
@@ -54,8 +53,8 @@ impl ArgAgg for Series {
         match self.dtype() {
             #[cfg(feature = "dtype-categorical")]
             Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
-                    arg_min_cat(self.cat::<$C>().unwrap())
+                with_match_categorical_physical_type!(cats.physical(), |C| {
+                    arg_min_cat(self.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
@@ -68,8 +67,8 @@ impl ArgAgg for Series {
             BinaryOffset => arg_min_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_min_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(phys_s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = phys_s.as_ref().as_ref().as_ref();
+                with_match_physical_numeric_polars_type!(phys_s.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = phys_s.as_ref().as_ref().as_ref();
                     arg_min_numeric(ca)
                 })
             },
@@ -88,8 +87,8 @@ impl ArgAgg for Series {
         match self.dtype() {
             #[cfg(feature = "dtype-categorical")]
             Categorical(cats, _) => {
-                with_match_categorical_physical_type!(cats.physical(), |$C| {
-                    arg_max_cat(self.cat::<$C>().unwrap())
+                with_match_categorical_physical_type!(cats.physical(), |C| {
+                    arg_max_cat(self.cat::<C>().unwrap())
                 })
             },
             #[cfg(feature = "dtype-categorical")]
@@ -102,8 +101,8 @@ impl ArgAgg for Series {
             BinaryOffset => arg_max_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_max_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
-                with_match_physical_numeric_polars_type!(phys_s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = phys_s.as_ref().as_ref().as_ref();
+                with_match_physical_numeric_polars_type!(phys_s.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = phys_s.as_ref().as_ref().as_ref();
                     arg_max_numeric(ca)
                 })
             },

--- a/crates/polars-ops/src/series/ops/bitwise.rs
+++ b/crates/polars-ops/src/series/ops/bitwise.rs
@@ -20,7 +20,7 @@ macro_rules! apply_bitwise_op {
                     ).into_series())
                 },
                 dt if dt.is_integer() => {
-                    with_match_physical_integer_polars_type!(dt, |T| {
+                    with_match_physical_integer_polars_type!(dt, impl<T> {
                         let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
                         Ok(unary_mut_values::<T, UInt32Type, _, _>(
                             ca,
@@ -29,7 +29,7 @@ macro_rules! apply_bitwise_op {
                     })
                 },
                 dt if dt.is_float() => {
-                    with_match_physical_float_polars_type!(dt, |T| {
+                    with_match_physical_float_polars_type!(dt, impl<T> {
                         let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
                         Ok(unary_mut_values::<T, UInt32Type, _, _>(
                             ca,

--- a/crates/polars-ops/src/series/ops/bitwise.rs
+++ b/crates/polars-ops/src/series/ops/bitwise.rs
@@ -20,18 +20,18 @@ macro_rules! apply_bitwise_op {
                     ).into_series())
                 },
                 dt if dt.is_integer() => {
-                    with_match_physical_integer_polars_type!(dt, |$T| {
-                        let ca: &ChunkedArray<$T> = s.as_any().downcast_ref().unwrap();
-                        Ok(unary_mut_values::<$T, UInt32Type, _, _>(
+                    with_match_physical_integer_polars_type!(dt, |T| {
+                        let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
+                        Ok(unary_mut_values::<T, UInt32Type, _, _>(
                             ca,
                             |a| polars_compute::bitwise::BitwiseKernel::$op(a),
                         ).into_series())
                     })
                 },
                 dt if dt.is_float() => {
-                    with_match_physical_float_polars_type!(dt, |$T| {
-                        let ca: &ChunkedArray<$T> = s.as_any().downcast_ref().unwrap();
-                        Ok(unary_mut_values::<$T, UInt32Type, _, _>(
+                    with_match_physical_float_polars_type!(dt, |T| {
+                        let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
+                        Ok(unary_mut_values::<T, UInt32Type, _, _>(
                             ca,
                             |a| polars_compute::bitwise::BitwiseKernel::$op(a),
                         ).into_series())

--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -57,7 +57,7 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
         max.to_physical_repr(),
     );
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+    with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
         let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
         let min: &ChunkedArray<T> = min.as_ref().as_ref().as_ref();
         let max: &ChunkedArray<T> = max.as_ref().as_ref().as_ref();
@@ -94,7 +94,7 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
 
     let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+    with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
         let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
         let max: &ChunkedArray<T> = max.as_ref().as_ref().as_ref();
         let out = clip_helper_single_bound(ca, max, clamp_max).into_series();
@@ -130,7 +130,7 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
 
     let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+    with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
         let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
         let min: &ChunkedArray<T> = min.as_ref().as_ref().as_ref();
         let out = clip_helper_single_bound(ca, min, clamp_min).into_series();

--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -57,19 +57,21 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
         max.to_physical_repr(),
     );
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-        let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
-        let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+        let min: &ChunkedArray<T> = min.as_ref().as_ref().as_ref();
+        let max: &ChunkedArray<T> = max.as_ref().as_ref().as_ref();
         let out = clip_helper_both_bounds(ca, min, max).into_series();
         match original_type {
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => {
                 let phys = out.i128()?.as_ref().clone();
-                Ok(phys.into_decimal_unchecked(*precision, *scale).into_series())
+                Ok(phys
+                    .into_decimal_unchecked(*precision, *scale)
+                    .into_series())
             },
             dt if dt.is_logical() => out.cast(original_type),
-            _ => Ok(out)
+            _ => Ok(out),
         }
     })
 }
@@ -92,18 +94,20 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
 
     let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-        let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+        let max: &ChunkedArray<T> = max.as_ref().as_ref().as_ref();
         let out = clip_helper_single_bound(ca, max, clamp_max).into_series();
         match original_type {
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => {
                 let phys = out.i128()?.as_ref().clone();
-                Ok(phys.into_decimal_unchecked(*precision, *scale).into_series())
+                Ok(phys
+                    .into_decimal_unchecked(*precision, *scale)
+                    .into_series())
             },
             dt if dt.is_logical() => out.cast(original_type),
-            _ => Ok(out)
+            _ => Ok(out),
         }
     })
 }
@@ -126,18 +130,20 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
 
     let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
 
-    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-        let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
+    with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+        let min: &ChunkedArray<T> = min.as_ref().as_ref().as_ref();
         let out = clip_helper_single_bound(ca, min, clamp_min).into_series();
         match original_type {
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => {
                 let phys = out.i128()?.as_ref().clone();
-                Ok(phys.into_decimal_unchecked(*precision, *scale).into_series())
+                Ok(phys
+                    .into_decimal_unchecked(*precision, *scale)
+                    .into_series())
             },
             dt if dt.is_logical() => out.cast(original_type),
-            _ => Ok(out)
+            _ => Ok(out),
         }
     })
 }

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -368,7 +368,7 @@ pub fn cum_min_with_init(
         },
         dt if dt.to_physical().is_primitive_numeric() => {
             let s = s.to_physical_repr();
-            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 let out = cum_min_numeric(ca, reverse, init.extract()).into_series();
                 if dt.is_logical() {
@@ -406,7 +406,7 @@ pub fn cum_max_with_init(
         },
         dt if dt.to_physical().is_primitive_numeric() => {
             let s = s.to_physical_repr();
-            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 let out = cum_max_numeric(ca, reverse, init.extract()).into_series();
                 if dt.is_logical() {

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -368,8 +368,8 @@ pub fn cum_min_with_init(
         },
         dt if dt.to_physical().is_primitive_numeric() => {
             let s = s.to_physical_repr();
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 let out = cum_min_numeric(ca, reverse, init.extract()).into_series();
                 if dt.is_logical() {
                     out.cast(dt)
@@ -406,8 +406,8 @@ pub fn cum_max_with_init(
         },
         dt if dt.to_physical().is_primitive_numeric() => {
             let s = s.to_physical_repr();
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 let out = cum_max_numeric(ca, reverse, init.extract()).into_series();
                 if dt.is_logical() {
                     out.cast(dt)

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -24,10 +24,10 @@ fn map_enum_cats(
     let fcats = FrozenCategories::new(labels.iter().map(|s| s.as_str()))?;
     let enum_dtype = DataType::from_frozen_categories(fcats.clone());
 
-    with_match_categorical_physical_type!(fcats.physical(), |$C| {
+    with_match_categorical_physical_type!(fcats.physical(), |C| {
         if include_breaks {
             let right_ends = [sorted_breaks, &[f64::INFINITY]].concat();
-            let mut bld = CategoricalChunkedBuilder::<$C>::new(out_name.clone(), enum_dtype);
+            let mut bld = CategoricalChunkedBuilder::<C>::new(out_name.clone(), enum_dtype);
             let mut brk_vals = PrimitiveChunkedBuilder::<Float64Type>::new(
                 PlSmallStr::from_static("breakpoint"),
                 s.len(),
@@ -49,9 +49,12 @@ fn map_enum_cats(
                 });
 
             let outvals = [brk_vals.finish().into_series(), bld.finish().into_series()];
-            Ok(StructChunked::from_series(out_name, outvals[0].len(), outvals.iter())?.into_series())
+            Ok(
+                StructChunked::from_series(out_name, outvals[0].len(), outvals.iter())?
+                    .into_series(),
+            )
         } else {
-            Ok(CategoricalChunked::<$C>::from_str_iter(
+            Ok(CategoricalChunked::<C>::from_str_iter(
                 out_name,
                 enum_dtype,
                 s_iter.map(|opt| {

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -24,7 +24,7 @@ fn map_enum_cats(
     let fcats = FrozenCategories::new(labels.iter().map(|s| s.as_str()))?;
     let enum_dtype = DataType::from_frozen_categories(fcats.clone());
 
-    with_match_categorical_physical_type!(fcats.physical(), |C| {
+    with_match_categorical_physical_type!(fcats.physical(), impl<C> {
         if include_breaks {
             let right_ends = [sorted_breaks, &[f64::INFINITY]].concat();
             let mut bld = CategoricalChunkedBuilder::<C>::new(out_name.clone(), enum_dtype);

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -45,7 +45,7 @@ pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
     let a = a.to_physical_repr();
     let b = b.to_physical_repr();
 
-    let out = with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+    let out = with_match_physical_numeric_polars_type!(a.dtype(), impl<T> {
         let a: &ChunkedArray<T> = a.as_ref().as_ref().as_ref();
         let b: &ChunkedArray<T> = b.as_ref().as_ref().as_ref();
 

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -45,9 +45,9 @@ pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
     let a = a.to_physical_repr();
     let b = b.to_physical_repr();
 
-    let out = with_match_physical_numeric_polars_type!(a.dtype(), |$T| {
-        let a: &ChunkedArray<$T> = a.as_ref().as_ref().as_ref();
-        let b: &ChunkedArray<$T> = b.as_ref().as_ref().as_ref();
+    let out = with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+        let a: &ChunkedArray<T> = a.as_ref().as_ref().as_ref();
+        let b: &ChunkedArray<T> = b.as_ref().as_ref().as_ref();
 
         floor_div_ca(a, b).into_series()
     });

--- a/crates/polars-ops/src/series/ops/fused.rs
+++ b/crates/polars-ops/src/series/ops/fused.rs
@@ -43,10 +43,10 @@ fn fma_ca<T: PolarsNumericType>(
 
 pub fn fma_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |$T| {
-            let a: &ChunkedArray<$T> = a.as_materialized_series().as_ref().as_ref().as_ref();
-            let b: &ChunkedArray<$T> = b.as_materialized_series().as_ref().as_ref().as_ref();
-            let c: &ChunkedArray<$T> = c.as_materialized_series().as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+            let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
+            let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
+            let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();
 
             fma_ca(a, b, c).into_column()
         })
@@ -94,10 +94,10 @@ fn fsm_ca<T: PolarsNumericType>(
 
 pub fn fsm_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |$T| {
-            let a: &ChunkedArray<$T> = a.as_materialized_series().as_ref().as_ref().as_ref();
-            let b: &ChunkedArray<$T> = b.as_materialized_series().as_ref().as_ref().as_ref();
-            let c: &ChunkedArray<$T> = c.as_materialized_series().as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+            let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
+            let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
+            let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();
 
             fsm_ca(a, b, c).into_column()
         })
@@ -144,10 +144,10 @@ fn fms_ca<T: PolarsNumericType>(
 
 pub fn fms_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |$T| {
-            let a: &ChunkedArray<$T> = a.as_materialized_series().as_ref().as_ref().as_ref();
-            let b: &ChunkedArray<$T> = b.as_materialized_series().as_ref().as_ref().as_ref();
-            let c: &ChunkedArray<$T> = c.as_materialized_series().as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+            let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
+            let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
+            let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();
 
             fms_ca(a, b, c).into_column()
         })

--- a/crates/polars-ops/src/series/ops/fused.rs
+++ b/crates/polars-ops/src/series/ops/fused.rs
@@ -43,7 +43,7 @@ fn fma_ca<T: PolarsNumericType>(
 
 pub fn fma_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(a.dtype(), impl<T> {
             let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
             let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
             let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();
@@ -94,7 +94,7 @@ fn fsm_ca<T: PolarsNumericType>(
 
 pub fn fsm_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(a.dtype(), impl<T> {
             let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
             let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
             let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();
@@ -144,7 +144,7 @@ fn fms_ca<T: PolarsNumericType>(
 
 pub fn fms_columns(a: &Column, b: &Column, c: &Column) -> Column {
     if a.len() == b.len() && a.len() == c.len() {
-        with_match_physical_numeric_polars_type!(a.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(a.dtype(), impl<T> {
             let a: &ChunkedArray<T> = a.as_materialized_series().as_ref().as_ref();
             let b: &ChunkedArray<T> = b.as_materialized_series().as_ref().as_ref();
             let c: &ChunkedArray<T> = c.as_materialized_series().as_ref().as_ref();

--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -94,15 +94,19 @@ fn min_max_binary_columns(left: &Column, right: &Column, min: bool) -> PolarsRes
         let lhs = lhs.to_physical_repr();
         let rhs = rhs.to_physical_repr();
 
-        with_match_physical_numeric_polars_type!(lhs.dtype(), |$T| {
-            let a: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-            let b: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(lhs.dtype(), |T| {
+            let a: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
+            let b: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
 
             unsafe {
                 if min {
-                    min_binary(a, b).into_series().from_physical_unchecked(logical)
+                    min_binary(a, b)
+                        .into_series()
+                        .from_physical_unchecked(logical)
                 } else {
-                    max_binary(a, b).into_series().from_physical_unchecked(logical)
+                    max_binary(a, b)
+                        .into_series()
+                        .from_physical_unchecked(logical)
                 }
             }
         })

--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -94,7 +94,7 @@ fn min_max_binary_columns(left: &Column, right: &Column, min: bool) -> PolarsRes
         let lhs = lhs.to_physical_repr();
         let rhs = rhs.to_physical_repr();
 
-        with_match_physical_numeric_polars_type!(lhs.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(lhs.dtype(), impl<T> {
             let a: &ChunkedArray<T> = lhs.as_ref().as_ref().as_ref();
             let b: &ChunkedArray<T> = rhs.as_ref().as_ref().as_ref();
 

--- a/crates/polars-ops/src/series/ops/index.rs
+++ b/crates/polars-ops/src/series/ops/index.rs
@@ -100,8 +100,8 @@ pub fn convert_and_bound_index(
         InvalidOperation: "expected integers as index"
     );
 
-    with_match_physical_integer_polars_type!(dtype, |$T| {
-        let ca: &ChunkedArray<$T> = s.as_ref().as_ref();
+    with_match_physical_integer_polars_type!(dtype, |T| {
+        let ca: &ChunkedArray<T> = s.as_ref().as_ref();
         convert_and_bound_idx_ca(ca, target_len, null_on_oob)
     })
 }

--- a/crates/polars-ops/src/series/ops/index.rs
+++ b/crates/polars-ops/src/series/ops/index.rs
@@ -100,7 +100,7 @@ pub fn convert_and_bound_index(
         InvalidOperation: "expected integers as index"
     );
 
-    with_match_physical_integer_polars_type!(dtype, |T| {
+    with_match_physical_integer_polars_type!(dtype, impl<T> {
         let ca: &ChunkedArray<T> = s.as_ref().as_ref();
         convert_and_bound_idx_ca(ca, target_len, null_on_oob)
     })

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -120,7 +120,7 @@ pub fn is_first_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
             return is_first_distinct(&s);
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(s.dtype(), |T| {
+            with_match_physical_float_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_first_distinct_numeric(ca)
             })

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -120,8 +120,8 @@ pub fn is_first_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
             return is_first_distinct(&s);
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_float_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_first_distinct_numeric(ca)
             })
         },

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -671,8 +671,8 @@ pub fn is_in(
     match needle.dtype() {
         #[cfg(feature = "dtype-categorical")]
         dt @ DataType::Categorical(_, _) | dt @ DataType::Enum(_, _) => {
-            with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |$C| {
-                is_in_cat_and_enum(needle.cat::<$C>().unwrap(), haystack, nulls_equal)
+            with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+                is_in_cat_and_enum(needle.cat::<C>().unwrap(), haystack, nulls_equal)
             })
         },
         DataType::String => {
@@ -698,8 +698,8 @@ pub fn is_in(
             let s = needle.to_physical_repr();
             let other = haystack.to_physical_repr();
             let other = other.as_ref();
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_in_numeric(ca, other, nulls_equal)
             })
         },

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -671,7 +671,7 @@ pub fn is_in(
     match needle.dtype() {
         #[cfg(feature = "dtype-categorical")]
         dt @ DataType::Categorical(_, _) | dt @ DataType::Enum(_, _) => {
-            with_match_categorical_physical_type!(dt.cat_physical().unwrap(), |C| {
+            with_match_categorical_physical_type!(dt.cat_physical().unwrap(), impl<C> {
                 is_in_cat_and_enum(needle.cat::<C>().unwrap(), haystack, nulls_equal)
             })
         },
@@ -698,7 +698,7 @@ pub fn is_in(
             let s = needle.to_physical_repr();
             let other = haystack.to_physical_repr();
             let other = other.as_ref();
-            with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_in_numeric(ca, other, nulls_equal)
             })

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -41,7 +41,7 @@ pub fn is_last_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
             return is_last_distinct(&s);
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(s.dtype(), |T| {
+            with_match_physical_float_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_last_distinct_numeric(ca)
             })

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -41,8 +41,8 @@ pub fn is_last_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
             return is_last_distinct(&s);
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_float_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 is_last_distinct_numeric(ca)
             })
         },

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -23,7 +23,7 @@ pub trait LogSeries: SeriesSealed {
             (dt1, dt2) if dt1 == dt2 && dt1.is_float() => {
                 let s = s.to_physical_repr();
                 let base = base.to_physical_repr();
-                with_match_physical_float_polars_type!(s.dtype(), |T| {
+                with_match_physical_float_polars_type!(s.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                     let base_ca: &ChunkedArray<T> = base.as_ref().as_ref().as_ref();
                     let out: ChunkedArray<T> =
@@ -51,7 +51,7 @@ pub trait LogSeries: SeriesSealed {
         use DataType::*;
         match s.dtype() {
             dt if dt.is_integer() => {
-                with_match_physical_integer_polars_type!(s.dtype(), |T| {
+                with_match_physical_integer_polars_type!(s.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = s.as_ref().as_ref();
                     Ok(log1p(ca).into_series())
                 })
@@ -78,7 +78,7 @@ pub trait LogSeries: SeriesSealed {
         use DataType::*;
         match s.dtype() {
             dt if dt.is_integer() => {
-                with_match_physical_integer_polars_type!(s.dtype(), |T| {
+                with_match_physical_integer_polars_type!(s.dtype(), impl<T> {
                     let ca: &ChunkedArray<T> = s.as_ref().as_ref();
                     Ok(exp(ca).into_series())
                 })

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -23,12 +23,11 @@ pub trait LogSeries: SeriesSealed {
             (dt1, dt2) if dt1 == dt2 && dt1.is_float() => {
                 let s = s.to_physical_repr();
                 let base = base.to_physical_repr();
-                with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    let base_ca: &ChunkedArray<$T> = base.as_ref().as_ref().as_ref();
-                    let out: ChunkedArray<$T> = broadcast_binary_elementwise_values(ca, base_ca,
-                        |x, base| x.log(base)
-                    );
+                with_match_physical_float_polars_type!(s.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+                    let base_ca: &ChunkedArray<T> = base.as_ref().as_ref().as_ref();
+                    let out: ChunkedArray<T> =
+                        broadcast_binary_elementwise_values(ca, base_ca, |x, base| x.log(base));
                     out.into_series()
                 })
             },
@@ -52,8 +51,8 @@ pub trait LogSeries: SeriesSealed {
         use DataType::*;
         match s.dtype() {
             dt if dt.is_integer() => {
-                with_match_physical_integer_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                with_match_physical_integer_polars_type!(s.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = s.as_ref().as_ref();
                     Ok(log1p(ca).into_series())
                 })
             },
@@ -79,8 +78,8 @@ pub trait LogSeries: SeriesSealed {
         use DataType::*;
         match s.dtype() {
             dt if dt.is_integer() => {
-                with_match_physical_integer_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                with_match_physical_integer_polars_type!(s.dtype(), |T| {
+                    let ca: &ChunkedArray<T> = s.as_ref().as_ref();
                     Ok(exp(ca).into_series())
                 })
             },

--- a/crates/polars-ops/src/series/ops/not.rs
+++ b/crates/polars-ops/src/series/ops/not.rs
@@ -8,7 +8,7 @@ pub fn negate_bitwise(s: &Series) -> PolarsResult<Series> {
     match s.dtype() {
         DataType::Boolean => Ok(s.bool().unwrap().not().into_series()),
         dt if dt.is_integer() => {
-            with_match_physical_integer_polars_type!(dt, |T| {
+            with_match_physical_integer_polars_type!(dt, impl<T> {
                 let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
                 Ok(ca.apply_values(|v| !v).into_series())
             })

--- a/crates/polars-ops/src/series/ops/not.rs
+++ b/crates/polars-ops/src/series/ops/not.rs
@@ -8,8 +8,8 @@ pub fn negate_bitwise(s: &Series) -> PolarsResult<Series> {
     match s.dtype() {
         DataType::Boolean => Ok(s.bool().unwrap().not().into_series()),
         dt if dt.is_integer() => {
-            with_match_physical_integer_polars_type!(dt, |$T| {
-                let ca: &ChunkedArray<$T> = s.as_any().downcast_ref().unwrap();
+            with_match_physical_integer_polars_type!(dt, |T| {
+                let ca: &ChunkedArray<T> = s.as_any().downcast_ref().unwrap();
                 Ok(ca.apply_values(|v| !v).into_series())
             })
         },

--- a/crates/polars-ops/src/series/ops/rle.rs
+++ b/crates/polars-ops/src/series/ops/rle.rs
@@ -33,8 +33,8 @@ pub fn rle_lengths(s: &Column, lengths: &mut Vec<IdxSize>) -> PolarsResult<()> {
             return Ok(());
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(dt, |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+            with_match_physical_float_polars_type!(dt, |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 rle_lengths_helper_ca(ca, lengths);
                 return Ok(());
             })

--- a/crates/polars-ops/src/series/ops/rle.rs
+++ b/crates/polars-ops/src/series/ops/rle.rs
@@ -33,7 +33,7 @@ pub fn rle_lengths(s: &Column, lengths: &mut Vec<IdxSize>) -> PolarsResult<()> {
             return Ok(());
         },
         dt if dt.is_float() => {
-            with_match_physical_float_polars_type!(dt, |T| {
+            with_match_physical_float_polars_type!(dt, impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 rle_lengths_helper_ca(ca, lengths);
                 return Ok(());

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -236,23 +236,27 @@ pub trait RoundSeries: SeriesSealed {
         }
 
         polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "round_sig_figs can only be used on numeric types" );
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            let s = ca.apply_values(|value| {
-                let value = AsPrimitive::<f64>::as_(value);
-                if value == 0.0 {
-                    return AsPrimitive::<<$T as PolarsNumericType>::Native>::as_(value);
-                }
-                // To deal with very large/small numbers we split up 10^n in 5^n and 2^n.
-                // The scaling by 2^n is almost always lossless.
-                let exp = digits - 1 - value.abs().log10().floor() as i32;
-                let pow5 = 5.0_f64.powi(exp);
-                let scaled = libm::scalbn(value, exp) * pow5;
-                let descaled = libm::scalbn(scaled.round() / pow5, -exp);
-                AsPrimitive::<<$T as PolarsNumericType>::Native>::as_(
-                    if descaled.is_finite() { descaled } else { value }
-                )
-            }).into_series();
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            let s = ca
+                .apply_values(|value| {
+                    let value = AsPrimitive::<f64>::as_(value);
+                    if value == 0.0 {
+                        return AsPrimitive::<<T as PolarsNumericType>::Native>::as_(value);
+                    }
+                    // To deal with very large/small numbers we split up 10^n in 5^n and 2^n.
+                    // The scaling by 2^n is almost always lossless.
+                    let exp = digits - 1 - value.abs().log10().floor() as i32;
+                    let pow5 = 5.0_f64.powi(exp);
+                    let scaled = libm::scalbn(value, exp) * pow5;
+                    let descaled = libm::scalbn(scaled.round() / pow5, -exp);
+                    AsPrimitive::<<T as PolarsNumericType>::Native>::as_(if descaled.is_finite() {
+                        descaled
+                    } else {
+                        value
+                    })
+                })
+                .into_series();
             return Ok(s);
         });
     }

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -236,7 +236,7 @@ pub trait RoundSeries: SeriesSealed {
         }
 
         polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "round_sig_figs can only be used on numeric types" );
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             let s = ca
                 .apply_values(|value| {

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -86,9 +86,9 @@ pub fn search_sorted(
         dt if dt.is_primitive_numeric() => {
             let search_values = search_values.to_physical_repr();
 
-            let idx = with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let search_values: &ChunkedArray<$T> = search_values.as_ref().as_ref().as_ref();
+            let idx = with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
+                let search_values: &ChunkedArray<T> = search_values.as_ref().as_ref().as_ref();
                 binary_search_ca(ca, search_values.iter(), side, descending)
             });
             Ok(IdxCa::new_vec(s.name().clone(), idx))

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -86,7 +86,7 @@ pub fn search_sorted(
         dt if dt.is_primitive_numeric() => {
             let search_values = search_values.to_physical_repr();
 
-            let idx = with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let idx = with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s.as_ref().as_ref().as_ref();
                 let search_values: &ChunkedArray<T> = search_values.as_ref().as_ref().as_ref();
                 binary_search_ca(ca, search_values.iter(), side, descending)

--- a/crates/polars-ops/src/series/ops/unique.rs
+++ b/crates/polars-ops/src/series/ops/unique.rs
@@ -45,8 +45,8 @@ pub fn unique_counts(s: &Series) -> PolarsResult<Series> {
     match s.dtype().to_physical() {
         dt if dt.is_float() => {
             let s_physical = s.to_physical_repr();
-            with_match_physical_float_polars_type!(s_physical.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s_physical.as_ref().as_ref().as_ref();
+            with_match_physical_float_polars_type!(s_physical.dtype(), |T| {
+                let ca: &ChunkedArray<T> = s_physical.as_ref().as_ref().as_ref();
                 Ok(unique_counts_helper(ca.iter()).into_series())
             })
         },

--- a/crates/polars-ops/src/series/ops/unique.rs
+++ b/crates/polars-ops/src/series/ops/unique.rs
@@ -45,7 +45,7 @@ pub fn unique_counts(s: &Series) -> PolarsResult<Series> {
     match s.dtype().to_physical() {
         dt if dt.is_float() => {
             let s_physical = s.to_physical_repr();
-            with_match_physical_float_polars_type!(s_physical.dtype(), |T| {
+            with_match_physical_float_polars_type!(s_physical.dtype(), impl<T> {
                 let ca: &ChunkedArray<T> = s_physical.as_ref().as_ref().as_ref();
                 Ok(unique_counts_helper(ca.iter()).into_series())
             })

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -149,9 +149,9 @@ fn is_sorted_impl(s: &Series, options: SortOptions) -> PolarsResult<bool> {
     }
 
     if s.dtype().is_primitive_numeric() {
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            return Ok(is_sorted_ca_num::<$T>(ca, options))
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            return Ok(is_sorted_ca_num::<T>(ca, options));
         })
     }
 
@@ -185,9 +185,9 @@ fn is_sorted_impl(s: &Series, options: SortOptions) -> PolarsResult<bool> {
     let phys = non_null.to_physical_repr();
     let s_phys = phys.as_ref();
     if s_phys.dtype().is_primitive_numeric() {
-        with_match_physical_numeric_polars_type!(s_phys.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s_phys.as_ref().as_ref().as_ref();
-            return Ok(is_sorted_ca_num::<$T>(ca, options))
+        with_match_physical_numeric_polars_type!(s_phys.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s_phys.as_ref().as_ref();
+            return Ok(is_sorted_ca_num::<T>(ca, options));
         })
     }
 
@@ -274,8 +274,8 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
         ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
     );
 
-    with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |$C| {
-        let ca = s.cat::<$C>()?;
+    with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |C| {
+        let ca = s.cat::<C>()?;
 
         // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)`
         Ok(is_sorted_adjacent_total_ord(

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -149,7 +149,7 @@ fn is_sorted_impl(s: &Series, options: SortOptions) -> PolarsResult<bool> {
     }
 
     if s.dtype().is_primitive_numeric() {
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             return Ok(is_sorted_ca_num::<T>(ca, options));
         })
@@ -185,7 +185,7 @@ fn is_sorted_impl(s: &Series, options: SortOptions) -> PolarsResult<bool> {
     let phys = non_null.to_physical_repr();
     let s_phys = phys.as_ref();
     if s_phys.dtype().is_primitive_numeric() {
-        with_match_physical_numeric_polars_type!(s_phys.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s_phys.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s_phys.as_ref().as_ref();
             return Ok(is_sorted_ca_num::<T>(ca, options));
         })
@@ -274,7 +274,7 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
         ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
     );
 
-    with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |C| {
+    with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), impl<C> {
         let ca = s.cat::<C>()?;
 
         // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)`

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -336,11 +336,11 @@ pub fn array_to_pages(
     mut encoding: Encoding,
 ) -> PolarsResult<DynIter<'static, PolarsResult<Page>>> {
     if let ArrowDataType::Dictionary(key_type, _, _) = primitive_array.dtype().to_storage() {
-        return match_integer_type!(key_type, |$T| {
-            dictionary::array_to_pages::<$T>(
+        return match_integer_type!(key_type, |T| {
+            dictionary::array_to_pages::<T>(
                 primitive_array.as_any().downcast_ref().unwrap(),
                 type_,
-                &nested,
+                nested,
                 options,
                 encoding,
             )

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -336,7 +336,7 @@ pub fn array_to_pages(
     mut encoding: Encoding,
 ) -> PolarsResult<DynIter<'static, PolarsResult<Page>>> {
     if let ArrowDataType::Dictionary(key_type, _, _) = primitive_array.dtype().to_storage() {
-        return match_integer_type!(key_type, |T| {
+        return match_integer_type!(key_type, impl<T> {
             dictionary::array_to_pages::<T>(
                 primitive_array.as_any().downcast_ref().unwrap(),
                 type_,

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -42,7 +42,7 @@ pub fn eager_int_range(
         .into());
     }
 
-    with_match_physical_integer_polars_type!(dtype, |T| {
+    with_match_physical_integer_polars_type!(dtype, impl<T> {
         let start_v: <T as PolarsNumericType>::Native = lower.extract()?;
         let end_v: <T as PolarsNumericType>::Native = upper.extract()?;
         let step: i64 = step.extract()?;

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -42,11 +42,11 @@ pub fn eager_int_range(
         .into());
     }
 
-    with_match_physical_integer_polars_type!(dtype, |$T| {
-        let start_v: <$T as PolarsNumericType>::Native = lower.extract()?;
-        let end_v: <$T as PolarsNumericType>::Native = upper.extract()?;
+    with_match_physical_integer_polars_type!(dtype, |T| {
+        let start_v: <T as PolarsNumericType>::Native = lower.extract()?;
+        let end_v: <T as PolarsNumericType>::Native = upper.extract()?;
         let step: i64 = step.extract()?;
-        py.enter_polars_series(|| new_int_range::<$T>(start_v, end_v, step, get_literal_name()))
+        py.enter_polars_series(|| new_int_range::<T>(start_v, end_v, step, get_literal_name()))
     })
 }
 

--- a/crates/polars-python/src/interop/numpy/mod.rs
+++ b/crates/polars-python/src/interop/numpy/mod.rs
@@ -4,21 +4,21 @@ macro_rules! with_match_physical_numpy_polars_type {(
     use polars_core::datatypes::DataType as D;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        D::Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
+        D::Int8 => { type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        D::Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
-        D::Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
-        D::Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
+        D::Int16 => { type $T = Int16Type; $($body)* },
+        D::Int32 => { type $T = Int32Type; $($body)* },
+        D::Int64 => { type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        D::UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
+        D::UInt8 => { type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        D::UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
-        D::UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
-        D::UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
+        D::UInt16 => { type $T = UInt16Type; $($body)* },
+        D::UInt32 => { type $T = UInt32Type; $($body)* },
+        D::UInt64 => { type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        D::Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
-        D::Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
-        D::Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
+        D::Float16 => { type $T = Float16Type; $($body)* },
+        D::Float32 => { type $T = Float32Type; $($body)* },
+        D::Float64 => { type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}

--- a/crates/polars-python/src/interop/numpy/mod.rs
+++ b/crates/polars-python/src/interop/numpy/mod.rs
@@ -1,5 +1,5 @@
 macro_rules! with_match_physical_numpy_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use polars_core::datatypes::DataType as D;
     match $key_type {

--- a/crates/polars-python/src/interop/numpy/mod.rs
+++ b/crates/polars-python/src/interop/numpy/mod.rs
@@ -1,25 +1,24 @@
 macro_rules! with_match_physical_numpy_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use polars_core::datatypes::DataType as D;
     match $key_type {
         #[cfg(feature = "dtype-i8")]
-        D::Int8 => __with_ty__! { Int8Type },
+        D::Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
         #[cfg(feature = "dtype-i16")]
-        D::Int16 => __with_ty__! { Int16Type },
-        D::Int32 => __with_ty__! { Int32Type },
-        D::Int64 => __with_ty__! { Int64Type },
+        D::Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
+        D::Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
+        D::Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
         #[cfg(feature = "dtype-u8")]
-        D::UInt8 => __with_ty__! { UInt8Type },
+        D::UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
         #[cfg(feature = "dtype-u16")]
-        D::UInt16 => __with_ty__! { UInt16Type },
-        D::UInt32 => __with_ty__! { UInt32Type },
-        D::UInt64 => __with_ty__! { UInt64Type },
+        D::UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
+        D::UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
+        D::UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
         #[cfg(feature = "dtype-f16")]
-        D::Float16 => __with_ty__! { Float16Type },
-        D::Float32 => __with_ty__! { Float32Type },
-        D::Float64 => __with_ty__! { Float64Type },
+        D::Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
+        D::Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
+        D::Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}

--- a/crates/polars-python/src/interop/numpy/to_numpy_df.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_df.rs
@@ -95,7 +95,7 @@ fn try_df_to_numpy_view(py: Python<'_>, df: &DataFrame, allow_nulls: bool) -> Op
 
     let arr = match first_dtype {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numpy_polars_type!(first_dtype, |T| {
+            with_match_physical_numpy_polars_type!(first_dtype, impl<T> {
                 numeric_df_to_numpy_view::<T>(py, df, owner)
             })
         },
@@ -138,7 +138,7 @@ fn check_df_columns_contiguous(df: &DataFrame) -> bool {
 
     match columns.first().unwrap().dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 let slices = columns
                     .iter()
                     .map(|s| {
@@ -257,7 +257,7 @@ fn try_df_to_numpy_numeric_supertype(
     let st = dtypes_to_supertype(df.columns().iter().map(|s| s.dtype())).ok()?;
 
     let np_array = match st {
-        dt if dt.is_primitive_numeric() => with_match_physical_numpy_polars_type!(dt, |T| {
+        dt if dt.is_primitive_numeric() => with_match_physical_numpy_polars_type!(dt, impl<T> {
             let arr = py.enter_polars(|| df.to_ndarray::<T>(order)).ok()?;
             arr.into_pyarray(py).into_py_any(py).ok()?
         }),

--- a/crates/polars-python/src/interop/numpy/to_numpy_df.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_df.rs
@@ -95,8 +95,8 @@ fn try_df_to_numpy_view(py: Python<'_>, df: &DataFrame, allow_nulls: bool) -> Op
 
     let arr = match first_dtype {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numpy_polars_type!(first_dtype, |$T| {
-                numeric_df_to_numpy_view::<$T>(py, df, owner)
+            with_match_physical_numpy_polars_type!(first_dtype, |T| {
+                numeric_df_to_numpy_view::<T>(py, df, owner)
             })
         },
         DataType::Datetime(_, _) | DataType::Duration(_) => {
@@ -138,16 +138,16 @@ fn check_df_columns_contiguous(df: &DataFrame) -> bool {
 
     match columns.first().unwrap().dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
+            with_match_physical_numeric_polars_type!(dt, |T| {
                 let slices = columns
                     .iter()
                     .map(|s| {
-                        let ca: &ChunkedArray<$T> = s.as_materialized_series().unpack().unwrap();
+                        let ca: &ChunkedArray<T> = s.as_materialized_series().unpack().unwrap();
                         ca.data_views().next().unwrap()
                     })
                     .collect::<Vec<_>>();
 
-                check_slices_contiguous::<$T>(slices)
+                check_slices_contiguous::<T>(slices)
             })
         },
         DataType::Datetime(_, _) | DataType::Duration(_) => {
@@ -257,8 +257,8 @@ fn try_df_to_numpy_numeric_supertype(
     let st = dtypes_to_supertype(df.columns().iter().map(|s| s.dtype())).ok()?;
 
     let np_array = match st {
-        dt if dt.is_primitive_numeric() => with_match_physical_numpy_polars_type!(dt, |$T| {
-            let arr = py.enter_polars(|| df.to_ndarray::<$T>(order)).ok()?;
+        dt if dt.is_primitive_numeric() => with_match_physical_numpy_polars_type!(dt, |T| {
+            let arr = py.enter_polars(|| df.to_ndarray::<T>(order)).ok()?;
             arr.into_pyarray(py).into_py_any(py).ok()?
         }),
         _ => return None,

--- a/crates/polars-python/src/interop/numpy/to_numpy_series.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_series.rs
@@ -119,7 +119,7 @@ fn series_to_numpy_view_recursive(py: Python<'_>, s: Series, writable: bool) -> 
 /// Create a NumPy view of a numeric Series.
 fn numeric_series_to_numpy_view(py: Python<'_>, s: Series, writable: bool) -> Py<PyAny> {
     let dims = [s.len()].into_dimension();
-    with_match_physical_numpy_polars_type!(s.dtype(), |T| {
+    with_match_physical_numpy_polars_type!(s.dtype(), impl<T> {
         let np_dtype = <T as PolarsNumericType>::Native::get_dtype(py);
         let ca: &ChunkedArray<T> = s.unpack::<T>().unwrap();
         let flags = if writable {
@@ -253,7 +253,7 @@ fn series_to_numpy_with_copy(py: Python<'_>, s: &Series, writable: bool) -> Py<P
             PyArray1::from_iter(py, values).into_py_any(py).unwrap()
         },
         Categorical(_, _) | Enum(_, _) => {
-            with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |C| {
+            with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), impl<C> {
                 let ca = s.cat::<C>().unwrap();
                 let values = ca.iter_str().map(|s| s.into_py_any(py).unwrap());
                 PyArray1::from_iter(py, values).into_py_any(py).unwrap()

--- a/crates/polars-python/src/interop/numpy/to_numpy_series.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_series.rs
@@ -119,9 +119,9 @@ fn series_to_numpy_view_recursive(py: Python<'_>, s: Series, writable: bool) -> 
 /// Create a NumPy view of a numeric Series.
 fn numeric_series_to_numpy_view(py: Python<'_>, s: Series, writable: bool) -> Py<PyAny> {
     let dims = [s.len()].into_dimension();
-    with_match_physical_numpy_polars_type!(s.dtype(), |$T| {
-        let np_dtype = <$T as PolarsNumericType>::Native::get_dtype(py);
-        let ca: &ChunkedArray<$T> = s.unpack::<$T>().unwrap();
+    with_match_physical_numpy_polars_type!(s.dtype(), |T| {
+        let np_dtype = <T as PolarsNumericType>::Native::get_dtype(py);
+        let ca: &ChunkedArray<T> = s.unpack::<T>().unwrap();
         let flags = if writable {
             flags::NPY_ARRAY_FARRAY
         } else {
@@ -253,8 +253,8 @@ fn series_to_numpy_with_copy(py: Python<'_>, s: &Series, writable: bool) -> Py<P
             PyArray1::from_iter(py, values).into_py_any(py).unwrap()
         },
         Categorical(_, _) | Enum(_, _) => {
-            with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |$C| {
-                let ca = s.cat::<$C>().unwrap();
+            with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |C| {
+                let ca = s.cat::<C>().unwrap();
                 let values = ca.iter_str().map(|s| s.into_py_any(py).unwrap());
                 PyArray1::from_iter(py, values).into_py_any(py).unwrap()
             })

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -57,9 +57,10 @@ impl PySeries {
                     PyList::new(py, series.f64().map_err(PyPolarsErr::from)?.iter())?
                 },
                 DataType::Categorical(_, _) | DataType::Enum(_, _) => {
-                    with_match_categorical_physical_type!(series.dtype().cat_physical().unwrap(), |$C| {
-                        PyList::new(py, series.cat::<$C>().unwrap().iter_str())?
-                    })
+                    with_match_categorical_physical_type!(
+                        series.dtype().cat_physical().unwrap(),
+                        |C| PyList::new(py, series.cat::<C>().unwrap().iter_str())?
+                    )
                 },
                 #[cfg(feature = "object")]
                 DataType::Object(_) => {

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -59,7 +59,7 @@ impl PySeries {
                 DataType::Categorical(_, _) | DataType::Enum(_, _) => {
                     with_match_categorical_physical_type!(
                         series.dtype().cat_physical().unwrap(),
-                        |C| PyList::new(py, series.cat::<C>().unwrap().iter_str())?
+                        impl<C> PyList::new(py, series.cat::<C>().unwrap().iter_str())?
                     )
                 },
                 #[cfg(feature = "object")]

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -112,7 +112,7 @@ fn scatter_impl(
 
     match mutable_s.dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |T| {
+            with_match_physical_numeric_polars_type!(dt, impl<T> {
                 let ca: &mut ChunkedArray<T> = mutable_s.as_mut();
                 let values: &ChunkedArray<T> = values.as_ref().as_ref();
                 ca.scatter(idx, values.iter())

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -112,9 +112,9 @@ fn scatter_impl(
 
     match mutable_s.dtype() {
         dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(dt, |$T| {
-                let ca: &mut ChunkedArray<$T> = mutable_s.as_mut();
-                let values: &ChunkedArray<$T> = values.as_ref().as_ref();
+            with_match_physical_numeric_polars_type!(dt, |T| {
+                let ca: &mut ChunkedArray<T> = mutable_s.as_mut();
+                let values: &ChunkedArray<T> = values.as_ref().as_ref();
                 ca.scatter(idx, values.iter())
             })
         },

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -369,8 +369,8 @@ unsafe fn decode(
                 }
             }
 
-            with_match_arrow_primitive_type!(dt, |$T| {
-                numeric::decode_primitive::<$T>(rows, opt).to_boxed()
+            with_match_arrow_primitive_type!(dt, |T| {
+                numeric::decode_primitive::<T>(rows, opt).to_boxed()
             })
         },
     }

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -369,7 +369,7 @@ unsafe fn decode(
                 }
             }
 
-            with_match_arrow_primitive_type!(dt, |T| {
+            with_match_arrow_primitive_type!(dt, impl<T> {
                 numeric::decode_primitive::<T>(rows, opt).to_boxed()
             })
         },

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -664,8 +664,8 @@ unsafe fn encode_flat_array(
                 }
             }
 
-            with_match_arrow_primitive_type!(dt, |$T| {
-                let array = array.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
+            with_match_arrow_primitive_type!(dt, |T| {
+                let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
                 numeric::encode(buffer, array, opt, offsets);
             })
         },

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -664,7 +664,7 @@ unsafe fn encode_flat_array(
                 }
             }
 
-            with_match_arrow_primitive_type!(dt, |T| {
+            with_match_arrow_primitive_type!(dt, impl<T> {
                 let array = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
                 numeric::encode(buffer, array, opt, offsets);
             })

--- a/crates/polars-row/src/utils.rs
+++ b/crates/polars-row/src/utils.rs
@@ -3,25 +3,24 @@ use arrow::bitmap::{Bitmap, BitmapBuilder};
 
 #[macro_export]
 macro_rules! with_match_arrow_primitive_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use arrow::datatypes::ArrowDataType::*;
     use polars_utils::float16::pf16;
     match $key_type {
-        Int8 => __with_ty__! { i8 },
-        Int16 => __with_ty__! { i16 },
-        Int32 => __with_ty__! { i32 },
-        Int64 => __with_ty__! { i64 },
-        Int128 => __with_ty__! { i128 },
-        UInt8 => __with_ty__! { u8 },
-        UInt16 => __with_ty__! { u16 },
-        UInt32 => __with_ty__! { u32 },
-        UInt64 => __with_ty__! { u64 },
-        UInt128 => __with_ty__! { u128 },
-        Float16 => __with_ty__! { pf16 },
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
+        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
+        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
+        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
+        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
+        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
+        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
+        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
         _ => unreachable!(),
     }
 })}

--- a/crates/polars-row/src/utils.rs
+++ b/crates/polars-row/src/utils.rs
@@ -8,19 +8,19 @@ macro_rules! with_match_arrow_primitive_type {(
     use arrow::datatypes::ArrowDataType::*;
     use polars_utils::float16::pf16;
     match $key_type {
-        Int8 => { #[allow(dead_code)] type $T = i8; $($body)* },
-        Int16 => { #[allow(dead_code)] type $T = i16; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = i32; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = i64; $($body)* },
-        Int128 => { #[allow(dead_code)] type $T = i128; $($body)* },
-        UInt8 => { #[allow(dead_code)] type $T = u8; $($body)* },
-        UInt16 => { #[allow(dead_code)] type $T = u16; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = u32; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = u64; $($body)* },
-        UInt128 => { #[allow(dead_code)] type $T = u128; $($body)* },
-        Float16 => { #[allow(dead_code)] type $T = pf16; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = f32; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = f64; $($body)* },
+        Int8 => { type $T = i8; $($body)* },
+        Int16 => { type $T = i16; $($body)* },
+        Int32 => { type $T = i32; $($body)* },
+        Int64 => { type $T = i64; $($body)* },
+        Int128 => { type $T = i128; $($body)* },
+        UInt8 => { type $T = u8; $($body)* },
+        UInt16 => { type $T = u16; $($body)* },
+        UInt32 => { type $T = u32; $($body)* },
+        UInt64 => { type $T = u64; $($body)* },
+        UInt128 => { type $T = u128; $($body)* },
+        Float16 => { type $T = pf16; $($body)* },
+        Float32 => { type $T = f32; $($body)* },
+        Float64 => { type $T = f64; $($body)* },
         _ => unreachable!(),
     }
 })}

--- a/crates/polars-row/src/utils.rs
+++ b/crates/polars-row/src/utils.rs
@@ -3,7 +3,7 @@ use arrow::bitmap::{Bitmap, BitmapBuilder};
 
 #[macro_export]
 macro_rules! with_match_arrow_primitive_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use arrow::datatypes::ArrowDataType::*;
     use polars_utils::float16::pf16;

--- a/crates/polars-stream/src/nodes/io_sinks/components/partition_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/partition_key.rs
@@ -51,14 +51,13 @@ impl PreComputedKeys {
                     .try_into()
                     .unwrap();
 
-                let (bytes, width): (Buffer<u8>, usize) =
-                    with_match_physical_integer_type!(dt, |T| {
-                        let arr: &PrimitiveArray<T> = arr.as_any().downcast_ref().unwrap();
-                        (
-                            arr.values().clone().try_transmute().unwrap(),
-                            std::mem::size_of::<T>(),
-                        )
-                    });
+                let (bytes, width): (Buffer<u8>, usize) = with_match_physical_integer_type!(dt, impl<T> {
+                    let arr: &PrimitiveArray<T> = arr.as_any().downcast_ref().unwrap();
+                    (
+                        arr.values().clone().try_transmute().unwrap(),
+                        std::mem::size_of::<T>(),
+                    )
+                });
 
                 assert_eq!(width * arr.len(), bytes.len());
 

--- a/crates/polars-stream/src/nodes/io_sinks/components/partition_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/partition_key.rs
@@ -51,10 +51,14 @@ impl PreComputedKeys {
                     .try_into()
                     .unwrap();
 
-                let (bytes, width): (Buffer<u8>, usize) = with_match_physical_integer_type!(dt, |$T| {
-                    let arr: &PrimitiveArray<$T> = arr.as_any().downcast_ref().unwrap();
-                    (arr.values().clone().try_transmute().unwrap(), std::mem::size_of::<$T>())
-                });
+                let (bytes, width): (Buffer<u8>, usize) =
+                    with_match_physical_integer_type!(dt, |T| {
+                        let arr: &PrimitiveArray<T> = arr.as_any().downcast_ref().unwrap();
+                        (
+                            arr.values().clone().try_transmute().unwrap(),
+                            std::mem::size_of::<T>(),
+                        )
+                    });
 
                 assert_eq!(width * arr.len(), bytes.len());
 

--- a/crates/polars-stream/src/nodes/top_k.rs
+++ b/crates/polars-stream/src/nodes/top_k.rs
@@ -485,7 +485,7 @@ fn new_top_k_reducer(
         let (_name, dt) = key_schema.get_at_index(0).unwrap();
         match dt {
             dt if dt.is_primitive_numeric() | dt.is_temporal() | dt.is_decimal() | dt.is_enum() => {
-                return with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
+                return with_match_physical_numeric_polars_type!(dt.to_physical(), impl<T> {
                     match (reverse[0], nulls_last[0]) {
                         (false, false) => Box::new(PrimitiveBottomK::<T, true, false>::new(k)),
                         (false, true) => Box::new(PrimitiveBottomK::<T, true, true>::new(k)),

--- a/crates/polars-stream/src/nodes/top_k.rs
+++ b/crates/polars-stream/src/nodes/top_k.rs
@@ -485,12 +485,12 @@ fn new_top_k_reducer(
         let (_name, dt) = key_schema.get_at_index(0).unwrap();
         match dt {
             dt if dt.is_primitive_numeric() | dt.is_temporal() | dt.is_decimal() | dt.is_enum() => {
-                return with_match_physical_numeric_polars_type!(dt.to_physical(), |$T| {
+                return with_match_physical_numeric_polars_type!(dt.to_physical(), |T| {
                     match (reverse[0], nulls_last[0]) {
-                        (false, false) => Box::new(PrimitiveBottomK::<$T, true, false>::new(k)),
-                        (false, true) => Box::new(PrimitiveBottomK::<$T, true, true>::new(k)),
-                        (true, false) => Box::new(PrimitiveBottomK::<$T, false, false>::new(k)),
-                        (true, true) => Box::new(PrimitiveBottomK::<$T, false, true>::new(k)),
+                        (false, false) => Box::new(PrimitiveBottomK::<T, true, false>::new(k)),
+                        (false, true) => Box::new(PrimitiveBottomK::<T, true, true>::new(k)),
+                        (true, false) => Box::new(PrimitiveBottomK::<T, false, false>::new(k)),
+                        (true, true) => Box::new(PrimitiveBottomK::<T, false, true>::new(k)),
                     }
                 });
             },

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1656,7 +1656,7 @@ fn to_graph_rec<'a>(
 
             let state: Box<dyn EwmStateUpdate + Send> = match ewm_variant {
                 EwmMean { .. } => {
-                    with_match_physical_float_type!(dtype, |T| {
+                    with_match_physical_float_type!(dtype, impl<T> {
                         let state: EwmMeanState<T> = EwmMeanState::new(
                             AsPrimitive::<T>::as_(options.alpha),
                             options.adjust,
@@ -1668,7 +1668,7 @@ fn to_graph_rec<'a>(
                     })
                 },
                 EwmSum { .. } => {
-                    with_match_physical_float_type!(dtype, |T| {
+                    with_match_physical_float_type!(dtype, impl<T> {
                         let state: EwmSumState<T> = EwmSumState::new(
                             AsPrimitive::<T>::as_(options.alpha),
                             options.min_periods,
@@ -1678,7 +1678,7 @@ fn to_graph_rec<'a>(
                         Box::new(state)
                     })
                 },
-                _ => with_match_physical_float_type!(dtype, |T| {
+                _ => with_match_physical_float_type!(dtype, impl<T> {
                     let state: EwmCovState<T> = EwmCovState::new(
                         AsPrimitive::<T>::as_(options.alpha),
                         options.adjust,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1656,9 +1656,9 @@ fn to_graph_rec<'a>(
 
             let state: Box<dyn EwmStateUpdate + Send> = match ewm_variant {
                 EwmMean { .. } => {
-                    with_match_physical_float_type!(dtype, |$T| {
-                        let state: EwmMeanState<$T> = EwmMeanState::new(
-                            AsPrimitive::<$T>::as_(options.alpha),
+                    with_match_physical_float_type!(dtype, |T| {
+                        let state: EwmMeanState<T> = EwmMeanState::new(
+                            AsPrimitive::<T>::as_(options.alpha),
                             options.adjust,
                             options.min_periods,
                             options.ignore_nulls,
@@ -1668,9 +1668,9 @@ fn to_graph_rec<'a>(
                     })
                 },
                 EwmSum { .. } => {
-                    with_match_physical_float_type!(dtype, |$T| {
-                        let state: EwmSumState<$T> = EwmSumState::new(
-                            AsPrimitive::<$T>::as_(options.alpha),
+                    with_match_physical_float_type!(dtype, |T| {
+                        let state: EwmSumState<T> = EwmSumState::new(
+                            AsPrimitive::<T>::as_(options.alpha),
                             options.min_periods,
                             options.ignore_nulls,
                         );
@@ -1678,9 +1678,9 @@ fn to_graph_rec<'a>(
                         Box::new(state)
                     })
                 },
-                _ => with_match_physical_float_type!(dtype, |$T| {
-                    let state: EwmCovState<$T> = EwmCovState::new(
-                        AsPrimitive::<$T>::as_(options.alpha),
+                _ => with_match_physical_float_type!(dtype, |T| {
+                    let state: EwmCovState<T> = EwmCovState::new(
+                        AsPrimitive::<T>::as_(options.alpha),
                         options.adjust,
                         options.bias,
                         options.min_periods,

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -226,7 +226,7 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg_by::<T, _, MeanWindow<_>, MeanWindow<_>>(ca, by, options)
         })
@@ -237,7 +237,7 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_mean(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -271,7 +271,7 @@ pub trait SeriesOpsTime: AsSeries {
             s.dtype()
         );
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             type Native = <T as PolarsNumericType>::Native;
             type SM<'a> = SumWindow<'a, Native, Native>;
@@ -300,7 +300,7 @@ pub trait SeriesOpsTime: AsSeries {
             s.dtype()
         );
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -319,7 +319,7 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg_by::<T, _, no_nulls::QuantileWindow<_>, nulls::QuantileWindow<_>>(
                 ca, by, options,
@@ -331,7 +331,7 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_quantile(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -372,7 +372,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg_by::<T, _, no_nulls::MinWindow<_>, nulls::MinWindow<_>>(ca, by, options)
         })
@@ -407,7 +407,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(dt, |T| {
+        with_match_physical_numeric_polars_type!(dt, impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -448,7 +448,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg_by::<T, _, no_nulls::MaxWindow<_>, nulls::MaxWindow<_>>(ca, by, options)
         })
@@ -483,7 +483,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -503,7 +503,7 @@ pub trait SeriesOpsTime: AsSeries {
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
 
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             rolling_agg_by::<
@@ -520,7 +520,7 @@ pub trait SeriesOpsTime: AsSeries {
     fn rolling_var(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
 
-        with_match_physical_float_polars_type!(s.dtype(), |T| {
+        with_match_physical_float_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             rolling_agg(
@@ -540,7 +540,7 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         self.rolling_var_by(by, options).map(|mut s| {
-            with_match_physical_float_polars_type!(s.dtype(), |T| {
+            with_match_physical_float_polars_type!(s.dtype(), impl<T> {
                 let ca: &mut ChunkedArray<T> = s._get_inner_mut().as_mut();
                 ca.apply_mut(|v| v.sqrt());
             });
@@ -553,7 +553,7 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_std(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         self.rolling_var(options).map(|mut s| {
-            with_match_physical_float_polars_type!(s.dtype(), |T| {
+            with_match_physical_float_polars_type!(s.dtype(), impl<T> {
                 let ca: &mut ChunkedArray<T> = s._get_inner_mut().as_mut();
                 ca.apply_mut(|v| v.sqrt());
             });
@@ -596,7 +596,7 @@ pub trait SeriesOpsTime: AsSeries {
             unreachable!("expected RollingFnParams::Rank");
         };
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             match method {
@@ -646,7 +646,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+        with_match_physical_numeric_polars_type!(s.dtype(), impl<T> {
             let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             let ca = ca.clone();
 

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -226,9 +226,9 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by::<$T, _, MeanWindow<_>, MeanWindow<_>>(ca, by, options)
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            rolling_agg_by::<T, _, MeanWindow<_>, MeanWindow<_>>(ca, by, options)
         })
     }
     /// Apply a rolling mean to a Series.
@@ -237,8 +237,8 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_mean(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
                 options,
@@ -271,11 +271,11 @@ pub trait SeriesOpsTime: AsSeries {
             s.dtype()
         );
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            type Native = <$T as PolarsNumericType>::Native;
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            type Native = <T as PolarsNumericType>::Native;
             type SM<'a> = SumWindow<'a, Native, Native>;
-            rolling_agg_by::<$T, _, SM, SM>(ca, by, options)
+            rolling_agg_by::<T, _, SM, SM>(ca, by, options)
         })
     }
 
@@ -300,8 +300,8 @@ pub trait SeriesOpsTime: AsSeries {
             s.dtype()
         );
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
                 options,
@@ -319,14 +319,11 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by::<
-                $T,
-                _,
-                no_nulls::QuantileWindow<_>,
-                nulls::QuantileWindow<_>
-            >(ca, by, options)
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            rolling_agg_by::<T, _, no_nulls::QuantileWindow<_>, nulls::QuantileWindow<_>>(
+                ca, by, options,
+            )
         })
     }
 
@@ -334,8 +331,8 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_quantile(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
                 options,
@@ -375,14 +372,9 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by::<
-                $T,
-                _,
-                no_nulls::MinWindow<_>,
-                nulls::MinWindow<_>
-            >(ca, by, options)
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            rolling_agg_by::<T, _, no_nulls::MinWindow<_>, nulls::MinWindow<_>>(ca, by, options)
         })
     }
 
@@ -415,8 +407,8 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(dt, |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(dt, |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
                 options,
@@ -456,14 +448,9 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by::<
-                $T,
-                _,
-                no_nulls::MaxWindow<_>,
-                nulls::MaxWindow<_>
-            >(ca, by, options)
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            rolling_agg_by::<T, _, no_nulls::MaxWindow<_>, nulls::MaxWindow<_>>(ca, by, options)
         })
     }
 
@@ -496,8 +483,8 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
             rolling_agg(
                 ca,
                 options,
@@ -516,14 +503,14 @@ pub trait SeriesOpsTime: AsSeries {
     ) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
 
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             rolling_agg_by::<
-                $T,
+                T,
                 _,
                 no_nulls::MomentWindow<_, no_nulls::VarianceMoment>,
-                nulls::MomentWindow<_, nulls::VarianceMoment>
+                nulls::MomentWindow<_, nulls::VarianceMoment>,
             >(ca, by, options)
         })
     }
@@ -533,8 +520,8 @@ pub trait SeriesOpsTime: AsSeries {
     fn rolling_var(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         let s = self.as_series().to_float()?;
 
-        with_match_physical_float_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_float_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             rolling_agg(
                 ca,
@@ -553,8 +540,8 @@ pub trait SeriesOpsTime: AsSeries {
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
         self.rolling_var_by(by, options).map(|mut s| {
-            with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                let ca: &mut ChunkedArray<$T> = s._get_inner_mut().as_mut();
+            with_match_physical_float_polars_type!(s.dtype(), |T| {
+                let ca: &mut ChunkedArray<T> = s._get_inner_mut().as_mut();
                 ca.apply_mut(|v| v.sqrt());
             });
 
@@ -566,8 +553,8 @@ pub trait SeriesOpsTime: AsSeries {
     #[cfg(feature = "rolling_window")]
     fn rolling_std(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
         self.rolling_var(options).map(|mut s| {
-            with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                let ca: &mut ChunkedArray<$T> = s._get_inner_mut().as_mut();
+            with_match_physical_float_polars_type!(s.dtype(), |T| {
+                let ca: &mut ChunkedArray<T> = s._get_inner_mut().as_mut();
                 ca.apply_mut(|v| v.sqrt());
             });
 
@@ -609,41 +596,35 @@ pub trait SeriesOpsTime: AsSeries {
             unreachable!("expected RollingFnParams::Rank");
         };
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
 
             match method {
-                RollingRankMethod::Average => rolling_agg_by::<
-                    $T,
-                    _,
-                    no_nulls::RankWindowAvg<_>,
-                    nulls::RankWindowAvg<_>
-                >(ca, by, options),
-                RollingRankMethod::Min => rolling_agg_by::<
-                    $T,
-                    _,
-                    no_nulls::RankWindowMin<_>,
-                    nulls::RankWindowMin<_>
-                >(ca, by, options),
-                RollingRankMethod::Max => rolling_agg_by::<
-                    $T,
-                    _,
-                    no_nulls::RankWindowMax<_>,
-                    nulls::RankWindowMax<_>
-                >(ca, by, options),
-                RollingRankMethod::Dense => rolling_agg_by::<
-                    $T,
-                    _,
-                    no_nulls::RankWindowDense<_>,
-                    nulls::RankWindowDense<_>
-                >(ca, by, options),
-                RollingRankMethod::Random => rolling_agg_by::<
-                    $T,
-                    _,
-                    no_nulls::RankWindowRandom<_>,
-                    nulls::RankWindowRandom<_>
-                >(ca, by, options),
-                _ => todo!()
+                RollingRankMethod::Average => {
+                    rolling_agg_by::<T, _, no_nulls::RankWindowAvg<_>, nulls::RankWindowAvg<_>>(
+                        ca, by, options,
+                    )
+                },
+                RollingRankMethod::Min => {
+                    rolling_agg_by::<T, _, no_nulls::RankWindowMin<_>, nulls::RankWindowMin<_>>(
+                        ca, by, options,
+                    )
+                },
+                RollingRankMethod::Max => {
+                    rolling_agg_by::<T, _, no_nulls::RankWindowMax<_>, nulls::RankWindowMax<_>>(
+                        ca, by, options,
+                    )
+                },
+                RollingRankMethod::Dense => {
+                    rolling_agg_by::<T, _, no_nulls::RankWindowDense<_>, nulls::RankWindowDense<_>>(
+                        ca, by, options,
+                    )
+                },
+                RollingRankMethod::Random => {
+                    rolling_agg_by::<T, _, no_nulls::RankWindowRandom<_>, nulls::RankWindowRandom<_>>(
+                        ca, by, options,
+                    )
+                },
             }
         })
     }
@@ -665,9 +646,9 @@ pub trait SeriesOpsTime: AsSeries {
             },
         }
 
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-            let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            let mut ca = ca.clone();
+        with_match_physical_numeric_polars_type!(s.dtype(), |T| {
+            let ca: &ChunkedArray<T> = s.as_ref().as_ref();
+            let ca = ca.clone();
 
             rolling_agg(
                 &ca,

--- a/crates/polars-utils/src/macros.rs
+++ b/crates/polars-utils/src/macros.rs
@@ -17,24 +17,23 @@ macro_rules! no_call_const {
 // Same as OSS except for the feature gates.
 #[macro_export]
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+    $key_type:expr, |$T:ident| $($body:tt)*
 ) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
     match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Int128 => __with_ty__! { Int128Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        UInt128 => __with_ty__! { UInt128Type },
-        Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
+        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
+        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
+        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
+        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
+        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
+        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
+        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
+        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
+        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
+        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
+        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
+        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
+        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}

--- a/crates/polars-utils/src/macros.rs
+++ b/crates/polars-utils/src/macros.rs
@@ -21,19 +21,19 @@ macro_rules! with_match_physical_numeric_polars_type {(
 ) => ({
     use $crate::datatypes::DataType::*;
     match $key_type {
-        Int8 => { #[allow(dead_code)] type $T = Int8Type; $($body)* },
-        Int16 => { #[allow(dead_code)] type $T = Int16Type; $($body)* },
-        Int32 => { #[allow(dead_code)] type $T = Int32Type; $($body)* },
-        Int64 => { #[allow(dead_code)] type $T = Int64Type; $($body)* },
-        Int128 => { #[allow(dead_code)] type $T = Int128Type; $($body)* },
-        UInt8 => { #[allow(dead_code)] type $T = UInt8Type; $($body)* },
-        UInt16 => { #[allow(dead_code)] type $T = UInt16Type; $($body)* },
-        UInt32 => { #[allow(dead_code)] type $T = UInt32Type; $($body)* },
-        UInt64 => { #[allow(dead_code)] type $T = UInt64Type; $($body)* },
-        UInt128 => { #[allow(dead_code)] type $T = UInt128Type; $($body)* },
-        Float16 => { #[allow(dead_code)] type $T = Float16Type; $($body)* },
-        Float32 => { #[allow(dead_code)] type $T = Float32Type; $($body)* },
-        Float64 => { #[allow(dead_code)] type $T = Float64Type; $($body)* },
+        Int8 => { type $T = Int8Type; $($body)* },
+        Int16 => { type $T = Int16Type; $($body)* },
+        Int32 => { type $T = Int32Type; $($body)* },
+        Int64 => { type $T = Int64Type; $($body)* },
+        Int128 => { type $T = Int128Type; $($body)* },
+        UInt8 => { type $T = UInt8Type; $($body)* },
+        UInt16 => { type $T = UInt16Type; $($body)* },
+        UInt32 => { type $T = UInt32Type; $($body)* },
+        UInt64 => { type $T = UInt64Type; $($body)* },
+        UInt128 => { type $T = UInt128Type; $($body)* },
+        Float16 => { type $T = Float16Type; $($body)* },
+        Float32 => { type $T = Float32Type; $($body)* },
+        Float64 => { type $T = Float64Type; $($body)* },
         dt => panic!("not implemented for dtype {:?}", dt),
     }
 })}

--- a/crates/polars-utils/src/macros.rs
+++ b/crates/polars-utils/src/macros.rs
@@ -17,7 +17,7 @@ macro_rules! no_call_const {
 // Same as OSS except for the feature gates.
 #[macro_export]
 macro_rules! with_match_physical_numeric_polars_type {(
-    $key_type:expr, |$T:ident| $($body:tt)*
+    $key_type:expr, impl<$T:ident> $($body:tt)*
 ) => ({
     use $crate::datatypes::DataType::*;
     match $key_type {

--- a/docs/source/development/contributing/code-style.md
+++ b/docs/source/development/contributing/code-style.md
@@ -85,9 +85,9 @@ fn compute_chunked_array_2_args<T: PolarsNumericType>(
 
 pub fn compute_expr_2_args(arg_1: &Series, arg_2: &Series) -> Series {
     // Dispatch the numerical series to `compute_chunked_array_2_args`.
-    with_match_physical_numeric_polars_type!(arg_1.dtype(), |$T| {
-        let ca_1: &ChunkedArray<$T> = arg_1.as_ref().as_ref().as_ref();
-        let ca_2: &ChunkedArray<$T> = arg_2.as_ref().as_ref().as_ref();
+    with_match_physical_numeric_polars_type!(arg_1.dtype(), |T| {
+        let ca_1: &ChunkedArray<T> = arg_1.as_ref().as_ref();
+        let ca_2: &ChunkedArray<T> = arg_2.as_ref().as_ref();
         compute_chunked_array_2_args(ca_1, ca_2).into_series()
     })
 }

--- a/pyo3-polars/example/derive_expression/expression_lib/src/distances.rs
+++ b/pyo3-polars/example/derive_expression/expression_lib/src/distances.rs
@@ -36,7 +36,7 @@ pub(super) fn naive_jaccard_sim(a: &ListChunked, b: &ListChunked) -> PolarsResul
         a.inner_dtype().is_integer(),
         ComputeError: "inner data types must be integer"
     );
-    Ok(with_match_physical_integer_type!(a.inner_dtype(), |T| {
+    Ok(with_match_physical_integer_type!(a.inner_dtype(), impl<T> {
         polars::prelude::arity::binary_elementwise(a, b, |a, b| match (a, b) {
             (Some(a), Some(b)) => {
                 let a = a.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();

--- a/pyo3-polars/example/derive_expression/expression_lib/src/distances.rs
+++ b/pyo3-polars/example/derive_expression/expression_lib/src/distances.rs
@@ -36,17 +36,15 @@ pub(super) fn naive_jaccard_sim(a: &ListChunked, b: &ListChunked) -> PolarsResul
         a.inner_dtype().is_integer(),
         ComputeError: "inner data types must be integer"
     );
-    Ok(with_match_physical_integer_type!(a.inner_dtype(), |$T| {
-    polars::prelude::arity::binary_elementwise(a, b, |a, b| {
-        match (a, b) {
+    Ok(with_match_physical_integer_type!(a.inner_dtype(), |T| {
+        polars::prelude::arity::binary_elementwise(a, b, |a, b| match (a, b) {
             (Some(a), Some(b)) => {
-                let a = a.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
-                let b = b.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
+                let a = a.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+                let b = b.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
                 Some(jacc_helper(a, b))
             },
-            _ => None
-        }
-    })
+            _ => None,
+        })
     }))
 }
 


### PR DESCRIPTION
Autogenerated by Claude Opus 5.

E.g. -

Before -
```rust
with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
    ...
```

After -
```rust
with_match_physical_numeric_polars_type!(s.dtype(), |T| {
    let ca: &ChunkedArray<T> = s.as_ref().as_ref();
    ...
```

<img width="357" height="50" alt="image" src="https://github.com/user-attachments/assets/c863e355-4311-4c1f-863f-0c51f041c0b3" />

