### PR TITLE
perf: Push more predicates past caches

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -1012,3 +1012,107 @@ fn fold_and(nodes: Vec<Node>, expr_arena: &mut Arena<AExpr>) -> Node {
     }
     acc
 }
+
+/// Comparisons that every predicate in `predicates` implies.
+///
+/// Each predicate is read as an `AND` chain of `col op lit` comparisons, and a
+/// column bounded in all of them contributes the widest of those bounds. Every row
+/// any one predicate keeps therefore passes all of the results, so they may be
+/// applied ahead of a set of filters without changing what those filters select.
+///
+/// Returned one comparison at a time, as pushdown moves a conjunct only when it is
+/// its own filter.
+///
+/// Only bounds widen: a column some predicate leaves free is dropped, as are `!=`,
+/// `is_in` and null checks. Empty when nothing survives.
+pub(crate) fn widen_over_predicates(
+    predicates: &[Node],
+    expr_arena: &mut Arena<AExpr>,
+) -> Vec<Node> {
+    let Some((&first, rest)) = predicates.split_first() else {
+        return Vec::new();
+    };
+    let Some(mut widened) = predicate_bounds(first, expr_arena) else {
+        return Vec::new();
+    };
+
+    for &predicate in rest {
+        let Some(bounds) = predicate_bounds(predicate, expr_arena) else {
+            return Vec::new();
+        };
+        widened.retain(|name, cc| {
+            bounds
+                .get(name)
+                .is_some_and(|other| widen_bounds(cc, other))
+        });
+        if widened.is_empty() {
+            return Vec::new();
+        }
+    }
+
+    let mut comparisons: Vec<(&PlSmallStr, Operator, &Scalar)> = Vec::new();
+    for (name, cc) in &widened {
+        collect_column_comparisons(name, cc, &mut comparisons);
+    }
+    comparisons
+        .into_iter()
+        .map(|(name, op, value)| comparison_node(name, op, value.clone(), expr_arena))
+        .collect()
+}
+
+// The bounds one predicate places on the columns it constrains. `None` for an
+// unsatisfiable predicate: it selects nothing, so it says nothing about what the
+// others need.
+fn predicate_bounds(
+    predicate: Node,
+    expr_arena: &Arena<AExpr>,
+) -> Option<PlIndexMap<PlSmallStr, ColumnConstraints>> {
+    let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
+    for conjunct in MintermIter::new(predicate, expr_arena) {
+        if matches!(
+            classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints),
+            Classification::Unsat
+        ) {
+            return None;
+        }
+    }
+    // Only the bounds carry over. Anything else would be emitted as a comparison
+    // the other predicates never agreed to.
+    constraints.retain(|_, cc| {
+        if cc.unsat || (cc.lower.is_none() && cc.upper.is_none()) {
+            return false;
+        }
+        *cc = ColumnConstraints {
+            lower: cc.lower.take(),
+            upper: cc.upper.take(),
+            ..Default::default()
+        };
+        true
+    });
+    Some(constraints)
+}
+
+// Loosens `cc` to also admit everything `other` admits. A bound `other` does not
+// have is dropped, as is one whose values cannot be ordered. Returns whether any
+// bound is left.
+fn widen_bounds(cc: &mut ColumnConstraints, other: &ColumnConstraints) -> bool {
+    // A lower bound widens to the smaller value, an upper bound to the larger one.
+    // Equal values keep the inclusive bound, which is the wider of the two.
+    fn widen(slot: &mut Option<(Scalar, bool)>, other: &Option<(Scalar, bool)>, wider: Ordering) {
+        let (Some((value, inclusive)), Some((other_value, other_inclusive))) = (&*slot, other)
+        else {
+            *slot = None;
+            return;
+        };
+        match scalar_cmp(other_value, value) {
+            Some(ord) if ord == wider => *slot = Some((other_value.clone(), *other_inclusive)),
+            Some(Ordering::Equal) => *slot = Some((value.clone(), *inclusive || *other_inclusive)),
+            Some(_) => {},
+            None => *slot = None,
+        }
+    }
+
+    widen(&mut cc.lower, &other.lower, Ordering::Less);
+    widen(&mut cc.upper, &other.upper, Ordering::Greater);
+    cc.lower.is_some() || cc.upper.is_some()
+}

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -76,9 +76,6 @@ enum Nullability {
     NonNull,
 }
 
-// Orders two scalars; incomparable pairs give `None`, so we never declare a
-// contradiction we aren't sure of. The dtype guard is load-bearing: `AnyValue`'s
-// `PartialOrd` panics on nested/mixed/object dtypes rather than returning `None`.
 // Whether the comparisons in `node` order their column the way they order the
 // literals it is compared against. A categorical or an enum orders by its
 // categories instead, so nothing here may reason about its bounds. A column that
@@ -87,11 +84,14 @@ fn compares_in_literal_order(node: Node, schema: &Schema, expr_arena: &Arena<AEx
     expr_arena.iter(node).all(|(_, ae)| match ae {
         AExpr::Column(name) => schema
             .get(name)
-            .is_some_and(|dtype| !dtype.is_categorical() && !dtype.is_enum()),
+            .is_some_and(|dtype| !dtype.contains_categoricals() && !dtype.contains_enums()),
         _ => true,
     })
 }
 
