### PR TITLE
perf: Parallelize large Float arr.dot calls outside Rayon workers

### DIFF
--- a/crates/polars-expr/src/dispatch/array.rs
+++ b/crates/polars-expr/src/dispatch/array.rs
@@ -1,6 +1,6 @@
 use polars_core::error::{PolarsResult, polars_bail, polars_ensure, polars_err};
 use polars_core::prelude::{Column, DataType, ExplodeOptions, IntoColumn, SortOptions};
-use polars_ops::prelude::array::ArrayNameSpace;
+use polars_ops::prelude::array::{ArrayNameSpace, array_dot_with_parallelism};
 use polars_plan::dsl::{ColumnsUdf, SpecialEq};
 use polars_plan::plans::IRArrayFunction;
 use polars_utils::broadcast::broadcast_len;
@@ -8,7 +8,10 @@ use polars_utils::pl_str::PlSmallStr;
 
 use super::*;
 
-pub fn function_expr_to_udf(func: IRArrayFunction) -> SpecialEq<Arc<dyn ColumnsUdf>> {
+pub fn function_expr_to_udf(
+    func: IRArrayFunction,
+    allow_threading: bool,
+) -> SpecialEq<Arc<dyn ColumnsUdf>> {
     use IRArrayFunction::*;
     match func {
         Concat => map_as_slice!(concat_arr),
@@ -16,7 +19,7 @@ pub fn function_expr_to_udf(func: IRArrayFunction) -> SpecialEq<Arc<dyn ColumnsU
         Min => map!(min),
         Max => map!(max),
         Sum => map!(sum),
-        Dot => map_as_slice!(dot),
+        Dot => map_as_slice!(dot, allow_threading),
         ToList => map!(to_list),
         Std(ddof) => map!(std, ddof),
         Var(ddof) => map!(var, ddof),
@@ -74,12 +77,11 @@ pub(super) fn sum(s: &Column) -> PolarsResult<Column> {
     s.array()?.array_sum().map(Column::from)
 }
 
-pub(super) fn dot(s: &[Column]) -> PolarsResult<Column> {
+pub(super) fn dot(s: &[Column], allow_parallel: bool) -> PolarsResult<Column> {
     let lhs = s[0].as_materialized_series_maintain_scalar();
     let rhs = s[1].as_materialized_series_maintain_scalar();
 
-    lhs.array()?
-        .array_dot(rhs.array()?)?
+    array_dot_with_parallelism(lhs.array()?, rhs.array()?, allow_parallel)?
         .into_column()
         .broadcast_owned_to(broadcast_len(s)?)
 }

--- a/crates/polars-expr/src/dispatch/mod.rs
+++ b/crates/polars-expr/src/dispatch/mod.rs
@@ -139,11 +139,21 @@ mod trigonometry;
 pub use groups_dispatch::drop_items;
 
 pub fn function_expr_to_udf(func: IRFunctionExpr) -> SpecialEq<Arc<dyn ColumnsUdf>> {
+    function_expr_to_udf_with_threading(func, false)
+}
+
+pub(crate) fn function_expr_to_udf_with_threading(
+    func: IRFunctionExpr,
+    allow_threading: bool,
+) -> SpecialEq<Arc<dyn ColumnsUdf>> {
+    #[cfg(not(feature = "dtype-array"))]
+    let _ = allow_threading;
+
     use IRFunctionExpr as F;
     match func {
         // Namespaces
         #[cfg(feature = "dtype-array")]
-        F::ArrayExpr(func) => array::function_expr_to_udf(func),
+        F::ArrayExpr(func) => array::function_expr_to_udf(func, allow_threading),
         F::BinaryExpr(func) => binary::function_expr_to_udf(func),
         #[cfg(feature = "dtype-categorical")]
         F::Categorical(func) => cat::function_expr_to_udf(func),

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -4,7 +4,7 @@ use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::*;
 use recursive::recursive;
 
-use crate::dispatch::{function_expr_to_groups_udf, function_expr_to_udf};
+use crate::dispatch::{function_expr_to_groups_udf, function_expr_to_udf_with_threading};
 use crate::expressions as phys_expr;
 use crate::expressions::*;
 use crate::reduce::GroupedReduction;
@@ -640,7 +640,7 @@ fn create_physical_expr_inner(
 
             Ok(Arc::new(ApplyExpr::new(
                 input,
-                function_expr_to_udf(function.clone()),
+                function_expr_to_udf_with_threading(function.clone(), state.allow_threading),
                 function_expr_to_groups_udf(&function),
                 node_to_expr(expression, expr_arena),
                 options,

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -10,6 +10,8 @@ use rayon::prelude::*;
 
 // Historical crossover center; recalibrate against the all-valid baseline.
 const PARALLEL_MIN_COORDINATE_WORK: usize = 1 << 20;
+// Match the bounded task budget used by `polars_core::utils::par_iter_bounded`.
+const PARALLEL_TASKS_PER_THREAD: usize = 8;
 
 type ArrayDotKernel = fn(&ArrayChunked, &ArrayChunked, usize, bool) -> PolarsResult<Series>;
 
@@ -118,6 +120,7 @@ fn dot_outer_all_valid_parallel<T>(
     lhs_broadcast: bool,
     rhs_broadcast: bool,
     output_len: usize,
+    min_len: usize,
 ) -> Vec<T::Sum>
 where
     T: NativeType + PlNumArithmetic + SumCast,
@@ -128,6 +131,7 @@ where
     RAYON.install(|| {
         (0..output_len)
             .into_par_iter()
+            .with_min_len(min_len)
             .map(|output_idx| {
                 let lhs_idx = if lhs_broadcast { 0 } else { output_idx };
                 let rhs_idx = if rhs_broadcast { 0 } else { output_idx };
@@ -142,16 +146,15 @@ where
 }
 
 #[inline]
-fn should_parallelize(
-    allow_parallel: bool,
-    output_len: usize,
-    width: usize,
-    n_threads: usize,
-) -> bool {
-    allow_parallel
-        && n_threads > 1
-        && output_len > 1
-        && output_len.saturating_mul(width) >= PARALLEL_MIN_COORDINATE_WORK
+fn has_enough_parallel_work(output_len: usize, width: usize) -> bool {
+    output_len > 1 && output_len.saturating_mul(width) >= PARALLEL_MIN_COORDINATE_WORK
+}
+
+#[inline]
+fn parallel_min_len(output_len: usize, n_threads: usize) -> usize {
+    output_len
+        .div_ceil(n_threads.saturating_mul(PARALLEL_TASKS_PER_THREAD).max(1))
+        .max(1)
 }
 
 fn dot_primitive<T, const MAY_PARALLELIZE: bool>(
@@ -209,18 +212,22 @@ where
     // An absent outer bitmap guarantees valid output rows without scanning.
     // Child validity only filters coordinate pairs inside `DotRowReducer`.
     if lhs_array.validity().is_none() && rhs_array.validity().is_none() {
-        let parallel = if MAY_PARALLELIZE {
-            should_parallelize(
-                allow_parallel,
+        let min_parallel_len =
+            if MAY_PARALLELIZE && allow_parallel && has_enough_parallel_work(output_len, width) {
+                let n_threads = RAYON.current_num_threads();
+                (n_threads > 1 && !RAYON.current_thread_has_pending_tasks().unwrap_or(false))
+                    .then(|| parallel_min_len(output_len, n_threads))
+            } else {
+                None
+            };
+        let output = if let Some(min_len) = min_parallel_len {
+            dot_outer_all_valid_parallel(
+                &row_reducer,
+                lhs_broadcast,
+                rhs_broadcast,
                 output_len,
-                width,
-                RAYON.current_num_threads(),
+                min_len,
             )
-        } else {
-            false
-        };
-        let output = if parallel {
-            dot_outer_all_valid_parallel(&row_reducer, lhs_broadcast, rhs_broadcast, output_len)
         } else {
             dot_outer_all_valid(&row_reducer, lhs_broadcast, rhs_broadcast, output_len)
         };
@@ -335,25 +342,51 @@ pub fn array_dot_with_parallelism(
 mod tests {
     use super::*;
 
+    fn assert_parallel_matches_serial_bits<T>(lhs: &[T; 12], rhs: &[T; 12])
+    where
+        T: NativeType + PlNumArithmetic + SumCast,
+        T::Sum: WrappingAdd,
+    {
+        let reducer = DotRowReducer {
+            lhs_slice: lhs,
+            rhs_slice: rhs,
+            lhs_inner_validity: None,
+            rhs_inner_validity: None,
+            width: 3,
+        };
+
+        let output_len = lhs.len() / reducer.width;
+        let serial = dot_outer_all_valid(&reducer, false, false, output_len);
+        let parallel = dot_outer_all_valid_parallel(&reducer, false, false, output_len, 1);
+        assert_eq!(
+            bytemuck::cast_slice::<_, u8>(&serial),
+            bytemuck::cast_slice::<_, u8>(&parallel),
+        );
+    }
+
     #[test]
-    fn test_should_parallelize() {
-        assert!(!should_parallelize(false, usize::MAX, 2, 16));
-        assert!(!should_parallelize(true, 2, usize::MAX, 1));
-        assert!(!should_parallelize(true, 1, usize::MAX, 16));
-        assert!(!should_parallelize(true, usize::MAX, 0, 16));
-        assert!(!should_parallelize(
-            true,
+    fn test_has_enough_parallel_work() {
+        assert!(!has_enough_parallel_work(1, usize::MAX));
+        assert!(!has_enough_parallel_work(usize::MAX, 0));
+        assert!(!has_enough_parallel_work(
             PARALLEL_MIN_COORDINATE_WORK - 1,
             1,
-            16,
         ));
-        assert!(should_parallelize(true, PARALLEL_MIN_COORDINATE_WORK, 1, 2,));
-        assert!(should_parallelize(true, usize::MAX, 2, 2));
+        assert!(has_enough_parallel_work(PARALLEL_MIN_COORDINATE_WORK, 1,));
+        assert!(has_enough_parallel_work(usize::MAX, 2));
+    }
+
+    #[test]
+    fn test_parallel_min_len() {
+        assert_eq!(parallel_min_len(100, 0), 100);
+        assert_eq!(parallel_min_len(1, 16), 1);
+        assert_eq!(parallel_min_len(100, 2), 7);
+        assert_eq!(parallel_min_len(usize::MAX, usize::MAX), 1);
     }
 
     #[test]
     fn test_parallel_outer_matches_serial_bitwise() {
-        let lhs = [
+        let lhs_f32 = [
             1e20_f32,
             1.0,
             -1e20,
@@ -367,29 +400,14 @@ mod tests {
             2.0,
             3.0,
         ];
-        let rhs = [
+        let rhs_f32 = [
             1.0_f32, 1.0, 1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0,
         ];
-        let reducer = DotRowReducer {
-            lhs_slice: &lhs,
-            rhs_slice: &rhs,
-            lhs_inner_validity: None,
-            rhs_inner_validity: None,
-            width: 3,
-        };
+        assert_parallel_matches_serial_bits(&lhs_f32, &rhs_f32);
 
-        let serial = dot_outer_all_valid(&reducer, false, false, 4);
-        let parallel = dot_outer_all_valid_parallel(&reducer, false, false, 4);
-        assert_eq!(
-            serial
-                .iter()
-                .map(|value| value.to_bits())
-                .collect::<Vec<_>>(),
-            parallel
-                .iter()
-                .map(|value| value.to_bits())
-                .collect::<Vec<_>>(),
-        );
+        let lhs_f64 = lhs_f32.map(f64::from);
+        let rhs_f64 = rhs_f32.map(f64::from);
+        assert_parallel_matches_serial_bits(&lhs_f64, &rhs_f64);
     }
 
     #[test]
@@ -408,7 +426,7 @@ mod tests {
 
         assert_eq!(
             dot_outer_all_valid(&reducer, true, false, 2),
-            dot_outer_all_valid_parallel(&reducer, true, false, 2),
+            dot_outer_all_valid_parallel(&reducer, true, false, 2, 1),
         );
 
         let reverse_reducer = DotRowReducer {
@@ -420,7 +438,7 @@ mod tests {
         };
         assert_eq!(
             dot_outer_all_valid(&reverse_reducer, false, true, 2),
-            dot_outer_all_valid_parallel(&reverse_reducer, false, true, 2),
+            dot_outer_all_valid_parallel(&reverse_reducer, false, true, 2, 1),
         );
     }
 
@@ -435,7 +453,7 @@ mod tests {
         };
 
         assert_eq!(
-            dot_outer_all_valid_parallel(&reducer, false, false, 3),
+            dot_outer_all_valid_parallel(&reducer, false, false, 3, 1),
             vec![0.0, 0.0, 0.0],
         );
     }

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -8,7 +8,6 @@ use polars_core::prelude::*;
 use polars_core::runtime::RAYON;
 use rayon::prelude::*;
 
-// Historical crossover center; recalibrate against the all-valid baseline.
 const PARALLEL_MIN_COORDINATE_WORK: usize = 1 << 20;
 // Match the bounded task budget used by `polars_core::utils::par_iter_bounded`.
 const PARALLEL_TASKS_PER_THREAD: usize = 8;
@@ -157,6 +156,23 @@ fn parallel_min_len(output_len: usize, n_threads: usize) -> usize {
         .max(1)
 }
 
+#[inline]
+fn eligible_parallel_min_len(
+    allow_parallel: bool,
+    output_len: usize,
+    width: usize,
+) -> Option<usize> {
+    if !allow_parallel
+        || !has_enough_parallel_work(output_len, width)
+        || RAYON.current_thread_index().is_some()
+    {
+        return None;
+    }
+
+    let n_threads = RAYON.current_num_threads();
+    (n_threads > 1).then(|| parallel_min_len(output_len, n_threads))
+}
+
 fn dot_primitive<T, const MAY_PARALLELIZE: bool>(
     lhs: &ArrayChunked,
     rhs: &ArrayChunked,
@@ -212,14 +228,11 @@ where
     // An absent outer bitmap guarantees valid output rows without scanning.
     // Child validity only filters coordinate pairs inside `DotRowReducer`.
     if lhs_array.validity().is_none() && rhs_array.validity().is_none() {
-        let min_parallel_len =
-            if MAY_PARALLELIZE && allow_parallel && has_enough_parallel_work(output_len, width) {
-                let n_threads = RAYON.current_num_threads();
-                (n_threads > 1 && !RAYON.current_thread_has_pending_tasks().unwrap_or(false))
-                    .then(|| parallel_min_len(output_len, n_threads))
-            } else {
-                None
-            };
+        let min_parallel_len = if MAY_PARALLELIZE {
+            eligible_parallel_min_len(allow_parallel, output_len, width)
+        } else {
+            None
+        };
         let output = if let Some(min_len) = min_parallel_len {
             dot_outer_all_valid_parallel(
                 &row_reducer,
@@ -439,22 +452,6 @@ mod tests {
         assert_eq!(
             dot_outer_all_valid(&reverse_reducer, false, true, 2),
             dot_outer_all_valid_parallel(&reverse_reducer, false, true, 2, 1),
-        );
-    }
-
-    #[test]
-    fn test_parallel_outer_zero_width() {
-        let reducer = DotRowReducer::<f64> {
-            lhs_slice: &[],
-            rhs_slice: &[],
-            lhs_inner_validity: None,
-            rhs_inner_validity: None,
-            width: 0,
-        };
-
-        assert_eq!(
-            dot_outer_all_valid_parallel(&reducer, false, false, 3, 1),
-            vec![0.0, 0.0, 0.0],
         );
     }
 }

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -5,8 +5,13 @@ use num_traits::Zero;
 use polars_compute::arithmetic::pl_num::PlNumArithmetic;
 use polars_compute::sum::WrappingAdd;
 use polars_core::prelude::*;
+use polars_core::runtime::RAYON;
+use rayon::prelude::*;
 
-type ArrayDotKernel = fn(&ArrayChunked, &ArrayChunked, usize) -> PolarsResult<Series>;
+// Historical crossover center; recalibrate against the all-valid baseline.
+const PARALLEL_MIN_COORDINATE_WORK: usize = 1 << 20;
+
+type ArrayDotKernel = fn(&ArrayChunked, &ArrayChunked, usize, bool) -> PolarsResult<Series>;
 
 pub fn is_supported_array_dot_dtype(dtype: &DataType) -> bool {
     array_dot_kernel(dtype).is_some()
@@ -107,10 +112,53 @@ where
     output
 }
 
-fn dot_primitive<T>(
+#[inline(never)]
+fn dot_outer_all_valid_parallel<T>(
+    row_reducer: &DotRowReducer<T>,
+    lhs_broadcast: bool,
+    rhs_broadcast: bool,
+    output_len: usize,
+) -> Vec<T::Sum>
+where
+    T: NativeType + PlNumArithmetic + SumCast,
+    T::Sum: WrappingAdd,
+{
+    let mut output = Vec::with_capacity(output_len);
+
+    RAYON.install(|| {
+        (0..output_len)
+            .into_par_iter()
+            .map(|output_idx| {
+                let lhs_idx = if lhs_broadcast { 0 } else { output_idx };
+                let rhs_idx = if rhs_broadcast { 0 } else { output_idx };
+                // SAFETY: broadcast uses row 0; otherwise validated equal
+                // lengths make `output_idx` valid for both operands.
+                unsafe { row_reducer.dot_row(lhs_idx, rhs_idx) }
+            })
+            .collect_into_vec(&mut output);
+    });
+
+    output
+}
+
+#[inline]
+fn should_parallelize(
+    allow_parallel: bool,
+    output_len: usize,
+    width: usize,
+    n_threads: usize,
+) -> bool {
+    allow_parallel
+        && n_threads > 1
+        && output_len > 1
+        && output_len.saturating_mul(width) >= PARALLEL_MIN_COORDINATE_WORK
+}
+
+fn dot_primitive<T, const MAY_PARALLELIZE: bool>(
     lhs: &ArrayChunked,
     rhs: &ArrayChunked,
     output_len: usize,
+    allow_parallel: bool,
 ) -> PolarsResult<Series>
 where
     T: NativeType + PlNumArithmetic + SumCast,
@@ -161,7 +209,21 @@ where
     // An absent outer bitmap guarantees valid output rows without scanning.
     // Child validity only filters coordinate pairs inside `DotRowReducer`.
     if lhs_array.validity().is_none() && rhs_array.validity().is_none() {
-        let output = dot_outer_all_valid(&row_reducer, lhs_broadcast, rhs_broadcast, output_len);
+        let parallel = if MAY_PARALLELIZE {
+            should_parallelize(
+                allow_parallel,
+                output_len,
+                width,
+                RAYON.current_num_threads(),
+            )
+        } else {
+            false
+        };
+        let output = if parallel {
+            dot_outer_all_valid_parallel(&row_reducer, lhs_broadcast, rhs_broadcast, output_len)
+        } else {
+            dot_outer_all_valid(&row_reducer, lhs_broadcast, rhs_broadcast, output_len)
+        };
         let output = PrimitiveArray::from_data_default(output.into(), None);
         return Series::try_from((lhs.name().clone(), vec![Box::new(output) as ArrayRef]));
     }
@@ -196,26 +258,35 @@ where
 
 fn array_dot_kernel(dtype: &DataType) -> Option<ArrayDotKernel> {
     let kernel = match dtype {
-        DataType::Int8 => dot_primitive::<i8>,
-        DataType::Int16 => dot_primitive::<i16>,
-        DataType::Int32 => dot_primitive::<i32>,
-        DataType::Int64 => dot_primitive::<i64>,
+        DataType::Int8 => dot_primitive::<i8, false>,
+        DataType::Int16 => dot_primitive::<i16, false>,
+        DataType::Int32 => dot_primitive::<i32, false>,
+        DataType::Int64 => dot_primitive::<i64, false>,
         #[cfg(feature = "dtype-i128")]
-        DataType::Int128 => dot_primitive::<i128>,
-        DataType::UInt8 => dot_primitive::<u8>,
-        DataType::UInt16 => dot_primitive::<u16>,
-        DataType::UInt32 => dot_primitive::<u32>,
-        DataType::UInt64 => dot_primitive::<u64>,
+        DataType::Int128 => dot_primitive::<i128, false>,
+        DataType::UInt8 => dot_primitive::<u8, false>,
+        DataType::UInt16 => dot_primitive::<u16, false>,
+        DataType::UInt32 => dot_primitive::<u32, false>,
+        DataType::UInt64 => dot_primitive::<u64, false>,
         #[cfg(feature = "dtype-u128")]
-        DataType::UInt128 => dot_primitive::<u128>,
-        DataType::Float32 => dot_primitive::<f32>,
-        DataType::Float64 => dot_primitive::<f64>,
+        DataType::UInt128 => dot_primitive::<u128, false>,
+        DataType::Float32 => dot_primitive::<f32, true>,
+        DataType::Float64 => dot_primitive::<f64, true>,
         _ => return None,
     };
     Some(kernel)
 }
 
 pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<Series> {
+    array_dot_with_parallelism(lhs, rhs, false)
+}
+
+#[doc(hidden)]
+pub fn array_dot_with_parallelism(
+    lhs: &ArrayChunked,
+    rhs: &ArrayChunked,
+    allow_parallel: bool,
+) -> PolarsResult<Series> {
     let (lhs_inner, lhs_width) = match lhs.dtype() {
         DataType::Array(inner, width) => (inner.as_ref(), *width),
         _ => unreachable!(),
@@ -257,5 +328,115 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
         ));
     }
 
-    kernel(lhs, rhs, output_len)
+    kernel(lhs, rhs, output_len, allow_parallel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_parallelize() {
+        assert!(!should_parallelize(false, usize::MAX, 2, 16));
+        assert!(!should_parallelize(true, 2, usize::MAX, 1));
+        assert!(!should_parallelize(true, 1, usize::MAX, 16));
+        assert!(!should_parallelize(true, usize::MAX, 0, 16));
+        assert!(!should_parallelize(
+            true,
+            PARALLEL_MIN_COORDINATE_WORK - 1,
+            1,
+            16,
+        ));
+        assert!(should_parallelize(true, PARALLEL_MIN_COORDINATE_WORK, 1, 2,));
+        assert!(should_parallelize(true, usize::MAX, 2, 2));
+    }
+
+    #[test]
+    fn test_parallel_outer_matches_serial_bitwise() {
+        let lhs = [
+            1e20_f32,
+            1.0,
+            -1e20,
+            -0.0,
+            1.0,
+            2.0,
+            f32::INFINITY,
+            1.0,
+            2.0,
+            f32::NAN,
+            2.0,
+            3.0,
+        ];
+        let rhs = [
+            1.0_f32, 1.0, 1.0, 1.0, -1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ];
+        let reducer = DotRowReducer {
+            lhs_slice: &lhs,
+            rhs_slice: &rhs,
+            lhs_inner_validity: None,
+            rhs_inner_validity: None,
+            width: 3,
+        };
+
+        let serial = dot_outer_all_valid(&reducer, false, false, 4);
+        let parallel = dot_outer_all_valid_parallel(&reducer, false, false, 4);
+        assert_eq!(
+            serial
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+            parallel
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_parallel_outer_broadcast_and_inner_nulls() {
+        let lhs = [1.0_f64, 2.0, 3.0];
+        let rhs = [4.0_f64, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let lhs_validity: Bitmap = [true, false, true].into_iter().collect();
+        let rhs_validity: Bitmap = [true, true, false, true, false, true].into_iter().collect();
+        let reducer = DotRowReducer {
+            lhs_slice: &lhs,
+            rhs_slice: &rhs,
+            lhs_inner_validity: Some(&lhs_validity),
+            rhs_inner_validity: Some(&rhs_validity),
+            width: 3,
+        };
+
+        assert_eq!(
+            dot_outer_all_valid(&reducer, true, false, 2),
+            dot_outer_all_valid_parallel(&reducer, true, false, 2),
+        );
+
+        let reverse_reducer = DotRowReducer {
+            lhs_slice: &rhs,
+            rhs_slice: &lhs,
+            lhs_inner_validity: Some(&rhs_validity),
+            rhs_inner_validity: Some(&lhs_validity),
+            width: 3,
+        };
+        assert_eq!(
+            dot_outer_all_valid(&reverse_reducer, false, true, 2),
+            dot_outer_all_valid_parallel(&reverse_reducer, false, true, 2),
+        );
+    }
+
+    #[test]
+    fn test_parallel_outer_zero_width() {
+        let reducer = DotRowReducer::<f64> {
+            lhs_slice: &[],
+            rhs_slice: &[],
+            lhs_inner_validity: None,
+            rhs_inner_validity: None,
+            width: 0,
+        };
+
+        assert_eq!(
+            dot_outer_all_valid_parallel(&reducer, false, false, 3),
+            vec![0.0, 0.0, 0.0],
+        );
+    }
 }

--- a/crates/polars-ops/src/chunked_array/array/mod.rs
+++ b/crates/polars-ops/src/chunked_array/array/mod.rs
@@ -9,7 +9,7 @@ mod sum_mean;
 #[cfg(feature = "array_to_struct")]
 mod to_struct;
 
-pub use dot::is_supported_array_dot_dtype;
+pub use dot::{array_dot_with_parallelism, is_supported_array_dot_dtype};
 pub use namespace::ArrayNameSpace;
 use polars_core::prelude::*;
 #[cfg(feature = "array_to_struct")]

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -13,7 +13,6 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import INTEGER_DTYPES
 
 if TYPE_CHECKING:
-    from polars._typing import EngineType
     from tests.conftest import PlMonkeyPatch
 
 
@@ -175,54 +174,6 @@ def test_arr_dot_query_vector_streaming(
         raw_output=True,
     )
     assert "columnar-function" not in physical_plan
-
-
-@pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
-@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
-def test_arr_dot_parallel_execution_contexts(
-    dtype: pl.DataType,
-    engine: EngineType,
-) -> None:
-    width = 128
-    rows = (1 << 20) // width + 1
-    lhs_row = [1.0] * width
-    rhs_row = [2.0] * width
-    df = pl.DataFrame(
-        {
-            "lhs": [lhs_row] * rows,
-            "rhs": [rhs_row] * rows,
-        },
-        schema={
-            "lhs": pl.Array(dtype, width),
-            "rhs": pl.Array(dtype, width),
-        },
-    )
-    query = pl.lit(rhs_row, dtype=pl.Array(dtype, width))
-
-    result = (
-        df.lazy()
-        .select(
-            row_wise=pl.col("lhs").arr.dot("rhs"),
-            reverse=pl.col("rhs").arr.dot("lhs"),
-            scalar_rhs=pl.col("lhs").arr.dot(query),
-            scalar_lhs=query.arr.dot("lhs"),
-        )
-        .collect(engine=engine)
-    )
-    expected_value = float(2 * width)
-    expected = pl.DataFrame(
-        {
-            "row_wise": [expected_value] * rows,
-            "reverse": [expected_value] * rows,
-            "scalar_rhs": [expected_value] * rows,
-            "scalar_lhs": [expected_value] * rows,
-        },
-        schema=dict.fromkeys(result.columns, dtype),
-    )
-
-    assert_frame_equal(result, expected, check_exact=True)
-    if engine == "in-memory":
-        assert all(column.n_chunks() == 1 for column in result.get_columns())
 
 
 def test_arr_dot_query_vector() -> None:

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -13,6 +13,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import INTEGER_DTYPES
 
 if TYPE_CHECKING:
+    from polars._typing import EngineType
     from tests.conftest import PlMonkeyPatch
 
 
@@ -174,6 +175,54 @@ def test_arr_dot_query_vector_streaming(
         raw_output=True,
     )
     assert "columnar-function" not in physical_plan
+
+
+@pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_arr_dot_parallel_execution_contexts(
+    dtype: pl.DataType,
+    engine: EngineType,
+) -> None:
+    width = 128
+    rows = (1 << 20) // width + 1
+    lhs_row = [1.0] * width
+    rhs_row = [2.0] * width
+    df = pl.DataFrame(
+        {
+            "lhs": [lhs_row] * rows,
+            "rhs": [rhs_row] * rows,
+        },
+        schema={
+            "lhs": pl.Array(dtype, width),
+            "rhs": pl.Array(dtype, width),
+        },
+    )
+    query = pl.lit(rhs_row, dtype=pl.Array(dtype, width))
+
+    result = (
+        df.lazy()
+        .select(
+            row_wise=pl.col("lhs").arr.dot("rhs"),
+            reverse=pl.col("rhs").arr.dot("lhs"),
+            scalar_rhs=pl.col("lhs").arr.dot(query),
+            scalar_lhs=query.arr.dot("lhs"),
+        )
+        .collect(engine=engine)
+    )
+    expected_value = float(2 * width)
+    expected = pl.DataFrame(
+        {
+            "row_wise": [expected_value] * rows,
+            "reverse": [expected_value] * rows,
+            "scalar_rhs": [expected_value] * rows,
+            "scalar_lhs": [expected_value] * rows,
+        },
+        schema=dict.fromkeys(result.columns, dtype),
+    )
+
+    assert_frame_equal(result, expected, check_exact=True)
+    if engine == "in-memory":
+        assert all(column.n_chunks() == 1 for column in result.get_columns())
 
 
 def test_arr_dot_query_vector() -> None:


### PR DESCRIPTION
Closes #29211

Parallelizes output rows for large in-memory Float32/Float64 arr.dot calls using output path from #29115. Reuses DotRowReducer, preserving arithmetic order, child-null handling, and scalar broadcasting from #29000. Output stays in row order within one chunk.

Parallel execution requires planner threading permission, absent outer validity bitmaps, multiple output rows and workers, `output rows × Array width >= 2**20`, and entry outside Rayon pool. Other calls keep existing serial paths.

`with_min_len` limits how finely rows are split, using 8 tasks per worker as sizing budget. Budgets 2 and 4 showed no consistent improvement over 8 and repeatedly slowed larger workloads.
 
<details>
<summary>Scheduling alternatives tested</summary>

- Starting parallel row calculations from Polars workers helped 4 separate arr.dot calculations in one select(...), but slowed processing of 8 input chunks already running concurrently. Other workers could be busy even when current worker had no queued tasks.
- Evaluating arr.dot and reading Float column one after another restored dot parallelism. However, doing this with sum of 1,024-element Arrays was 2.3–4.1% slower than evaluating both expressions concurrently. This PR leaves scheduling of surrounding expressions unchanged.
- Int32 experiment regressed roughly 26% under Float scheduling cutoff. Integer parallelism needs separate measurements.

</details>

Evidence in comments.

**Validation limits**

- Performance measurements cover Apple M4 Max only. Current `2**20` cutoff and 8-task-per-worker sizing budget still need x86_64 performance validation.

- M4 measurements support current cutoff across widths 8/128/768. Below-cutoff calls stayed serial, benefit from lowering cutoff was not evaluated.

- Overlapping collections passed correctness and execution-path checks. Throughput under simultaneous queries was not measured.

**AI disclosure**

I used OpenAI Codex for coding incl private harness and benchmark.