### PR TITLE
docs(python): Refresh the ADBC section of the database IO guide

### DIFF
--- a/docs/source/src/python/user-guide/io/database.py
+++ b/docs/source/src/python/user-guide/io/database.py
@@ -27,6 +27,15 @@ query = "SELECT * FROM foo"
 pl.read_database_uri(query=query, uri=uri, engine="adbc")
 # --8<-- [end:adbc]
 
+# --8<-- [start:adbc_odbc]
+import adbcbridge
+
+conn = adbcbridge.connect(
+    uri="Driver=Firebird;Dbname=localhost:/data/sales.fdb;Uid=SYSDBA;Pwd=masterkey;"
+)
+df = pl.read_database(query="SELECT * FROM foo", connection=conn)
+# --8<-- [end:adbc_odbc]
+
 # --8<-- [start:write]
 uri = "postgresql://username:password@server:port/database"
 df = pl.DataFrame({"foo": [1, 2, 3]})

--- a/docs/source/user-guide/io/database.md
+++ b/docs/source/user-guide/io/database.md
@@ -55,11 +55,13 @@ ADBC (Arrow Database Connectivity) is an engine supported by the Apache Arrow pr
 be both an API standard for connecting to databases and libraries implementing this standard in a
 range of languages.
 
-It is still early days for ADBC so support for different databases is limited. At present, drivers
-for ADBC are only available for [Postgres](https://pypi.org/project/adbc-driver-postgresql/),
+ADBC drivers exist for a growing set of databases. The Apache Arrow project ships drivers for
+[PostgreSQL](https://pypi.org/project/adbc-driver-postgresql/),
 [SQLite](https://pypi.org/project/adbc-driver-sqlite/) and
-[Snowflake](https://pypi.org/project/adbc-driver-snowflake/). To install ADBC, you need to install
-the driver for your database. For example, to install the driver for SQLite, you run:
+[Flight SQL](https://pypi.org/project/adbc-driver-flightsql/); more, including Snowflake, BigQuery,
+Databricks, MySQL and SQL Server, are listed by the
+[ADBC Driver Foundry](https://adbc-drivers.org/). To install ADBC, you need to install the driver
+for your database. For example, to install the driver for SQLite, you run:
 
 ```shell
 $ pip install adbc-driver-sqlite
@@ -69,6 +71,12 @@ As ADBC is not the default engine, you must specify the engine as an argument to
 `pl.read_database_uri`.
 
 {{code_block('user-guide/io/database','adbc',['read_database_uri'])}}
+
+A database that has an ODBC driver but no native ADBC driver can be read through
+[adbcBridge](https://adbcbridge.org), an ADBC driver that wraps the ODBC driver. It returns an
+ordinary ADBC connection, which `pl.read_database` accepts directly:
+
+{{code_block('user-guide/io/database','adbc_odbc',['read_database'])}}
 
 ## Write to a database
 


### PR DESCRIPTION
The ADBC paragraph of the database IO guide says drivers exist only for Postgres, SQLite and Snowflake, which predates the ADBC Driver Foundry's drivers (Snowflake, BigQuery, Databricks, MySQL, SQL Server and others).

This refreshes that paragraph: names the Arrow project's own drivers, points at the Foundry for the full list, and adds one example of reading a database that has only an ODBC driver, through an ADBC connection object with `read_database`. `read_database_uri` cannot reach such a driver because it imports `adbc_driver_<scheme>` from the URI, so the example uses the connection-object form.

Docs only; no code change.