+// Orders two scalars; incomparable pairs give `None`, so we never declare a
+// contradiction we aren't sure of. The dtype guard is load-bearing: `AnyValue`'s
+// `PartialOrd` panics on nested/mixed/object dtypes rather than returning `None`.
 fn scalar_cmp(a: &Scalar, b: &Scalar) -> Option<Ordering> {
     if a.dtype() != b.dtype() || a.dtype().is_nested() || a.dtype().is_object() {
         return None;

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -18,11 +18,13 @@ use std::cmp::Ordering;
 #[cfg(feature = "is_in")]
 use polars_core::prelude::{AnyValue, Series};
 use polars_core::scalar::Scalar;
+use polars_core::schema::Schema;
 use polars_utils::aliases::{InitHashMaps, PlIndexMap, PlIndexSet};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::properties::ExprPushdownGroup;
+use crate::plans::iterator::ArenaExprIter;
 use super::{AExpr, IRBooleanFunction, IRFunctionExpr, LiteralValue, MintermIter, Operator};
 #[cfg(feature = "is_between")]
 use crate::prelude::ClosedInterval;
@@ -77,6 +79,19 @@ enum Nullability {
 // Orders two scalars; incomparable pairs give `None`, so we never declare a
 // contradiction we aren't sure of. The dtype guard is load-bearing: `AnyValue`'s
 // `PartialOrd` panics on nested/mixed/object dtypes rather than returning `None`.
+// Whether the comparisons in `node` order their column the way they order the
+// literals it is compared against. A categorical or an enum orders by its
+// categories instead, so nothing here may reason about its bounds. A column that
+// is not in `schema` is treated the same way.
+fn compares_in_literal_order(node: Node, schema: &Schema, expr_arena: &Arena<AExpr>) -> bool {
+    expr_arena.iter(node).all(|(_, ae)| match ae {
+        AExpr::Column(name) => schema
+            .get(name)
+            .is_some_and(|dtype| !dtype.is_categorical() && !dtype.is_enum()),
+        _ => true,
+    })
+}
+
 fn scalar_cmp(a: &Scalar, b: &Scalar) -> Option<Ordering> {
     if a.dtype() != b.dtype() || a.dtype().is_nested() || a.dtype().is_object() {
         return None;
@@ -401,6 +416,7 @@ impl ColumnConstraints {
 /// `a >= 3 AND a != 3` to `a > 3`).
 pub(crate) fn merge_filter_constraints(
     predicate: Node,
+    schema: &Schema,
     maintain_errors: bool,
     expr_arena: &mut Arena<AExpr>,
 ) -> Option<Node> {
@@ -415,6 +431,10 @@ pub(crate) fn merge_filter_constraints(
     let mut unsat = false;
 
     for conjunct in MintermIter::new(predicate, expr_arena) {
+        if !compares_in_literal_order(conjunct, schema, expr_arena) {
+            opaque.push(conjunct);
+            continue;
+        }
         match classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints) {
             Classification::Unsat => {
                 unsat = true;
@@ -1023,20 +1043,23 @@ fn fold_and(nodes: Vec<Node>, expr_arena: &mut Arena<AExpr>) -> Node {
 /// Only bounds widen; `!=`, `is_in` and null checks are dropped. Returned one
 /// comparison per node, as pushdown moves a conjunct only when it is its own
 /// filter. Empty when nothing survives.
+///
+/// `schema` is the schema the predicates are evaluated against.
 pub(crate) fn widen_over_predicates(
     predicates: &[Node],
+    schema: &Schema,
     maintain_errors: bool,
     expr_arena: &mut Arena<AExpr>,
 ) -> Vec<Node> {
     let Some((&first, rest)) = predicates.split_first() else {
         return Vec::new();
     };
-    let Some(mut widened) = predicate_bounds(first, maintain_errors, expr_arena) else {
+    let Some(mut widened) = predicate_bounds(first, schema, maintain_errors, expr_arena) else {
         return Vec::new();
     };
 
     for &predicate in rest {
-        let Some(bounds) = predicate_bounds(predicate, maintain_errors, expr_arena) else {
+        let Some(bounds) = predicate_bounds(predicate, schema, maintain_errors, expr_arena) else {
             return Vec::new();
         };
         widened.retain(|name, cc| {
@@ -1066,6 +1089,7 @@ pub(crate) fn widen_over_predicates(
 // as a whole sees a different column once rows are dropped beneath it.
 fn predicate_bounds(
     predicate: Node,
+    schema: &Schema,
     maintain_errors: bool,
     expr_arena: &Arena<AExpr>,
 ) -> Option<PlIndexMap<PlSmallStr, ColumnConstraints>> {
@@ -1077,6 +1101,9 @@ fn predicate_bounds(
 
     let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
     for conjunct in MintermIter::new(predicate, expr_arena) {
+        if !compares_in_literal_order(conjunct, schema, expr_arena) {
+            continue;
+        }
         if matches!(
             classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints),
             Classification::Unsat

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -24,8 +24,8 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::properties::ExprPushdownGroup;
-use crate::plans::iterator::ArenaExprIter;
 use super::{AExpr, IRBooleanFunction, IRFunctionExpr, LiteralValue, MintermIter, Operator};
+use crate::plans::iterator::ArenaExprIter;
 #[cfg(feature = "is_between")]
 use crate::prelude::ClosedInterval;
 
@@ -1051,27 +1051,32 @@ pub(crate) fn widen_over_predicates(
     maintain_errors: bool,
     expr_arena: &mut Arena<AExpr>,
 ) -> Vec<Node> {
-    let Some((&first, rest)) = predicates.split_first() else {
-        return Vec::new();
-    };
-    let Some(mut widened) = predicate_bounds(first, schema, maintain_errors, expr_arena) else {
-        return Vec::new();
-    };
+    let mut widened: Option<PlIndexMap<PlSmallStr, ColumnConstraints>> = None;
 
-    for &predicate in rest {
-        let Some(bounds) = predicate_bounds(predicate, schema, maintain_errors, expr_arena) else {
-            return Vec::new();
+    for &predicate in predicates {
+        let bounds = match predicate_bounds(predicate, schema, maintain_errors, expr_arena) {
+            PredicateBounds::Blocked => return Vec::new(),
+            // Keeps no rows, so it asks nothing of the result.
+            PredicateBounds::Unsat => continue,
+            PredicateBounds::Bounds(bounds) => bounds,
         };
-        widened.retain(|name, cc| {
-            bounds
-                .get(name)
-                .is_some_and(|other| widen_bounds(cc, other))
-        });
-        if widened.is_empty() {
+        match &mut widened {
+            None => widened = Some(bounds),
+            Some(widened) => widened.retain(|name, cc| {
+                bounds
+                    .get(name)
+                    .is_some_and(|other| widen_bounds(cc, other))
+            }),
+        }
+        if widened.as_ref().is_some_and(PlIndexMap::is_empty) {
             return Vec::new();
         }
     }
 
+    // Every predicate was unsatisfiable, so there is nothing to widen over.
+    let Some(widened) = widened else {
+        return Vec::new();
+    };
     let mut comparisons: Vec<(&PlSmallStr, Operator, &Scalar)> = Vec::new();
     for (name, cc) in &widened {
         collect_column_comparisons(name, cc, &mut comparisons);
@@ -1082,21 +1087,26 @@ pub(crate) fn widen_over_predicates(
         .collect()
 }
 
+enum PredicateBounds {
+    // The predicate does not decide row by row: one reading its column as a whole
+    // sees a different column once rows are dropped beneath it, so no bound
+    // describes the rows it keeps.
+    Blocked,
+    Unsat,
+    Bounds(PlIndexMap<PlSmallStr, ColumnConstraints>),
+}
+
 // The bounds one predicate places on the columns it constrains.
-//
-// `None` for an unsatisfiable predicate, which says nothing about what the others
-// need, and for one that does not decide row by row: a predicate reading its column
-// as a whole sees a different column once rows are dropped beneath it.
 fn predicate_bounds(
     predicate: Node,
     schema: &Schema,
     maintain_errors: bool,
     expr_arena: &Arena<AExpr>,
-) -> Option<PlIndexMap<PlSmallStr, ColumnConstraints>> {
+) -> PredicateBounds {
     let mut group = ExprPushdownGroup::Pushable;
     group.update_with_expr_rec(expr_arena.get(predicate), expr_arena, None);
     if group.blocks_pushdown(maintain_errors) {
-        return None;
+        return PredicateBounds::Blocked;
     }
 
     let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
@@ -1108,12 +1118,15 @@ fn predicate_bounds(
             classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints),
             Classification::Unsat
         ) {
-            return None;
+            return PredicateBounds::Unsat;
         }
+    }
+    if constraints.values().any(|cc| cc.unsat) {
+        return PredicateBounds::Unsat;
     }
     // Only bounds widen; drop the rest.
     constraints.retain(|_, cc| {
-        if cc.unsat || (cc.lower.is_none() && cc.upper.is_none()) {
+        if cc.lower.is_none() && cc.upper.is_none() {
             return false;
         }
         *cc = ColumnConstraints {
@@ -1123,7 +1136,7 @@ fn predicate_bounds(
         };
         true
     });
-    Some(constraints)
+    PredicateBounds::Bounds(constraints)
 }
 
 // Loosens `cc` to also admit everything `other` admits, dropping a bound `other`

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -1015,18 +1015,14 @@ fn fold_and(nodes: Vec<Node>, expr_arena: &mut Arena<AExpr>) -> Node {
 
 /// Comparisons that every predicate in `predicates` implies.
 ///
-/// Each predicate is read as an `AND` chain of `col op lit` comparisons, and a
-/// column bounded in all of them contributes the widest of those bounds. Every row
-/// any one predicate keeps therefore passes all of the results, so they may be
-/// applied ahead of a set of filters without changing what those filters select.
+/// Each predicate is read as an `AND` chain of `col op lit` comparisons; a column
+/// bounded in all of them contributes the widest of those bounds. Any row a
+/// predicate keeps passes all the returned comparisons, so they may be applied
+/// below those filters.
 ///
-/// Returned one comparison at a time, as pushdown moves a conjunct only when it is
-/// its own filter.
-///
-/// Only bounds widen: a column some predicate leaves free is dropped, as are `!=`,
-/// `is_in` and null checks. Empty when nothing survives, and empty unless every
-/// predicate keeps rows one at a time, which is what makes the reasoning above
-/// hold.
+/// Only bounds widen; `!=`, `is_in` and null checks are dropped. Returned one
+/// comparison per node, as pushdown moves a conjunct only when it is its own
+/// filter. Empty when nothing survives.
 pub(crate) fn widen_over_predicates(
     predicates: &[Node],
     maintain_errors: bool,
@@ -1063,13 +1059,11 @@ pub(crate) fn widen_over_predicates(
         .collect()
 }
 
-// The bounds one predicate places on the columns it constrains. `None` for an
-// unsatisfiable predicate: it selects nothing, so it says nothing about what the
-// others need.
+// The bounds one predicate places on the columns it constrains.
 //
-// Also `None` for a predicate that does not decide row by row. One reading its
-// column as a whole - a sort, say - sees a different column once rows are dropped
-// beneath it, so which rows it keeps is not implied by any per-row bound.
+// `None` for an unsatisfiable predicate, which says nothing about what the others
+// need, and for one that does not decide row by row: a predicate reading its column
+// as a whole sees a different column once rows are dropped beneath it.
 fn predicate_bounds(
     predicate: Node,
     maintain_errors: bool,
@@ -1090,8 +1084,7 @@ fn predicate_bounds(
             return None;
         }
     }
-    // Only the bounds carry over. Anything else would be emitted as a comparison
-    // the other predicates never agreed to.
+    // Only bounds widen; drop the rest.
     constraints.retain(|_, cc| {
         if cc.unsat || (cc.lower.is_none() && cc.upper.is_none()) {
             return false;
@@ -1106,12 +1099,11 @@ fn predicate_bounds(
     Some(constraints)
 }
 
-// Loosens `cc` to also admit everything `other` admits. A bound `other` does not
-// have is dropped, as is one whose values cannot be ordered. Returns whether any
-// bound is left.
+// Loosens `cc` to also admit everything `other` admits, dropping a bound `other`
+// does not have or whose values cannot be ordered. Returns whether a bound is left.
 fn widen_bounds(cc: &mut ColumnConstraints, other: &ColumnConstraints) -> bool {
-    // A lower bound widens to the smaller value, an upper bound to the larger one.
-    // Equal values keep the inclusive bound, which is the wider of the two.
+    // `wider` is the ordering that loosens: `Less` for a lower bound, `Greater` for
+    // an upper one. Equal values keep the inclusive bound.
     fn widen(slot: &mut Option<(Scalar, bool)>, other: &Option<(Scalar, bool)>, wider: Ordering) {
         let (Some((value, inclusive)), Some((other_value, other_inclusive))) = (&*slot, other)
         else {

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -1024,20 +1024,23 @@ fn fold_and(nodes: Vec<Node>, expr_arena: &mut Arena<AExpr>) -> Node {
 /// its own filter.
 ///
 /// Only bounds widen: a column some predicate leaves free is dropped, as are `!=`,
-/// `is_in` and null checks. Empty when nothing survives.
+/// `is_in` and null checks. Empty when nothing survives, and empty unless every
+/// predicate keeps rows one at a time, which is what makes the reasoning above
+/// hold.
 pub(crate) fn widen_over_predicates(
     predicates: &[Node],
+    maintain_errors: bool,
     expr_arena: &mut Arena<AExpr>,
 ) -> Vec<Node> {
     let Some((&first, rest)) = predicates.split_first() else {
         return Vec::new();
     };
-    let Some(mut widened) = predicate_bounds(first, expr_arena) else {
+    let Some(mut widened) = predicate_bounds(first, maintain_errors, expr_arena) else {
         return Vec::new();
     };
 
     for &predicate in rest {
-        let Some(bounds) = predicate_bounds(predicate, expr_arena) else {
+        let Some(bounds) = predicate_bounds(predicate, maintain_errors, expr_arena) else {
             return Vec::new();
         };
         widened.retain(|name, cc| {
@@ -1063,10 +1066,21 @@ pub(crate) fn widen_over_predicates(
 // The bounds one predicate places on the columns it constrains. `None` for an
 // unsatisfiable predicate: it selects nothing, so it says nothing about what the
 // others need.
+//
+// Also `None` for a predicate that does not decide row by row. One reading its
+// column as a whole - a sort, say - sees a different column once rows are dropped
+// beneath it, so which rows it keeps is not implied by any per-row bound.
 fn predicate_bounds(
     predicate: Node,
+    maintain_errors: bool,
     expr_arena: &Arena<AExpr>,
 ) -> Option<PlIndexMap<PlSmallStr, ColumnConstraints>> {
+    let mut group = ExprPushdownGroup::Pushable;
+    group.update_with_expr_rec(expr_arena.get(predicate), expr_arena, None);
+    if group.blocks_pushdown(maintain_errors) {
+        return None;
+    }
+
     let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
     for conjunct in MintermIter::new(predicate, expr_arena) {
         if matches!(

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -1109,19 +1109,27 @@ fn predicate_bounds(
         return PredicateBounds::Blocked;
     }
 
+    // The same stages `merge_filter_constraints` runs, so a predicate is recognized
+    // as keeping no rows here just as often as it is there.
     let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
+    let mut edges: Vec<(PlSmallStr, PlSmallStr, Node)> = Vec::new();
     for conjunct in MintermIter::new(predicate, expr_arena) {
         if !compares_in_literal_order(conjunct, schema, expr_arena) {
             continue;
         }
-        if matches!(
-            classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints),
-            Classification::Unsat
-        ) {
-            return PredicateBounds::Unsat;
+        match classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints) {
+            Classification::Unsat => return PredicateBounds::Unsat,
+            Classification::Equality(a, b) => edges.push((a, b, conjunct)),
+            _ => {},
         }
     }
-    if constraints.values().any(|cc| cc.unsat) {
+    if !edges.is_empty() {
+        propagate_equalities(&mut constraints, &edges);
+    }
+    if constraints.values_mut().any(|cc| {
+        cc.resolve_deferred();
+        cc.unsat
+    }) {
         return PredicateBounds::Unsat;
     }
     // Only bounds widen; drop the rest.

--- a/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/aexpr/filter_constraint.rs
@@ -157,6 +157,36 @@ impl ColumnConstraints {
         }
     }
 
+    // Keep the wider bound, dropping it when `other` has none or the values cannot be
+    // ordered. `wider` is the other-vs-existing ordering that means the other bound
+    // wins (`Less` lower, `Greater` upper).
+    fn widen_slot(
+        slot: &mut Option<(Scalar, bool)>,
+        other: &Option<(Scalar, bool)>,
+        wider: Ordering,
+    ) {
+        let (Some((value, inclusive)), Some((other_value, other_inclusive))) = (&*slot, other)
+        else {
+            *slot = None;
+            return;
+        };
+        match scalar_cmp(other_value, value) {
+            Some(ord) if ord == wider => *slot = Some((other_value.clone(), *other_inclusive)),
+            // Same value: the inclusive bound is the wider of the two.
+            Some(Ordering::Equal) => *slot = Some((value.clone(), *inclusive || *other_inclusive)),
+            Some(_) => {},
+            None => *slot = None,
+        }
+    }
+
+    // Loosens the bounds to also admit everything `other` admits. Returns whether a
+    // bound is left.
+    fn widen(&mut self, other: &Self) -> bool {
+        Self::widen_slot(&mut self.lower, &other.lower, Ordering::Less);
+        Self::widen_slot(&mut self.upper, &other.upper, Ordering::Greater);
+        self.lower.is_some() || self.upper.is_some()
+    }
+
     fn add_lower(&mut self, value: Scalar, inclusive: bool) -> bool {
         if self.unsat {
             return false;
@@ -409,17 +439,20 @@ impl ColumnConstraints {
     }
 }
 
-/// Rewrites `predicate`'s `AND` chain to a tighter equivalent, or `None` if
-/// nothing changes. Either collapses to `Literal(false)` when the comparisons
-/// can't all hold (letting the filter become an empty scan), or merges redundant
-/// per-column comparisons into the tightest set (`a >= 1 AND a >= 5` to `a >= 5`,
-/// `a >= 3 AND a != 3` to `a > 3`).
-pub(crate) fn merge_filter_constraints(
-    predicate: Node,
-    schema: &Schema,
-    maintain_errors: bool,
-    expr_arena: &mut Arena<AExpr>,
-) -> Option<Node> {
+// One `AND` chain modeled per column.
+struct ConstraintModel {
+    constraints: PlIndexMap<PlSmallStr, ColumnConstraints>,
+    // Conjuncts the model does not describe, kept for a rebuild.
+    opaque: Vec<Node>,
+    num_bound_conjuncts: usize,
+    normalized: bool,
+    propagated: bool,
+    dropped_equality: bool,
+    unsat: bool,
+}
+
+// Runs stages 1 to 3 of the module docs over `predicate`.
+fn model_and_chain(predicate: Node, schema: &Schema, expr_arena: &Arena<AExpr>) -> ConstraintModel {
     // Collect bounds per column; unmodeled conjuncts kept aside, `col == col`
     // routed to `edges` for cross-column propagation. Stop early once a column is
     // impossible (the whole filter is then false).
@@ -483,6 +516,38 @@ pub(crate) fn merge_filter_constraints(
             cc.unsat
         });
     }
+
+    ConstraintModel {
+        constraints,
+        opaque,
+        num_bound_conjuncts,
+        normalized,
+        propagated,
+        dropped_equality,
+        unsat,
+    }
+}
+
+/// Rewrites `predicate`'s `AND` chain to a tighter equivalent, or `None` if
+/// nothing changes. Either collapses to `Literal(false)` when the comparisons
+/// can't all hold (letting the filter become an empty scan), or merges redundant
+/// per-column comparisons into the tightest set (`a >= 1 AND a >= 5` to `a >= 5`,
+/// `a >= 3 AND a != 3` to `a > 3`).
+pub(crate) fn merge_filter_constraints(
+    predicate: Node,
+    schema: &Schema,
+    maintain_errors: bool,
+    expr_arena: &mut Arena<AExpr>,
+) -> Option<Node> {
+    let ConstraintModel {
+        constraints,
+        mut opaque,
+        num_bound_conjuncts,
+        normalized,
+        propagated,
+        dropped_equality,
+        unsat,
+    } = model_and_chain(predicate, schema, expr_arena);
 
     if unsat {
         // Collapsing to `false` drops the filter, so an expression that would have
@@ -1062,11 +1127,9 @@ pub(crate) fn widen_over_predicates(
         };
         match &mut widened {
             None => widened = Some(bounds),
-            Some(widened) => widened.retain(|name, cc| {
-                bounds
-                    .get(name)
-                    .is_some_and(|other| widen_bounds(cc, other))
-            }),
+            Some(widened) => {
+                widened.retain(|name, cc| bounds.get(name).is_some_and(|other| cc.widen(other)))
+            },
         }
         if widened.as_ref().is_some_and(PlIndexMap::is_empty) {
             return Vec::new();
@@ -1109,29 +1172,11 @@ fn predicate_bounds(
         return PredicateBounds::Blocked;
     }
 
-    // The same stages `merge_filter_constraints` runs, so a predicate is recognized
-    // as keeping no rows here just as often as it is there.
-    let mut constraints: PlIndexMap<PlSmallStr, ColumnConstraints> = PlIndexMap::new();
-    let mut edges: Vec<(PlSmallStr, PlSmallStr, Node)> = Vec::new();
-    for conjunct in MintermIter::new(predicate, expr_arena) {
-        if !compares_in_literal_order(conjunct, schema, expr_arena) {
-            continue;
-        }
-        match classify_into_constraints(expr_arena.get(conjunct), expr_arena, &mut constraints) {
-            Classification::Unsat => return PredicateBounds::Unsat,
-            Classification::Equality(a, b) => edges.push((a, b, conjunct)),
-            _ => {},
-        }
-    }
-    if !edges.is_empty() {
-        propagate_equalities(&mut constraints, &edges);
-    }
-    if constraints.values_mut().any(|cc| {
-        cc.resolve_deferred();
-        cc.unsat
-    }) {
+    let model = model_and_chain(predicate, schema, expr_arena);
+    if model.unsat {
         return PredicateBounds::Unsat;
     }
+    let mut constraints = model.constraints;
     // Only bounds widen; drop the rest.
     constraints.retain(|_, cc| {
         if cc.lower.is_none() && cc.upper.is_none() {
@@ -1145,28 +1190,4 @@ fn predicate_bounds(
         true
     });
     PredicateBounds::Bounds(constraints)
-}
-
-// Loosens `cc` to also admit everything `other` admits, dropping a bound `other`
-// does not have or whose values cannot be ordered. Returns whether a bound is left.
-fn widen_bounds(cc: &mut ColumnConstraints, other: &ColumnConstraints) -> bool {
-    // `wider` is the ordering that loosens: `Less` for a lower bound, `Greater` for
-    // an upper one. Equal values keep the inclusive bound.
-    fn widen(slot: &mut Option<(Scalar, bool)>, other: &Option<(Scalar, bool)>, wider: Ordering) {
-        let (Some((value, inclusive)), Some((other_value, other_inclusive))) = (&*slot, other)
-        else {
-            *slot = None;
-            return;
-        };
-        match scalar_cmp(other_value, value) {
-            Some(ord) if ord == wider => *slot = Some((other_value.clone(), *other_inclusive)),
-            Some(Ordering::Equal) => *slot = Some((value.clone(), *inclusive || *other_inclusive)),
-            Some(_) => {},
-            None => *slot = None,
-        }
-    }
-
-    widen(&mut cc.lower, &other.lower, Ordering::Less);
-    widen(&mut cc.upper, &other.upper, Ordering::Greater);
-    cc.lower.is_some() || cc.upper.is_some()
 }

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -538,13 +538,15 @@ fn narrow_shared_subplan(
         })
         .collect::<Option<Vec<_>>>()?;
 
-    let widened = widen_over_predicates(&predicates, maintain_errors, expr_arena);
+    let input = *children.first().unwrap();
+    let schema = lp_arena.get(input).schema(lp_arena).into_owned();
+    let widened = widen_over_predicates(&predicates, &schema, maintain_errors, expr_arena);
     if widened.is_empty() {
         return None;
     }
 
     // One filter per comparison: pushdown moves a conjunct only when it stands alone.
-    let mut node = *children.first().unwrap();
+    let mut node = input;
     for predicate in widened {
         node = lp_arena.add(IR::Filter {
             input: node,

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -355,12 +355,7 @@ pub(crate) fn set_cache_states(
                     }
 
                     // The filter (if any) that blocked pushdown sits directly above the cache.
-                    let filter_predicate = get_filter_node(*parents, lp_arena).map(|filter_node| {
-                        let IR::Filter { predicate, .. } = lp_arena.get(filter_node) else {
-                            unreachable!()
-                        };
-                        predicate.clone()
-                    });
+                    let filter_predicate = get_filter_predicate(*parents, lp_arena).cloned();
 
                     // Copy the subplan with this cache removed and re-run predicate pushdown on
                     // the copy. Nested caches of other ids are preserved.
@@ -529,13 +524,7 @@ fn narrow_shared_subplan(
 ) -> Option<Node> {
     let predicates = parents
         .iter()
-        .map(|parents| {
-            let filter = get_filter_node(*parents, lp_arena)?;
-            let IR::Filter { predicate, .. } = lp_arena.get(filter) else {
-                unreachable!()
-            };
-            Some(predicate.node())
-        })
+        .map(|parents| Some(get_filter_predicate(*parents, lp_arena)?.node()))
         .collect::<Option<Vec<_>>>()?;
 
     let input = *children.first().unwrap();
@@ -554,6 +543,14 @@ fn narrow_shared_subplan(
         });
     }
     Some(node)
+}
+
+fn get_filter_predicate(parents: TwoParents, lp_arena: &Arena<IR>) -> Option<&ExprIR> {
+    let filter = get_filter_node(parents, lp_arena)?;
+    let IR::Filter { predicate, .. } = lp_arena.get(filter) else {
+        unreachable!()
+    };
+    Some(predicate)
 }
 
 fn get_filter_node(parents: TwoParents, lp_arena: &Arena<IR>) -> Option<Node> {

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -484,9 +484,13 @@ pub(crate) fn set_cache_states(
 
                     lp_arena.replace(filter_node, new_lp);
                 }
-            } else if let Some(narrowed) =
-                narrow_shared_subplan(&v.children, &v.parents, lp_arena, expr_arena)
-            {
+            } else if let Some(narrowed) = narrow_shared_subplan(
+                &v.children,
+                &v.parents,
+                pushdown_maintain_errors,
+                lp_arena,
+                expr_arena,
+            ) {
                 let start_lp = lp_arena.take(narrowed);
                 let lp = pred_pd.optimize(start_lp, lp_arena, expr_arena)?;
                 lp_arena.replace(narrowed, lp);
@@ -527,6 +531,7 @@ pub(crate) fn set_cache_states(
 fn narrow_shared_subplan(
     children: &[Node],
     parents: &[TwoParents],
+    maintain_errors: bool,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
 ) -> Option<Node> {
@@ -541,7 +546,7 @@ fn narrow_shared_subplan(
         })
         .collect::<Option<Vec<_>>>()?;
 
-    let widened = widen_over_predicates(&predicates, expr_arena);
+    let widened = widen_over_predicates(&predicates, maintain_errors, expr_arena);
     if widened.is_empty() {
         return None;
     }

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -9,6 +9,7 @@ use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unique_id::UniqueId;
 
 use crate::dsl::Expr;
+use crate::plans::aexpr::filter_constraint::widen_over_predicates;
 use crate::plans::deep_copy::deep_copy_ir_delete_cache_id;
 use crate::plans::optimizer::ir_traversal::ir_graph_traversal;
 use crate::plans::visitor::AexprNode;
@@ -483,6 +484,19 @@ pub(crate) fn set_cache_states(
 
                     lp_arena.replace(filter_node, new_lp);
                 }
+            } else if let Some(narrowed) =
+                narrow_shared_subplan(&v.children, &v.parents, lp_arena, expr_arena)
+            {
+                let start_lp = lp_arena.take(narrowed);
+                let lp = pred_pd.optimize(start_lp, lp_arena, expr_arena)?;
+                lp_arena.replace(narrowed, lp);
+                // Every reference now reads the one narrowed subplan.
+                for &cache in &v.cache_nodes {
+                    let IR::Cache { input, .. } = lp_arena.get_mut(cache) else {
+                        unreachable!()
+                    };
+                    *input = narrowed;
+                }
             } else {
                 let child = *v.children.first().unwrap();
                 let child_lp = lp_arena.take(child);
@@ -495,6 +509,53 @@ pub(crate) fn set_cache_states(
         }
     }
     Ok(())
+}
+
+/// Filters the shared subplan by what every reference to it asks for, so the rows
+/// none of them keep are never materialized.
+///
+/// The references carry different predicates, which is why they blocked pushdown in
+/// the first place. What they agree on still narrows the subplan: a conjunction
+/// weak enough to be implied by all of them can be applied once, below the caches,
+/// leaving each reference's own filter in place above.
+///
+/// Returns the new node the caches should read, or `None` when a reference has no
+/// filter above it - it needs every row - or when the filters share no bound.
+///
+/// `children` and `parents` hold the cached subplan and the nodes above it, one
+/// entry per reference.
+fn narrow_shared_subplan(
+    children: &[Node],
+    parents: &[TwoParents],
+    lp_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+) -> Option<Node> {
+    let predicates = parents
+        .iter()
+        .map(|parents| {
+            let filter = get_filter_node(*parents, lp_arena)?;
+            let IR::Filter { predicate, .. } = lp_arena.get(filter) else {
+                unreachable!()
+            };
+            Some(predicate.node())
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let widened = widen_over_predicates(&predicates, expr_arena);
+    if widened.is_empty() {
+        return None;
+    }
+
+    // One filter per comparison: pushdown moves a conjunct only when it stands alone,
+    // and a comparison that cannot be pushed must not hold back the others.
+    let mut node = *children.first().unwrap();
+    for predicate in widened {
+        node = lp_arena.add(IR::Filter {
+            input: node,
+            predicate: ExprIR::from_node(predicate, expr_arena),
+        });
+    }
+    Some(node)
 }
 
 fn get_filter_node(parents: TwoParents, lp_arena: &Arena<IR>) -> Option<Node> {

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -494,7 +494,6 @@ pub(crate) fn set_cache_states(
                 let start_lp = lp_arena.take(narrowed);
                 let lp = pred_pd.optimize(start_lp, lp_arena, expr_arena)?;
                 lp_arena.replace(narrowed, lp);
-                // Every reference now reads the one narrowed subplan.
                 for &cache in &v.cache_nodes {
                     let IR::Cache { input, .. } = lp_arena.get_mut(cache) else {
                         unreachable!()
@@ -515,19 +514,12 @@ pub(crate) fn set_cache_states(
     Ok(())
 }
 
-/// Filters the shared subplan by what every reference to it asks for, so the rows
-/// none of them keep are never materialized.
+/// Filters the shared subplan by a conjunction that every reference's filter
+/// implies, so rows no reference keeps are not materialized. Each reference keeps
+/// its own filter above.
 ///
-/// The references carry different predicates, which is why they blocked pushdown in
-/// the first place. What they agree on still narrows the subplan: a conjunction
-/// weak enough to be implied by all of them can be applied once, below the caches,
-/// leaving each reference's own filter in place above.
-///
-/// Returns the new node the caches should read, or `None` when a reference has no
+/// Returns the node the caches should read, or `None` when a reference has no
 /// filter above it - it needs every row - or when the filters share no bound.
-///
-/// `children` and `parents` hold the cached subplan and the nodes above it, one
-/// entry per reference.
 fn narrow_shared_subplan(
     children: &[Node],
     parents: &[TwoParents],
@@ -551,8 +543,7 @@ fn narrow_shared_subplan(
         return None;
     }
 
-    // One filter per comparison: pushdown moves a conjunct only when it stands alone,
-    // and a comparison that cannot be pushed must not hold back the others.
+    // One filter per comparison: pushdown moves a conjunct only when it stands alone.
     let mut node = *children.first().unwrap();
     for predicate in widened {
         node = lp_arena.add(IR::Filter {

--- a/crates/polars-plan/src/plans/optimizer/filter_constraint.rs
+++ b/crates/polars-plan/src/plans/optimizer/filter_constraint.rs
@@ -22,8 +22,9 @@ impl OptimizationRule for FilterConstraintRule {
         let input = *input;
         let predicate_node = predicate.node();
 
+        let schema = lp_arena.get(input).schema(lp_arena).into_owned();
         let Some(new_predicate_node) =
-            merge_filter_constraints(predicate_node, self.maintain_errors, expr_arena)
+            merge_filter_constraints(predicate_node, &schema, self.maintain_errors, expr_arena)
         else {
             return Ok(None);
         };

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -2031,3 +2031,49 @@ def test_cspe_narrowing_keeps_the_rows_a_reader_still_needs() -> None:
         q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
         check_row_order=False,
     )
+
+
+def test_cspe_no_narrowing_past_a_reader_that_reads_a_whole_column() -> None:
+    # `s.sort()` sees a different column once rows are dropped beneath it, so which
+    # rows this reader keeps is not implied by any bound on `year`.
+    base = (
+        pl.LazyFrame({"year": [2000, 2001, 2002], "s": ["z", "a", "b"], "v": [1, 1, 1]})
+        .group_by("year", maintain_order=True)
+        .agg(pl.col("v").sum().alias("total"), pl.col("s").first())
+    )
+    q = pl.concat(
+        [
+            base.filter((pl.col("year") == 2001) & (pl.col("s").sort() == "b")),
+            base.filter((pl.col("year") == 2002) & (pl.col("s").sort() == "b")),
+        ]
+    )
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'col("year") >=' not in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )
+
+
+def test_cspe_no_narrowing_past_a_fallible_reader(plmonkeypatch: PlMonkeyPatch) -> None:
+    # Dropping rows beneath a filter that can error means it may no longer error.
+    base = (
+        pl.LazyFrame(
+            {"year": [2000, 2001, 2002], "lst": [[1], [1], [1]], "v": [1, 1, 1]}
+        )
+        .group_by("year", maintain_order=True)
+        .agg(pl.col("v").sum().alias("total"), pl.col("lst").first())
+    )
+    q = pl.concat(
+        [
+            base.filter((pl.col("year") == 2001) & (pl.col("lst").list.get(1) > 0)),
+            base.filter((pl.col("year") == 2002) & (pl.col("lst").list.get(1) > 0)),
+        ]
+    )
+    assert 'col("year") >=' in q.explain()
+
+    plmonkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+    assert 'col("year") >=' not in q.explain()

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1940,3 +1940,94 @@ def test_cspe_nondeterministic_still_caches_inputs_28733() -> None:
     # can be cached
     plan = copied.explain()
     assert plan.count("WITH_COLUMNS") == 1, plan
+
+
+def year_totals() -> pl.LazyFrame:
+    """An aggregation worth sharing, keyed by a column its readers filter on."""
+    lf = pl.LazyFrame(
+        {
+            "year": [2000, 2001, None, 2002, 2003] * 3,
+            "v": list(range(15)),
+            "w": list(range(15)),
+        }
+    )
+    return lf.group_by("year").agg(
+        pl.col("v").sum().alias("total"), pl.col("w").max().alias("mw")
+    )
+
+
+def test_cspe_narrows_shared_subplan_to_what_its_readers_ask_for() -> None:
+    # `total` is computed in the subplan so the filters cannot be pushed and the
+    # cache stays. The years they select still bound the subplan from both sides.
+    base = year_totals()
+    q = pl.concat(
+        [
+            base.filter((pl.col("year") == 2001) & (pl.col("total") > 0)),
+            base.filter((pl.col("year") == 2002) & (pl.col("total") > 0)),
+        ]
+    )
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'FILTER (col("year") >= 2001) & (col("year") <= 2002)' in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )
+
+
+def test_cspe_no_narrowing_when_a_reader_takes_every_row() -> None:
+    # One reader has no filter, so nothing may be dropped below the cache.
+    base = year_totals()
+    q = pl.concat([base, base.filter((pl.col("year") == 2001) & (pl.col("total") > 0))])
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'col("year") >=' not in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )
+
+
+def test_cspe_narrowing_keeps_only_what_every_reader_bounds() -> None:
+    # The readers bound different columns, so only the constraint they share is
+    # pushed; `year` and `mw` stay above the cache.
+    base = year_totals()
+    q = pl.concat(
+        [
+            base.filter((pl.col("total") > 0) & (pl.col("year") == 2001)),
+            base.filter((pl.col("total") > 0) & (pl.col("mw") > 1)),
+        ]
+    )
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'col("year") >=' not in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )
+
+
+def test_cspe_narrowing_keeps_the_rows_a_reader_still_needs() -> None:
+    # A reader taking an open range must not be narrowed to another's point.
+    base = year_totals()
+    q = pl.concat(
+        [
+            base.filter((pl.col("year") == 2001) & (pl.col("total") > 0)),
+            base.filter((pl.col("year") >= 2000) & (pl.col("total") > 0)),
+        ]
+    )
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'col("year") <=' not in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -2077,3 +2077,29 @@ def test_cspe_no_narrowing_past_a_fallible_reader(plmonkeypatch: PlMonkeyPatch) 
 
     plmonkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
     assert 'col("year") >=' not in q.explain()
+
+
+def test_cspe_no_narrowing_of_a_column_with_its_own_order() -> None:
+    # An enum compares by its categories, so the string bounds "m" and "z" do not
+    # describe the rows the readers keep.
+    dtype = pl.Enum(["z", "a", "m"])
+    base = (
+        pl.LazyFrame({"key": pl.Series(["z", "a", "m"], dtype=dtype), "v": [1, 2, 3]})
+        .group_by("key", maintain_order=True)
+        .agg(pl.col("v").sum().alias("total"))
+    )
+    q = pl.concat(
+        [
+            base.filter((pl.col("key") == "z") & (pl.col("total") > 0)),
+            base.filter((pl.col("key") == "m") & (pl.col("total") > 0)),
+        ]
+    )
+    plan = q.explain()
+
+    assert plan.count("CACHE[id:") == 2
+    assert 'col("key") >=' not in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -2105,19 +2105,24 @@ def test_cspe_no_narrowing_of_a_column_with_its_own_order() -> None:
     )
 
 
-def test_cspe_narrowing_ignores_a_reader_that_keeps_no_rows() -> None:
+@pytest.mark.parametrize(
+    "dead",
+    [
+        (pl.col("mw") > 10) & (pl.col("mw") < 0),
+        (pl.col("mw") == 1) & (pl.col("mw") != 1),
+        pl.col("mw").is_null() & (pl.col("mw") > 0),
+        pl.col("mw").is_in([1]) & pl.col("mw").is_in([2]),
+    ],
+)
+def test_cspe_narrowing_ignores_a_reader_that_keeps_no_rows(dead: pl.Expr) -> None:
     # The first reader selects nothing, so it asks nothing of the shared subplan
     # and the second one is still narrowed to the rows it wants.
     base = year_totals()
-    q = pl.concat(
-        [
-            base.filter((pl.col("year") > 2003) & (pl.col("year") < 2000)),
-            base.filter((pl.col("year") == 2001) & (pl.col("total") > 0)),
-        ]
-    )
+    q = pl.concat([base.filter(dead), base.filter(pl.col("year") == 2001)])
     plan = q.explain()
 
-    assert 'col("year") == 2001' in plan
+    # Twice: the second reader's own filter, and the copy of it below the cache.
+    assert plan.count('col("year") == 2001') == 2, plan
     assert_frame_equal(
         q.collect(),
         q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -2103,3 +2103,23 @@ def test_cspe_no_narrowing_of_a_column_with_its_own_order() -> None:
         q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
         check_row_order=False,
     )
+
+
+def test_cspe_narrowing_ignores_a_reader_that_keeps_no_rows() -> None:
+    # The first reader selects nothing, so it asks nothing of the shared subplan
+    # and the second one is still narrowed to the rows it wants.
+    base = year_totals()
+    q = pl.concat(
+        [
+            base.filter((pl.col("year") > 2003) & (pl.col("year") < 2000)),
+            base.filter((pl.col("year") == 2001) & (pl.col("total") > 0)),
+        ]
+    )
+    plan = q.explain()
+
+    assert 'col("year") == 2001' in plan
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1802,7 +1802,7 @@ def test_filter_constraint_column_with_its_own_order() -> None:
     lf = pl.LazyFrame({"key": pl.Series(["z", "a", "m"], dtype=dtype), "v": [1, 2, 3]})
 
     q = lf.filter((pl.col("key") == "z") & (pl.col("key") >= "m"))
-    assert q.explain().count("col(\"key\")") == 2
+    assert q.explain().count('col("key")') == 2
     assert q.collect().is_empty()
 
 

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1794,6 +1794,18 @@ def test_filter_constraint_nested_scalar_no_panic() -> None:
     assert_frame_equal(q.collect(), pl.DataFrame({"a": [[1, 2]], "b": [1]}))
 
 
+def test_filter_constraint_column_with_its_own_order() -> None:
+    # An enum compares by its declared categories, so a bound on it does not order
+    # the way the string literals do: under z < a < m, `== "z"` and `>= "m"` cannot
+    # both hold and neither comparison may be dropped.
+    dtype = pl.Enum(["z", "a", "m"])
+    lf = pl.LazyFrame({"key": pl.Series(["z", "a", "m"], dtype=dtype), "v": [1, 2, 3]})
+
+    q = lf.filter((pl.col("key") == "z") & (pl.col("key") >= "m"))
+    assert q.explain().count("col(\"key\")") == 2
+    assert q.collect().is_empty()
+
+
 def test_predicate_pushdown_after_collect_schema_26882() -> None:
     # Resolving schema mid-build caches DSL->IR conversion with schema-only `opt_flags`
     # (eg: no predicate pushdown); subsequent `collect` should NOT skip optimisations


### PR DESCRIPTION
Find the minimal shared conjucts in all the predicates applied above a shared cache node and apply them ANDed.

Before this, the whole subplan would be read and the full predicate would be applied afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)