### PR TITLE
fix: Include the library path in the plugin dlopen error message

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
@@ -1,9 +1,11 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 use std::ffi::CStr;
+use std::path::PathBuf;
 use std::sync::{LazyLock, RwLock};
 
 use arrow::ffi::{ArrowSchema, import_field_from_c};
 use libloading::Library;
+use polars_utils::io::PathIoError;
 #[cfg(feature = "python")]
 use pyo3::{Python, types::PyAnyMethods};
 
@@ -36,7 +38,13 @@ fn get_lib(lib: &str) -> PolarsResult<Arc<PluginAndVersion>> {
 
     let library = unsafe {
         Library::new(&load_path).map_err(|e| {
-            PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
+            // Format through `PathIoError` so long paths are truncated consistently with
+            // other IO errors, and the full path is only shown with `POLARS_VERBOSE=1`.
+            let err = PathIoError {
+                path: PathBuf::from(&load_path),
+                source: std::io::Error::other(e),
+            };
+            PolarsError::ComputeError(format!("error loading dynamic library: {err}").into())
         })?
     };
     let version_function: libloading::Symbol<unsafe extern "C" fn() -> u32> = unsafe {

--- a/py-polars/tests/unit/meta/test_plugins.py
+++ b/py-polars/tests/unit/meta/test_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -18,7 +19,11 @@ from tests.conftest import PlMonkeyPatch
 
 
 @pytest.mark.write_disk
-def test_register_plugin_function_invalid_plugin_path(tmp_path: Path) -> None:
+def test_register_plugin_function_invalid_plugin_path(
+    plmonkeypatch: PlMonkeyPatch, tmp_path: Path
+) -> None:
+    # The full path is shown in verbose mode; tmp_path may be long enough to truncate.
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
     tmp_path.mkdir(exist_ok=True)
     plugin_path = tmp_path / "lib.so"
     plugin_path.touch()
@@ -27,8 +32,38 @@ def test_register_plugin_function_invalid_plugin_path(tmp_path: Path) -> None:
         plugin_path=plugin_path, function_name="hello", args=5
     )
 
-    with pytest.raises(ComputeError, match="error loading dynamic library"):
+    with pytest.raises(
+        ComputeError,
+        match=f"error loading dynamic library: .*: {re.escape(str(plugin_path))}$",
+    ):
         pl.select(expr)
+
+
+@pytest.mark.write_disk
+def test_register_plugin_function_invalid_plugin_long_path(
+    plmonkeypatch: PlMonkeyPatch, tmp_path: Path
+) -> None:
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+    plugin_dir = tmp_path / ("a" * 100)
+    plugin_dir.mkdir()
+    plugin_path = plugin_dir / "lib.so"
+    plugin_path.touch()
+
+    expr = register_plugin_function(
+        plugin_path=plugin_path, function_name="hello", args=5
+    )
+
+    # Long paths are truncated from the front, keeping the tail and a hint.
+    # Match either path separator, as Windows joins paths with a backslash.
+    with pytest.raises(
+        ComputeError,
+        match=(
+            r"error loading dynamic library: .*: \.\.\.a+[\\/]lib\.so "
+            r"\(set POLARS_VERBOSE=1 to see full path\)"
+        ),
+    ) as exc_info:
+        pl.select(expr)
+    assert str(plugin_path) not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a plugin's dynamic library fails to load, the ComputeError only reported the underlying dlopen error (e.g. "dlopen failed") without saying which dynamic library file Polars tried to open.

This PR changes this to include the resolved load path so users can see whether the plugin is missing or resolved to the wrong location.

The path is formatted through PathIoError so long paths are truncated the same way as other IO errors, with the full path shown when POLARS_VERBOSE=1 is set.

Co-authored with Claude Fable 5.1
