### PR TITLE
fix(rust): Error instead of segfault for log() on non-numeric dtypes

### DIFF
--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -695,7 +695,7 @@ pub(super) fn log(columns: &[Column]) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
     assert_eq!(columns.len(), 2);
-    Column::apply_broadcasting_binary_elementwise(&columns[0], &columns[1], Series::log)
+    Column::try_apply_broadcasting_binary_elementwise(&columns[0], &columns[1], Series::log)
 }
 
 #[cfg(feature = "log")]

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -16,8 +16,10 @@ fn exp<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Float64Chunked {
 
 pub trait LogSeries: SeriesSealed {
     /// Compute the logarithm to a given base
-    fn log(&self, base: &Series) -> Series {
+    fn log(&self, base: &Series) -> PolarsResult<Series> {
         let s = self.as_series();
+        polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'log'");
+        polars_ensure!(base.dtype().is_numeric() || base.dtype().is_bool(), InvalidOperation: "expected numerical input for 'log'");
 
         match (s.dtype(), base.dtype()) {
             (dt1, dt2) if dt1 == dt2 && dt1.is_float() => {
@@ -29,7 +31,7 @@ pub trait LogSeries: SeriesSealed {
                     let out: ChunkedArray<$T> = broadcast_binary_elementwise_values(ca, base_ca,
                         |x, base| x.log(base)
                     );
-                    out.into_series()
+                    Ok(out.into_series())
                 })
             },
             (dt1, _) if dt1.is_float() => s.log(&base.cast(dt1).unwrap()),
@@ -119,7 +121,7 @@ pub trait LogSeries: SeriesSealed {
                 };
 
                 let base = &Series::new(PlSmallStr::EMPTY, [base]);
-                (&pk * &pk.log(base))?.sum::<f64>().map(|v| -v)
+                (&pk * &pk.log(base)?)?.sum::<f64>().map(|v| -v)
             },
             _ => s
                 .cast(&DataType::Float64)

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -295,7 +295,9 @@ impl IRFunctionExpr {
                 .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "exp")?
                 .map_to_float_dtype(),
             #[cfg(feature = "log")]
-            Log => mapper.log_dtype(),
+            Log => mapper
+                .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "log")?
+                .log_dtype(),
             Unique(_) => mapper.with_same_dtype(),
             #[cfg(feature = "round_series")]
             Round { .. } | RoundSF { .. } | Truncate { .. } | Floor | Ceil => {

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -275,6 +275,37 @@ def test_exp_log1p_invalid_dtype_29102(s: pl.Series) -> None:
             q.collect()
 
 
+@pytest.mark.parametrize(
+    "s",
+    [
+        pl.Series("a", [{"a": 1, "b": "x"}]),
+        pl.Series("a", ["1", "2", "3"]),
+        pl.Series("a", [date(2020, 1, 1), date(2021, 1, 1)]),
+        pl.Series("a", [[1, 2], [3]]),
+    ],
+)
+def test_log_invalid_dtype_29189(s: pl.Series) -> None:
+    lf = pl.LazyFrame([s])
+    q = lf.select(pl.col("a").log())
+
+    with pytest.raises(InvalidOperationError):
+        q.collect_schema()
+
+    with pytest.raises(InvalidOperationError):
+        q.collect()
+
+
+def test_log_invalid_base_dtype_29189() -> None:
+    lf = pl.LazyFrame({"a": [1.0, 2.0], "b": [{"x": 1}, {"x": 2}]})
+    q = lf.select(pl.col("a").log(pl.col("b")))
+
+    with pytest.raises(InvalidOperationError):
+        q.collect_schema()
+
+    with pytest.raises(InvalidOperationError):
+        q.collect()
+
+
 def test_dot_in_group_by() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
## Summary

```python
pl.Series([{"a": 1}]).log()
```
segfaults via infinite recursion. This is the same defect that `exp()`/`log1p()` had, fixed in #29112 for the literal sibling issue #29102, but `log()` (the two-argument log with a base) wasn't touched by that PR and still has it.

Closes #29189.

## Root cause

`LogSeries::log` (`crates/polars-ops/src/series/ops/log.rs`) has no dtype guard. For an unsupported input dtype it falls into the catch-all arm:
```rust
(_, _) => s.cast(&DataType::Float64).unwrap().log(base),
```
Casting a struct to `Float64` casts each field in place and the result is still a struct (`Struct({'a': Int64})` casts to `Struct({'a': Float64})`, verified directly), not a `Float64` series. So the retry lands on the exact same match arm again, recursing without ever terminating until the stack overflows.

`log()` takes a second `Series` argument (`base`) that `exp()`/`log1p()` don't have, and the identical failure is independently reachable through it, not just through the value being logged:
```rust
(dt1, _) if dt1.is_float() => s.log(&base.cast(dt1).unwrap()),
```
If `base` has an invalid dtype (e.g. a struct column passed as the base), this arm casts `base` the same way and recurses just as unboundedly, even when `s` itself is perfectly valid:
```python
pl.Series([1.0, 2.0]).log(pl.Series([{"x": 1}, {"x": 2}]))  # segfaults too
```
So the fix needs to guard both operands, not just the first, or this second surface is left open.

## Fix

Same pattern #29112 already established for `exp()`/`log1p()`, applied to both of `log()`'s operands:

- `log()` promoted from `-> Series` to `-> PolarsResult<Series>`, with a `polars_ensure!(dtype.is_numeric() || dtype.is_bool(), ...)` guard on `s` and on `base` before the match. `is_numeric() || is_bool()` matches #29112's own precedent (booleans were already accepted, cast to float, before that PR; rejecting them now would be a breaking change).
- `entropy()`'s internal call to `pk.log(base)` updated to propagate the `Result` (its own dtype guard already only allows `is_primitive_numeric()` input and its own `base` is always a genuine `Float64` literal, so this is a mechanical `?`, not a behavior change).
- `crates/polars-expr/src/dispatch/misc.rs::log` switched from `apply_broadcasting_binary_elementwise` to the already-existing `try_apply_broadcasting_binary_elementwise`, which takes a fallible closure.
- `crates/polars-plan/src/plans/aexpr/function_expr/schema.rs`'s `Log` arm gained the same `ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "log")?` guard `Log1p`/`Exp` already have. `ensure_satisfies` iterates every field the function was given, so this one call validates both `s` and `base` and catches the bug during schema resolution (`collect_schema()`), not only at execution.

## Test plan

- [x] Reproduced the exact segfault from the issue against an unpatched build; confirmed it's gone after the fix.
- [x] Reproduced the `base`-argument surface directly (`pl.Series([1.0, 2.0]).log(pl.Series([{"x": 1}, {"x": 2}]))`) against the unpatched build, confirmed it also segfaults, and confirmed the fix closes it too.
- [x] Added `test_log_invalid_dtype_29189` (struct/string/date/list value, mirroring `test_exp_log1p_invalid_dtype_29102`'s cases) and `test_log_invalid_base_dtype_29189` (struct base) to `py-polars/tests/unit/expr/test_exprs.py`, each asserting both `collect_schema()` and `collect()` raise `InvalidOperationError`.
- [x] Ran `test_exprs.py -k log` — 39 passed, including the pre-existing `test_log`/`test_exp_log1p` cases (int/float/bool inputs, scalar and Series base), confirming no regression.
- [x] `make test` — 19250 passed, 244 skipped, 8 xfailed.
- [x] `cargo clippy -p polars-ops -p polars-plan -p polars-expr --all-features --all-targets` — zero warnings from the changed files.
- [x] `cargo fmt --check` on the three touched crates — clean.
- [x] ruff, ruff format, mypy on the test file — clean.