### PR TITLE
fix: Compare struct `AnyValue`s through their field dtypes

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -1206,18 +1206,24 @@ impl AnyValue<'_> {
         ) -> impl ExactSizeIterator<Item = AnyValue<'a>> {
             v.0.iter().map(|v| v.as_borrowed())
         }
-        fn struct_value_iter(
+        #[cfg(feature = "dtype-struct")]
+        fn struct_value_iter<'a>(
             idx: usize,
-            arr: &StructArray,
-        ) -> impl ExactSizeIterator<Item = AnyValue<'_>> {
+            arr: &'a StructArray,
+            fields: &'a [Field],
+        ) -> impl ExactSizeIterator<Item = AnyValue<'a>> {
             assert!(idx < arr.len());
+            assert_eq!(arr.values().len(), fields.len());
 
-            arr.values().iter().map(move |field_arr| unsafe {
-                // SAFETY: We asserted before that idx is smaller than the array length. Since it
-                // is an invariant of StructArray that all fields have the same length this is fine
-                // to do.
-                field_arr.get_unchecked(idx)
-            })
+            arr.values()
+                .iter()
+                .zip(fields)
+                .map(move |(field_arr, field)| unsafe {
+                    // SAFETY: We asserted before that idx is smaller than the array length. Since
+                    // it is an invariant of StructArray that all fields have the same length this
+                    // is fine to do.
+                    arr_to_any_value(field_arr.as_ref(), idx, &field.dtype)
+                })
         }
 
         fn struct_eq_missing<'a>(
@@ -1327,21 +1333,21 @@ impl AnyValue<'_> {
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (StructOwned(l), Struct(idx, arr, _)) => struct_eq_missing(
+            (StructOwned(l), Struct(idx, arr, fields)) => struct_eq_missing(
                 struct_owned_value_iter(l.as_ref()),
-                struct_value_iter(*idx, arr),
+                struct_value_iter(*idx, arr, fields),
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (Struct(idx, arr, _), StructOwned(r)) => struct_eq_missing(
-                struct_value_iter(*idx, arr),
+            (Struct(idx, arr, fields), StructOwned(r)) => struct_eq_missing(
+                struct_value_iter(*idx, arr, fields),
                 struct_owned_value_iter(r.as_ref()),
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (Struct(l_idx, l_arr, _), Struct(r_idx, r_arr, _)) => struct_eq_missing(
-                struct_value_iter(*l_idx, l_arr),
-                struct_value_iter(*r_idx, r_arr),
+            (Struct(l_idx, l_arr, l_fields), Struct(r_idx, r_arr, r_fields)) => struct_eq_missing(
+                struct_value_iter(*l_idx, l_arr, l_fields),
+                struct_value_iter(*r_idx, r_arr, r_fields),
                 null_equal,
             ),
             #[cfg(feature = "dtype-decimal")]
@@ -1530,172 +1536,6 @@ fn struct_to_avs_static(idx: usize, arr: &StructArray, fields: &[Field]) -> Vec<
             unsafe { arr_to_any_value(arr.as_ref(), idx, &field.dtype) }.into_static()
         })
         .collect()
-}
-
-pub trait GetAnyValue {
-    /// # Safety
-    ///
-    /// Get an value without doing bound checks.
-    unsafe fn get_unchecked(&self, index: usize) -> AnyValue<'_>;
-}
-
-impl GetAnyValue for ArrayRef {
-    // Should only be called with physical types
-    unsafe fn get_unchecked(&self, index: usize) -> AnyValue<'_> {
-        match self.dtype() {
-            ArrowDataType::Int8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i8>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int8(v),
-                }
-            },
-            ArrowDataType::Int16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int16(v),
-                }
-            },
-            ArrowDataType::Int32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int32(v),
-                }
-            },
-            ArrowDataType::Int64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int64(v),
-                }
-            },
-            ArrowDataType::Int128 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i128>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int128(v),
-                }
-            },
-            ArrowDataType::UInt8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u8>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt8(v),
-                }
-            },
-            ArrowDataType::UInt16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt16(v),
-                }
-            },
-            ArrowDataType::UInt32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt32(v),
-                }
-            },
-            ArrowDataType::UInt64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt64(v),
-                }
-            },
-            ArrowDataType::UInt128 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u128>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt128(v),
-                }
-            },
-            ArrowDataType::Float16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<pf16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float16(v),
-                }
-            },
-            ArrowDataType::Float32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<f32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float32(v),
-                }
-            },
-            ArrowDataType::Float64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<f64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float64(v),
-                }
-            },
-            ArrowDataType::Boolean => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Boolean(v),
-                }
-            },
-            ArrowDataType::LargeUtf8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<LargeStringArray>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::String(v),
-                }
-            },
-            _ => unimplemented!(),
-        }
-    }
 }
 
 impl<K: NumericNative> From<K> for AnyValue<'static> {


### PR DESCRIPTION
<details>
<summary>AI-generated description</summary>

`AnyValue::eq_missing` read struct fields straight off the arrow array through
`GetAnyValue::get_unchecked`. That helper only sees the arrow dtype, so it cannot
reconstruct the polars `AnyValue` for anything the two disagree on, and it is
`unimplemented!()` for everything past `LargeUtf8` -- `Utf8View` included, which is
what a `String` field actually is.

`struct_value_iter` now takes the field list the `AnyValue::Struct` variant already
carries and goes through `arr_to_any_value` with each field's declared `DataType`, the
same way the neighbouring `struct_to_avs_static` does. That was `GetAnyValue`'s last
caller, so the trait is removed rather than left as a trap.

xref: @scalar-opt

## AI disclosure

Implemented with Claude Code (Claude Opus 5). The model wrote the patch, ran the test
suites and split the work into this stack; I reviewed and edited every hunk before
submitting. Each commit was verified on its own: `cargo check --workspace
--all-features`, `make clippy` and `clippy-default`, `make py-lint`, the Rust test suite
over the crate list in `test-rust.yml`, `cargo test --all-features -p polars --test it`,
and the default and streaming Python suites.

This is part of an experiment to have more of this kind of work done by Claude.

## Stack

- https://github.com/pola-rs/polars/pull/29185 fix: Compare struct `AnyValue`s through their field dtypes <- this one
- https://github.com/pola-rs/polars/pull/29186 fix: Raise instead of panicking when a dtype cannot be row encoded
- https://github.com/pola-rs/polars/pull/29187 fix: Treat scalar columns as having no chunk layout
- https://github.com/pola-rs/polars/pull/28989 perf: Do not materialize equal `ScalarColumn`s in `Column::append`/`extend`

Merge in order, top to bottom. Each PR is based on the one above it, so its
diff is a single commit. The first three are independent of each other; only
the last needs all of them.
</details>

xref: `@scalar-opt`