### PR TITLE
perf: Prevent cache trashing in row encoding for fixed width types

### DIFF
--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -61,6 +61,9 @@ pub fn convert_columns_amortized_no_order(
     );
 }
 
+/// Number of rows encoded across all columns at a time.
+const ENCODE_ROW_TILE: usize = 1024;
+
 pub fn convert_columns_amortized<'a>(
     num_rows: usize,
     columns: &[ArrayRef],
@@ -97,18 +100,38 @@ pub fn convert_columns_amortized<'a>(
 
     let masked_out_write_offset = total_num_bytes;
     let mut scratches = EncodeScratches::default();
-    for (encoder, (opt, dict)) in encoders.iter_mut().zip(fields) {
-        unsafe {
-            encode_array(
-                buffer,
-                encoder,
-                opt,
-                dict,
-                &mut offsets[1..],
-                masked_out_write_offset,
-                &mut scratches,
-            )
-        };
+    if encoders.len() > 1 && encoders.iter().all(|e| e.state.is_none()) {
+        let mut start = 0;
+        while start < num_rows {
+            let len = ENCODE_ROW_TILE.min(num_rows - start);
+            for (encoder, (opt, dict)) in encoders.iter().zip(fields.clone()) {
+                let array = encoder.array.sliced(start, len);
+                unsafe {
+                    encode_flat_array(
+                        buffer,
+                        array.as_ref(),
+                        opt,
+                        dict,
+                        &mut offsets[1 + start..1 + start + len],
+                    )
+                };
+            }
+            start += len;
+        }
+    } else {
+        for (encoder, (opt, dict)) in encoders.iter_mut().zip(fields) {
+            unsafe {
+                encode_array(
+                    buffer,
+                    encoder,
+                    opt,
+                    dict,
+                    &mut offsets[1..],
+                    masked_out_write_offset,
+                    &mut scratches,
+                )
+            };
+        }
     }
     // SAFETY: All the bytes in out up to total_num_bytes should now be initialized.
     unsafe {


### PR DESCRIPTION
We row-encode and thus convert from column major order to row major order. This PR ensures we tile all the columns at ones, hugely reducing cache invalidation.

Row-encoding benchmarks:

```
int_const_total_bytes (all-integer, exactly 64 data bytes/row: cols=4→i128, 8→i64, 16→i32, 32→i16, 64→i8):

┌────────────────────┬───────────────────────┬──────────────────────────┬─────────┐
│       config       │         tiled         │         untiled          │ speedup │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=100k, cols=4  │ 1.63ms [1.62,1.63]    │ 1.64ms [1.63,1.66]       │ 1.01x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=100k, cols=8  │ 627.0us [624.1,631.7] │ 613.3us [606.8,623.6]    │ 0.98x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=100k, cols=16 │ 1.07ms [1.07,1.07]    │ 1.21ms [1.19,1.23]       │ 1.13x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=100k, cols=32 │ 2.07ms [2.06,2.07]    │ 2.90ms [2.85,2.97]       │ 1.40x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=100k, cols=64 │ 3.79ms [3.75,3.86]    │ 9.36ms [9.28,9.43]       │ 2.47x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=1M, cols=4    │ 29.05ms [28.65,29.34] │ 28.23ms [28.19,28.28]    │ 0.97x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=1M, cols=8    │ 20.01ms [19.89,20.12] │ 34.82ms [34.52,35.09]    │ 1.74x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=1M, cols=16   │ 25.07ms [24.77,25.48] │ 59.03ms [58.66,59.73]    │ 2.35x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=1M, cols=32   │ 37.69ms [37.25,38.03] │ 119.04ms [118.66,119.44] │ 3.16x   │
├────────────────────┼───────────────────────┼──────────────────────────┼─────────┤
│ rows=1M, cols=64   │ 57.80ms [57.39,58.20] │ 230.68ms [229.72,231.74] │ 3.99x   │
└────────────────────┴───────────────────────┴──────────────────────────┴─────────┘
```