### PR TITLE
refactor: Add expand_paths parameter to toggle path expansion

### DIFF
--- a/crates/polars-lazy/src/scan/anonymous_scan.rs
+++ b/crates/polars-lazy/src/scan/anonymous_scan.rs
@@ -49,6 +49,7 @@ impl LazyFrame {
                 rechunk: false,
                 cache: false,
                 glob: false,
+                expand_paths: true,
                 hidden_file_prefix: None,
                 projection: None,
                 column_mapping: None,

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -405,6 +405,7 @@ impl LazyFileListReader for LazyCsvReader {
                 rechunk,
                 cache: self.cache,
                 glob: self.glob,
+                expand_paths: true,
                 hidden_file_prefix: None,
                 projection: None,
                 column_mapping: None,

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -132,6 +132,7 @@ impl LazyFileListReader for LazyJsonLineReader {
             rechunk: self.rechunk,
             cache: false,
             glob: true,
+            expand_paths: true,
             hidden_file_prefix: None,
             projection: None,
             column_mapping: None,

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -79,6 +79,7 @@ impl LazyFileListReader for LazyParquetReader {
             rechunk: self.args.rechunk,
             cache: self.args.cache,
             glob: self.args.glob,
+            expand_paths: true,
             hidden_file_prefix: None,
             projection: None,
             column_mapping: None,

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -465,6 +465,7 @@ where
         rechunk: _,
         cache: _,
         glob: _,
+        expand_paths: _,
         hidden_file_prefix: _,
         projection: _,
         column_mapping: _,

--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -199,7 +199,7 @@
   "TimeZoneSet": "8c889e8a71f388a0a73911ff847079fbce4c6f083b15e017a339858346631b79",
   "TrigonometricFunction": "9444fa00e47ea519496e1242418c2383101508ddd0dcec6174a6175f4e6d5371",
   "UnicodeForm": "f539f29f54ef29faede48a9842191bf0c0ca7206e4f7d32ef1a54972b4a0cae5",
-  "UnifiedScanArgs": "4fda2c0d3305637d2afad3d5cecd02b16f1c2550628a695a90df402e09554594",
+  "UnifiedScanArgs": "7cfa5ecf58c1a82a5f6c91d839dfef3c8a4d6b4198e97dea8fe7c3ee4d24ec5d",
   "UnifiedSinkArgs": "8364f31ac108b8d618f6bae43adfdcd2d548b3ba47cfa9e53c37fccbd0630f11",
   "UnionArgs": "98eb7fd93d1a3a6d7cb3e5fffd16e3536efb11344e1140a8763b21ee1d16d513",
   "UniqueId": "4cd0b4f653d64777df264faff1f08e1f1318915656c11642d852f60e9bf17f64",

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -569,6 +569,7 @@ pub struct UnifiedScanArgs {
     pub rechunk: bool,
     pub cache: bool,
     pub glob: bool,
+    pub expand_paths: bool,
     /// Files with these prefixes will not be read.
     pub hidden_file_prefix: Option<Arc<[PlSmallStr]>>,
 
@@ -621,6 +622,7 @@ impl Default for UnifiedScanArgs {
             rechunk: false,
             cache: false,
             glob: true,
+            expand_paths: true,
             hidden_file_prefix: None,
             projection: None,
             column_mapping: None,

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::fs::File;
 use std::sync::Arc;

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::fs::File;
 use std::sync::Arc;
@@ -190,11 +191,11 @@ impl ScanSources {
         match self {
             Self::Paths(paths) => {
                 // csv/ndjson/lines decode here; parquet/ipc decode in the hive variant.
-                let paths = decode_file_uri_paths(paths, scan_args.glob);
+                let decoded = decode_file_uri_paths(paths, scan_args.glob);
 
                 Ok(Self::Paths(
                     expand_paths(
-                        paths.as_ref(),
+                        decoded.as_ref(),
                         scan_args.glob,
                         scan_args.hidden_file_prefix.as_deref().unwrap_or_default(),
                         &mut scan_args.cloud_options,
@@ -217,8 +218,9 @@ impl ScanSources {
             Self::Paths(paths) => {
                 // Decode up front so expansion, single-directory detection, and hive parsing
                 // all see the same literal path; decoding later misfires hive detection.
-                let paths = decode_file_uri_paths(paths, scan_args.glob);
-                let paths = paths.as_ref();
+                let decoded = decode_file_uri_paths(paths, scan_args.glob);
+
+                let paths = decoded.as_ref();
 
                 let (expanded_paths, hive_start_idx, bytes_per_source) = expand_paths_hive(
                     paths,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -56,37 +56,43 @@ pub(super) async fn dsl_to_ir(
         let sources_before_expansion = &sources;
 
         let mut bytes_per_source = unified_scan_args.source_sizes.clone();
-        let sources = match &*scan_type {
-            #[cfg(feature = "parquet")]
-            FileScanDsl::Parquet { .. } => {
-                let (sources, bytes) = sources
-                    .expand_paths_with_hive_update(unified_scan_args)
-                    .await?;
-                bytes_per_source = bytes.map(Buffer::from_owner).or(bytes_per_source);
-                sources
-            },
-            #[cfg(feature = "ipc")]
-            FileScanDsl::Ipc { .. } => {
-                sources
-                    .expand_paths_with_hive_update(unified_scan_args)
-                    .await?
-                    .0
-            },
-            #[cfg(feature = "csv")]
-            FileScanDsl::Csv { .. } => sources.expand_paths(unified_scan_args).await?,
-            #[cfg(feature = "json")]
-            FileScanDsl::NDJson { .. } => sources.expand_paths(unified_scan_args).await?,
-            #[cfg(feature = "python")]
-            FileScanDsl::PythonDataset { .. } => {
-                // There are a lot of places that short-circuit if the paths is empty,
-                // so we just give a dummy path here.
-                ScanSources::Paths(Buffer::from_owner([PlRefPath::new("PL_PY_DSET")]))
-            },
-            #[cfg(feature = "scan_lines")]
-            FileScanDsl::Lines { .. } => sources.expand_paths(unified_scan_args).await?,
+        let sources = if !unified_scan_args.expand_paths {
+            sources.clone()
+        } else {
+            match &*scan_type {
+                #[cfg(feature = "parquet")]
+                FileScanDsl::Parquet { .. } => {
+                    let (sources, bytes) = sources
+                        .expand_paths_with_hive_update(unified_scan_args)
+                        .await?;
+                    bytes_per_source = bytes.map(Buffer::from_owner).or(bytes_per_source);
+                    sources
+                },
+                #[cfg(feature = "ipc")]
+                FileScanDsl::Ipc { .. } => {
+                    sources
+                        .expand_paths_with_hive_update(unified_scan_args)
+                        .await?
+                        .0
+                },
+                #[cfg(feature = "csv")]
+                FileScanDsl::Csv { .. } => sources.expand_paths(unified_scan_args).await?,
+                #[cfg(feature = "json")]
+                FileScanDsl::NDJson { .. } => sources.expand_paths(unified_scan_args).await?,
+                #[cfg(feature = "python")]
+                FileScanDsl::PythonDataset { .. } => {
+                    // There are a lot of places that short-circuit if the paths is empty,
+                    // so we just give a dummy path here.
+                    ScanSources::Paths(Buffer::from_owner([PlRefPath::new("PL_PY_DSET")]))
+                },
+                #[cfg(feature = "scan_lines")]
+                FileScanDsl::Lines { .. } => sources.expand_paths(unified_scan_args).await?,
 
-            FileScanDsl::ExpandedPaths { .. } => sources.expand_paths(unified_scan_args).await?,
-            FileScanDsl::Anonymous { .. } => sources.clone(),
+                FileScanDsl::ExpandedPaths { .. } => {
+                    sources.expand_paths(unified_scan_args).await?
+                },
+                FileScanDsl::Anonymous { .. } => sources.clone(),
+            }
         };
 
         if let Some(sizes) = &bytes_per_source {

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -325,6 +325,7 @@ fn expand_python_dataset(
                 rechunk,
                 cache,
                 glob: _,
+                expand_paths: _,
                 hidden_file_prefix: _hidden_file_prefix @ None,
                 projection: _projection @ None,
                 column_mapping,

--- a/crates/polars-python/src/io/scan_options.rs
+++ b/crates/polars-python/src/io/scan_options.rs
@@ -55,6 +55,7 @@ impl PyScanOptions<'_> {
             missing_columns: Wrap<MissingColumnsPolicy>,
             include_file_paths: Option<Wrap<PlSmallStr>>,
             glob: bool,
+            expand_paths: bool,
             hidden_file_prefix: Option<Vec<PyBackedStr>>,
             column_mapping: Option<Wrap<ColumnMapping>>,
             default_values: Option<Wrap<DefaultFieldValues>>,
@@ -81,6 +82,7 @@ impl PyScanOptions<'_> {
             column_mapping,
             default_values,
             glob,
+            expand_paths,
             hidden_file_prefix,
             hive_partitioning,
             hive_schema,
@@ -123,6 +125,7 @@ impl PyScanOptions<'_> {
             rechunk,
             cache,
             glob,
+            expand_paths,
             hidden_file_prefix: hidden_file_prefix
                 .map(|x| x.into_iter().map(|x| (*x).into()).collect()),
             projection: None,

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -104,6 +104,7 @@ def read_parquet(
     memory_map: bool = True,
     include_file_paths: str | None = None,
     missing_columns: Literal["insert", "raise"] = "raise",
+    _expand_paths: bool = True,
 ) -> DataFrame:
     """
     Read into a DataFrame from a parquet file.
@@ -286,6 +287,7 @@ def read_parquet(
         glob=glob,
         include_file_paths=include_file_paths,
         missing_columns=missing_columns,
+        _expand_paths=_expand_paths,
     )
 
     if columns is not None:
@@ -521,6 +523,7 @@ def scan_parquet(
     missing_columns: Literal["insert", "raise"] = "raise",
     extra_columns: Literal["ignore", "raise"] = "raise",
     cast_options: ScanCastOptions | None = None,
+    _expand_paths: bool = True,
     _column_mapping: ColumnMapping | None = None,
     _default_values: DefaultFieldValues | None = None,
     _deletion_files: DeletionFiles | None = None,
@@ -712,6 +715,7 @@ def scan_parquet(
             missing_columns=missing_columns,
             include_file_paths=include_file_paths,
             glob=glob,
+            expand_paths=_expand_paths,
             hidden_file_prefix=(
                 [hidden_file_prefix]
                 if isinstance(hidden_file_prefix, str)

--- a/py-polars/src/polars/io/scan_options/_options.py
+++ b/py-polars/src/polars/io/scan_options/_options.py
@@ -37,6 +37,7 @@ class ScanOptions:
 
     # For path expansion
     glob: bool = True
+    expand_paths: bool = True
     hidden_file_prefix: Sequence[str] | None = None
 
     # Hive

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1733,3 +1733,16 @@ def test_scan_from_object_nonzero_offset(
         assert f_rb.read(100) == padding
 
         assert_frame_equal(read(f_rb), pl.DataFrame({"x": 1}))
+
+
+@pytest.mark.write_disk
+def test_scan_expand_paths_arg(tmp_path: Path) -> None:
+    pl.DataFrame({"a": 1}).write_parquet(tmp_path / "data.parquet")
+
+    q = pl.scan_parquet(tmp_path)
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1}))
+
+    q = pl.scan_parquet(tmp_path, _expand_paths=False)
+
+    with pytest.raises(OSError):
+        q.collect()


### PR DESCRIPTION
Contains code generated by Claude Opus 5

Parameter is private (`_expand_paths`) on read/scan_parquet.

Needed for https://github.com/pola-rs/polars/pull/29004
