### PR TITLE
fix(python): Fix `filter`/`remove` raising `TypeError` when all predicates are no-op scalars

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -4315,10 +4315,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         all_predicates.extend(
             F.col(name).eq(value) for name, value in constraints.items()
         )
-        if not (all_predicates or boolean_masks):
-            msg = "at least one predicate or constraint must be provided"
-            raise TypeError(msg)
-
         # if multiple predicates, combine as 'horizontal' expression
         combined_predicate = (
             (

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -360,3 +360,15 @@ def test_filter_group_by_23681(maintain_order: bool) -> None:
     )
 
     assert_frame_equal(df, expected, check_row_order=maintain_order)
+
+
+def test_filter_all_scalar_predicates_28943() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+
+    assert_frame_equal(df.filter(True, True), df)
+    assert_frame_equal(df.remove(False, False), df)
+    assert_frame_equal(df.lazy().filter(True, True).collect(), df)
+    assert_frame_equal(df.lazy().remove(False, False).collect(), df)
+    assert_frame_equal(df.filter(True, pl.col("a") > 1), df.filter(pl.col("a") > 1))
+    assert df.filter(True, False).is_empty()
+    assert df.remove(False, True).is_empty()


### PR DESCRIPTION
Closes #28943

`df.filter(True)` returns all rows, but `df.filter(True, True)` raised
`TypeError: at least one predicate or constraint must be provided`.
The same happened for `df.remove(False, False)`. This bites optional
filters such as `df.filter(a is None or pl.col("x") == a, b is None or pl.col("y") == b)`
as soon as every condition is met.

Cause: `filter` and `remove` only short-circuit on a single scalar argument.
With several arguments, `_filter` skips each no-op scalar (`True` for `filter`,
`False` for `remove`) and then hit a guard that raised because no predicate was
left.

Fix: remove that guard. The `combined_predicate is None` branch right below it
already returns the frame unchanged, which is the expected result. The guard was
not reachable through the public API in any other way, since an empty call is
handled before `_filter` is entered.

Test: `test_filter_all_scalar_predicates_28943` covers `filter(True, True)`,
`remove(False, False)`, the lazy variants, a no-op scalar mixed with a real
predicate, and a no-op scalar mixed with the opposite scalar.

Local `make test` run (19202 passed, 244 skipped, 7 xfailed):

<img width="1410" height="1166" alt="Bildschirmfoto_20260906_185941" src="https://github.com/user-attachments/assets/a63a4d0a-e4c7-40da-9550-09a0cc0bb956" />
