### PR TITLE
fix: Respect Parquet schema when reading Int96 timestamps

### DIFF
--- a/crates/polars-parquet/src/arrow/read/schema/convert.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/convert.rs
@@ -16,17 +16,14 @@ use crate::parquet::schema::types::{
 /// Converts [`ParquetType`]s to a [`Field`], ignoring parquet fields that do not contain
 /// any physical column.
 pub fn parquet_to_arrow_schema(fields: &[ParquetType]) -> PolarsResult<ArrowSchema> {
-    parquet_to_arrow_schema_with_options(fields, &None)
+    parquet_to_arrow_schema_with_options(fields, &SchemaInferenceOptions::default())
 }
 
 /// Like [`parquet_to_arrow_schema`] but with configurable options which affect the behavior of schema inference
 pub fn parquet_to_arrow_schema_with_options(
     fields: &[ParquetType],
-    options: &Option<SchemaInferenceOptions>,
+    options: &SchemaInferenceOptions,
 ) -> PolarsResult<ArrowSchema> {
-    let default_options = SchemaInferenceOptions::default();
-    let options = options.as_ref().unwrap_or(&default_options);
-
     let fields = fields
         .iter()
         .map(|f| to_field(f, options))
@@ -440,6 +437,8 @@ pub(crate) fn is_nullable(field_info: &FieldInfo) -> bool {
 /// i.e. if it is a column-less group type.
 fn to_field(type_: &ParquetType, options: &SchemaInferenceOptions) -> PolarsResult<Option<Field>> {
     let field_info = type_.get_field_info();
+
+    let options = options.enter_nested(field_info.name.as_str());
 
     let metadata: Option<Arc<Metadata>> = field_info.id.map(|x: i32| {
         Arc::new(
@@ -1652,9 +1651,10 @@ mod tests {
             let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
             let fields = parquet_to_arrow_schema_with_options(
                 parquet_schema.fields(),
-                &Some(SchemaInferenceOptions {
+                &SchemaInferenceOptions {
                     int96_coerce_to_timeunit: tu,
-                }),
+                    ..Default::default()
+                },
             )?;
             let fields = fields.iter_values().cloned().collect::<Vec<_>>();
             assert_eq!(arrow_fields, fields);

--- a/crates/polars-parquet/src/arrow/read/schema/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/mod.rs
@@ -1,4 +1,6 @@
 //! APIs to handle Parquet <-> Arrow schemas.
+use std::sync::Arc;
+
 use arrow::datatypes::{ArrowSchema, TimeUnit};
 
 mod convert;
@@ -8,28 +10,51 @@ pub(crate) use convert::*;
 pub use convert::{parquet_to_arrow_schema, parquet_to_arrow_schema_with_options};
 pub use metadata::{read_custom_key_value_metadata, read_schema_from_metadata};
 use polars_error::{PolarsResult, polars_ensure};
-use polars_utils::aliases::{InitHashMaps, PlHashSet};
+use polars_utils::aliases::{InitHashMaps, PlHashMap, PlHashSet};
+use polars_utils::pl_str::PlSmallStr;
 
 use self::metadata::parse_key_value_metadata;
 pub use crate::parquet::metadata::{FileMetadata, KeyValue, SchemaDescriptor};
 pub use crate::parquet::schema::types::ParquetType;
 
-/// Options when inferring schemas from Parquet
+/// Options when inferring schemas from Parquet.
+///
+/// The structure mirrors the schema's nesting: `nested` holds the options for named child
+/// fields, and the conversion descends through it with [`enter_nested`][Self::enter_nested].
 pub struct SchemaInferenceOptions {
-    /// When inferring schemas from the Parquet INT96 timestamp type, this is the corresponding TimeUnit
-    /// in the inferred Arrow Timestamp type.
+    /// The TimeUnit INT96 timestamps convert to (they store a Julian day plus nanoseconds-of-day
+    /// and carry no unit of their own).
     ///
     /// This defaults to `TimeUnit::Nanosecond`, but INT96 timestamps outside of the range of years 1678-2262,
     /// will overflow when parsed as `Timestamp(TimeUnit::Nanosecond)`. Setting this to a lower resolution
     /// (e.g. TimeUnit::Milliseconds) will result in loss of precision, but support a larger range of dates
     /// without overflowing when parsing the data.
     pub int96_coerce_to_timeunit: TimeUnit,
+
+    /// Options for the named fields inside this one. Values are fully resolved at construction.
+    pub nested: PlHashMap<PlSmallStr, SchemaInferenceOptions>,
+
+    /// The root default options, applying to any field `nested` has no entry for (a field the
+    /// scan's schema says nothing about). `None` means these options are the default themselves.
+    pub default: Option<Arc<SchemaInferenceOptions>>,
+}
+
+impl SchemaInferenceOptions {
+    /// The options for the named field `name` inside the current one.
+    pub fn enter_nested(&self, name: &str) -> &SchemaInferenceOptions {
+        self.nested
+            .get(name)
+            .or(self.default.as_deref())
+            .unwrap_or(self)
+    }
 }
 
 impl Default for SchemaInferenceOptions {
     fn default() -> Self {
         SchemaInferenceOptions {
             int96_coerce_to_timeunit: TimeUnit::Nanosecond,
+            nested: PlHashMap::default(),
+            default: None,
         }
     }
 }
@@ -44,13 +69,13 @@ impl Default for SchemaInferenceOptions {
 /// - Errors if the parquet schema contains duplicate top-level column names, since
 ///   the resulting [`ArrowSchema`] cannot represent them.
 pub fn infer_schema(file_metadata: &FileMetadata) -> PolarsResult<ArrowSchema> {
-    infer_schema_with_options(file_metadata, &None)
+    infer_schema_with_options(file_metadata, &SchemaInferenceOptions::default())
 }
 
 /// Like [`infer_schema`] but with configurable options which affects the behavior of inference
 pub fn infer_schema_with_options(
     file_metadata: &FileMetadata,
-    options: &Option<SchemaInferenceOptions>,
+    options: &SchemaInferenceOptions,
 ) -> PolarsResult<ArrowSchema> {
     let fields = file_metadata.schema().fields();
     let mut seen = PlHashSet::with_capacity(fields.len());

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -212,9 +212,11 @@ impl NativeType for [u32; 3] {
 
     #[inline]
     fn ord(&self, other: &Self) -> std::cmp::Ordering {
-        int96_to_i64_ns(*self)
-            .unwrap_or(i64::MAX)
-            .ord(&int96_to_i64_ns(*other).unwrap_or(i64::MAX))
+        // An INT96 timestamp is a Julian day (index 2) plus nanoseconds-of-day (indices 1, 0),
+        // so comparing those lexicographically is exact chronological order. Converting to
+        // nanoseconds first would clamp out-of-range values to i64::MAX, misordering them.
+        let key = |x: &[u32; 3]| (x[2], x[1], x[0]);
+        key(self).cmp(&key(other))
     }
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::datatypes::{ArrowSchemaRef, TimeUnit as ArrowTimeUnit};
+use arrow::datatypes::ArrowSchemaRef;
 use async_trait::async_trait;
 use polars_async::executor::{self};
 use polars_async::primitives::wait_group::{WaitGroup, WaitToken};
@@ -57,10 +57,6 @@ pub struct ParquetFileReader {
     init_data: Option<InitializedState>,
 }
 
-/// INT96 timestamps carry no time unit, so schema inference has to pick one; the default of
-/// nanoseconds overflows outside of the years 1678..=2262. Build inference options mirroring the
-/// user-provided scan schema (if any) so INT96 columns are inferred - and thus decoded -
-/// directly at the precision the scan asks for.
 fn schema_inference_options(config: &ParquetOptions) -> SchemaInferenceOptions {
     let Some(schema) = config.schema.as_ref() else {
         return SchemaInferenceOptions::default();
@@ -81,8 +77,6 @@ fn int96_options(
     mut dtype: &DataType,
     default: &Arc<SchemaInferenceOptions>,
 ) -> SchemaInferenceOptions {
-    // List/array levels are anonymous in parquet, so a datetime beneath them belongs to the
-    // field holding `dtype`; only structs introduce new named fields.
     while let Some(inner) = dtype.inner_dtype() {
         dtype = inner;
     }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use arrow::datatypes::ArrowSchemaRef;
+use arrow::datatypes::{ArrowSchemaRef, TimeUnit as ArrowTimeUnit};
 use async_trait::async_trait;
 use polars_async::executor::{self};
 use polars_async::primitives::wait_group::{WaitGroup, WaitToken};
-use polars_core::prelude::ArrowSchema;
+use polars_core::prelude::{ArrowSchema, DataType};
 use polars_core::runtime::ASYNC;
 use polars_core::schema::{Schema, SchemaExt, SchemaRef};
 use polars_error::{PolarsResult, polars_err};
@@ -13,9 +13,10 @@ use polars_io::cloud::CloudOptions;
 use polars_io::predicates::ScanIOPredicate;
 use polars_io::prelude::{FileMetadata, ParquetOptions};
 use polars_io::utils::byte_source::{BufferByteSource, DynByteSource, DynByteSourceBuilder};
-use polars_parquet::read::schema::infer_schema_with_options;
+use polars_parquet::read::schema::{SchemaInferenceOptions, infer_schema_with_options};
 use polars_plan::dsl::ScanSource;
 use polars_utils::IdxSize;
+use polars_utils::aliases::PlHashMap;
 use polars_utils::mem::prefetch::get_memory_prefetch_func;
 use polars_utils::slice_enum::Slice;
 
@@ -54,6 +55,55 @@ pub struct ParquetFileReader {
 
     /// Set during initialize()
     init_data: Option<InitializedState>,
+}
+
+/// INT96 timestamps carry no time unit, so schema inference has to pick one; the default of
+/// nanoseconds overflows outside of the years 1678..=2262. Build inference options mirroring the
+/// user-provided scan schema (if any) so INT96 columns are inferred - and thus decoded -
+/// directly at the precision the scan asks for.
+fn schema_inference_options(config: &ParquetOptions) -> SchemaInferenceOptions {
+    let Some(schema) = config.schema.as_ref() else {
+        return SchemaInferenceOptions::default();
+    };
+    let default = Arc::new(SchemaInferenceOptions::default());
+
+    SchemaInferenceOptions {
+        int96_coerce_to_timeunit: default.int96_coerce_to_timeunit,
+        nested: schema
+            .iter()
+            .map(|(name, dtype)| (name.clone(), int96_options(dtype, &default)))
+            .collect(),
+        default: Some(default),
+    }
+}
+
+fn int96_options(
+    mut dtype: &DataType,
+    default: &Arc<SchemaInferenceOptions>,
+) -> SchemaInferenceOptions {
+    // List/array levels are anonymous in parquet, so a datetime beneath them belongs to the
+    // field holding `dtype`; only structs introduce new named fields.
+    while let Some(inner) = dtype.inner_dtype() {
+        dtype = inner;
+    }
+
+    let (int96_coerce_to_timeunit, nested) = match dtype {
+        DataType::Datetime(time_unit, _) => (time_unit.to_arrow(), PlHashMap::default()),
+        DataType::Struct(fields) => (
+            default.int96_coerce_to_timeunit,
+            fields
+                .iter()
+                .map(|f| (f.name().clone(), int96_options(f.dtype(), default)))
+                .collect(),
+        ),
+        _ => (default.int96_coerce_to_timeunit, PlHashMap::default()),
+    };
+
+    SchemaInferenceOptions {
+        int96_coerce_to_timeunit,
+        nested,
+        default: Some(default.clone()),
+    }
 }
 
 struct RowGroupPrefetchSync {
@@ -127,7 +177,10 @@ impl FileReader for ParquetFileReader {
             )?)
         };
 
-        let file_schema = Arc::new(infer_schema_with_options(&file_metadata, &None)?);
+        let file_schema = Arc::new(infer_schema_with_options(
+            &file_metadata,
+            &schema_inference_options(&self.config),
+        )?);
 
         self.init_data = Some(InitializedState {
             file_metadata,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3006,6 +3006,32 @@ def test_nested_deprecated_int96_timestamps_21332() -> None:
     )
 
 
+def test_int96_timestamps_respect_scan_schema_time_unit_29184() -> None:
+    f = io.BytesIO()
+
+    # Spark writes INT96 (a Julian day plus nanoseconds-of-day) and no arrow
+    # schema metadata. Every date fits INT96, but decoding it as nanoseconds
+    # saturates outside 1677..=2262; a scan schema requesting a coarser unit
+    # must decode directly into that unit instead.
+    values = [
+        datetime(9999, 12, 31, 23, 59, 59, 999999),
+        datetime(1000, 1, 1),
+        datetime(2024, 6, 1, 12),
+        None,
+    ]
+    df = pl.DataFrame({"a": values, "b": [{"t": v} for v in values]})
+
+    pq.write_table(
+        df.to_arrow(),
+        f,
+        use_deprecated_int96_timestamps=True,
+        store_schema=False,
+    )
+
+    f.seek(0)
+    assert_frame_equal(pl.scan_parquet(f, schema=df.collect_schema()).collect(), df)
+
+
 def test_final_masked_optional_iteration_21378() -> None:
     # fmt: off
     values = [

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3009,10 +3009,6 @@ def test_nested_deprecated_int96_timestamps_21332() -> None:
 def test_int96_timestamps_respect_scan_schema_time_unit_29184() -> None:
     f = io.BytesIO()
 
-    # Spark writes INT96 (a Julian day plus nanoseconds-of-day) and no arrow
-    # schema metadata. Every date fits INT96, but decoding it as nanoseconds
-    # saturates outside 1677..=2262; a scan schema requesting a coarser unit
-    # must decode directly into that unit instead.
     values = [
         datetime(9999, 12, 31, 23, 59, 59, 999999),
         datetime(1000, 1, 1),


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/29184.