### PR TITLE
perf: Make file read concurrency semaphore global

### DIFF
--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use dio_align::DioAlign;
 use futures::{StreamExt, TryStreamExt};
@@ -95,6 +95,17 @@ pub struct FileByteSource {
     // File size.
     size: u64,
     io_metrics: OptIOMetrics,
+}
+
+/// Each permit pins a tokio blocking thread for the duration of a `pread`.
+pub fn global_read_permits() -> Arc<Semaphore> {
+    static PERMITS: LazyLock<Arc<Semaphore>> = LazyLock::new(|| {
+        Arc::new(Semaphore::new(
+            polars_config::config().file_read_concurrency().max(1) as usize,
+        ))
+    });
+
+    PERMITS.clone()
 }
 
 #[derive(Clone)]

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -7,9 +7,8 @@ use polars_io::cloud::CloudOptions;
 use polars_io::cloud::concurrency::get_request_budget;
 use polars_io::cloud::concurrency_config::FetchConfig;
 use polars_io::prelude::{FileMetadata, ParallelStrategy, ParquetOptions};
-use polars_io::utils::byte_source::{DynByteSourceBuilder, FileReadContext};
+use polars_io::utils::byte_source::{self, DynByteSourceBuilder, FileReadContext};
 use polars_plan::dsl::ScanSource;
-use tokio::sync::Semaphore;
 
 use super::super::shared::pipeline_budget::PipelineBudget;
 use super::{FileReader, ParquetFileReader};
@@ -160,12 +159,10 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                         );
                     }
 
-                    let permits = Arc::new(Semaphore::new(concurrency));
-
                     FileReadContext {
                         enable_o_direct,
                         concurrency,
-                        permits,
+                        permits: byte_source::global_read_permits(),
                         advice: fadv,
                     }
                 });


### PR DESCRIPTION
Follow-up to https://github.com/pola-rs/polars/pull/29091

This PR makes the newly introduced semaphore global, i.e. shared across all files being opened.

Defaults to 32. 

For a single SSD, performance on TPC-H SF=100 flattens at 16. Can be increased to a higher value for high-end systems (multiple SSD drives) via a private env var. We may expose a public control over time if justified.