### PR TITLE
refactor(rust): Dispatch through agg_valid_count

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -980,7 +980,7 @@ impl Column {
     ///
     /// Does no bounds checks, groups must be correct.
     #[cfg(feature = "algorithm_group_by")]
-    pub fn agg_valid_count(&self, groups: &GroupsType) -> Self {
+    pub unsafe fn agg_valid_count(&self, groups: &GroupsType) -> Self {
         // @scalar-opt
         unsafe { self.as_materialized_series().agg_valid_count(groups) }.into()
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -36,7 +36,7 @@ impl Series {
                     }
                     Some(count)
                 } else {
-                    Some(self.len() as IdxSize)
+                    Some(idxs.len() as IdxSize)
                 }
             }),
             GroupsType::Slice { groups, .. } => {
@@ -46,7 +46,7 @@ impl Series {
                         let m = BitMask::from_bitmap(v).sliced(first as usize, len as usize);
                         Some(m.set_bits() as IdxSize)
                     } else {
-                        Some(self.len() as IdxSize)
+                        Some(len)
                     }
                 })
             },

--- a/crates/polars-expr/src/expressions/count.rs
+++ b/crates/polars-expr/src/expressions/count.rs
@@ -85,42 +85,9 @@ pub fn evaluate_count_on_ac<'a>(
             AggState::NotAggregated(s) => {
                 let s = s.clone();
                 let groups = ac.groups();
-                let out: IdxCa = if matches!(s.dtype(), &DataType::Null) {
-                    IdxCa::full(s.name().clone(), 0, groups.len())
-                } else {
-                    match groups.as_ref().as_ref() {
-                        GroupsType::Idx(idx) => {
-                            let s = s.rechunk();
-                            // @scalar-opt
-                            // @partition-opt
-                            let array = &s.as_materialized_series().chunks()[0];
-                            let validity = array.validity().unwrap();
-                            idx.iter()
-                                .map(|(_, g)| {
-                                    let mut count = 0 as IdxSize;
-                                    // Count valid values
-                                    g.iter().for_each(|i| unsafe {
-                                        count += validity.get_bit_unchecked(*i as usize) as IdxSize;
-                                    });
-                                    count
-                                })
-                                .collect_ca_trusted_with_dtype(PlSmallStr::EMPTY, IDX_DTYPE)
-                        },
-                        GroupsType::Slice { groups, .. } => {
-                            // Slice and use computed null count
-                            groups
-                                .iter()
-                                .map(|g| {
-                                    let start = g[0];
-                                    let len = g[1];
-                                    len - s.slice(start as i64, len as usize).null_count()
-                                        as IdxSize
-                                })
-                                .collect_ca_trusted_with_dtype(PlSmallStr::EMPTY, IDX_DTYPE)
-                        },
-                    }
-                };
-                out.into_column()
+                // Null-typed data has an all-invalid validity, so it counts as 0.
+                // SAFETY: groups are always in bounds.
+                unsafe { s.agg_valid_count(groups.as_ref().as_ref()) }
             },
         }
     };


### PR DESCRIPTION
Previously `agg_valid_count` was unused.