### PR TITLE
refactor(rust): Remove pyobject_converter

### DIFF
--- a/crates/polars-core/src/chunked_array/object/registry.rs
+++ b/crates/polars-core/src/chunked_array/object/registry.rs
@@ -21,7 +21,6 @@ use crate::series::{IntoSeries, Series};
 pub type BuilderConstructor =
     Box<dyn Fn(PlSmallStr, usize) -> Box<dyn AnonymousObjectBuilder> + Send + Sync>;
 pub type ObjectConverter = Arc<dyn Fn(AnyValue) -> Box<dyn Any> + Send + Sync>;
-pub type PyObjectConverter = Arc<dyn Fn(AnyValue) -> Box<dyn Any> + Send + Sync>;
 pub type ObjectArrayGetter = Arc<dyn Fn(&dyn Array, usize) -> Option<AnyValue<'_>> + Send + Sync>;
 pub type WithGIL = Arc<dyn Fn(&mut dyn FnMut()) + Send + Sync>;
 
@@ -30,8 +29,6 @@ pub struct ObjectRegistry {
     pub builder_constructor: BuilderConstructor,
     // A function that converts AnyValue to Box<dyn Any> of the object type
     object_converter: Option<ObjectConverter>,
-    // A function that converts AnyValue to Box<dyn Any> of the PyObject type
-    pyobject_converter: Option<PyObjectConverter>,
     pub physical_dtype: ArrowDataType,
     // A function that gets an AnyValue from a Box<dyn Array>.
     array_getter: ObjectArrayGetter,
@@ -127,7 +124,6 @@ impl<T: PolarsObject> AnonymousObjectBuilder for ObjectChunkedBuilder<T> {
 pub fn register_object_builder(
     builder_constructor: BuilderConstructor,
     object_converter: ObjectConverter,
-    pyobject_converter: PyObjectConverter,
     physical_dtype: ArrowDataType,
     array_getter: ObjectArrayGetter,
     with_gil: WithGIL,
@@ -138,7 +134,6 @@ pub fn register_object_builder(
     *reg = Some(ObjectRegistry {
         builder_constructor,
         object_converter: Some(object_converter),
-        pyobject_converter: Some(pyobject_converter),
         physical_dtype,
         array_getter,
         with_gil,
@@ -162,12 +157,6 @@ pub fn get_object_converter() -> ObjectConverter {
     let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
     let reg = reg.as_ref().unwrap();
     reg.object_converter.as_ref().unwrap().clone()
-}
-
-pub fn get_pyobject_converter() -> PyObjectConverter {
-    let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
-    let reg = reg.as_ref().unwrap();
-    reg.pyobject_converter.as_ref().unwrap().clone()
 }
 
 pub fn get_object_array_getter() -> ObjectArrayGetter {

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -198,10 +198,6 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_functio
             });
             Box::new(object) as Box<dyn Any>
         });
-        let pyobject_converter = Arc::new(|av: AnyValue| {
-            let object = Python::attach(|py| Wrap(av).into_py_any(py).unwrap());
-            Box::new(object) as Box<dyn Any>
-        });
         fn object_array_getter(arr: &dyn Array, idx: usize) -> Option<AnyValue<'_>> {
             let arr = arr
                 .as_any()
@@ -289,7 +285,6 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_functio
         registry::register_object_builder(
             object_builder,
             object_converter,
-            pyobject_converter,
             physical_dtype,
             Arc::new(object_array_getter),
             Arc::new(with_gil),


### PR DESCRIPTION
Appears to be completely unused.