### PR TITLE
ci: Remove auto-streaming jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -137,14 +137,7 @@ jobs:
 
       - name: Run non-benchmark tests
         working-directory: py-polars
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
-        run: pytest -m 'not may_fail_auto_streaming and not benchmark and not debug' -n auto
+        run: pytest -m 'not benchmark and not debug' -n auto
         env:
           POLARS_TIMEOUT_MS: 60000
 
-      - name: Run non-benchmark tests on new streaming engine
-        working-directory: py-polars
-        env:
-          POLARS_AUTO_STREAMING: 1
-          POLARS_TIMEOUT_MS: 60000
-        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not debug and not ci_only"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -157,11 +157,10 @@ jobs:
         working-directory: py-polars
         env:
           POLARS_TIMEOUT_MS: 60000
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
         run: >
           pytest
           -n auto
-          -m "not may_fail_auto_streaming and not release and not benchmark and not docs"
+          -m "not release and not benchmark and not docs"
           -k 'not test_polars_import'
           --cov --cov-report xml:main.xml --cov-fail-under=0
 
@@ -177,28 +176,15 @@ jobs:
           -k 'not test_polars_import'
           --cov --cov-report xml:in-memory.xml --cov-fail-under=0
 
-      - name: Run Python tests - streaming
+      - name: Run Python tests - morsel size 4
         working-directory: py-polars
         env:
-          POLARS_AUTO_STREAMING: 1
-          POLARS_TIMEOUT_MS: 60000
-        run: >
-          pytest
-          -n auto
-          -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not benchmark and not docs"
-          -k 'not test_polars_import'
-          --cov --cov-report xml:auto-streaming.xml --cov-fail-under=0
-
-      - name: Run Python tests - streaming with morsel size 4
-        working-directory: py-polars
-        env:
-          POLARS_AUTO_STREAMING: 1
           POLARS_IDEAL_MORSEL_SIZE: 4
           POLARS_TIMEOUT_MS: 60000
         run: >
           pytest
           -n auto
-          -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not benchmark and not docs"
+          -m "not slow and not write_disk and not release and not benchmark and not docs"
           -k 'not test_polars_import'
           --cov --cov-report xml:small-morsel.xml --cov-fail-under=0
 
@@ -207,11 +193,10 @@ jobs:
         env:
           POLARS_FORCE_ASYNC: 1
           POLARS_TIMEOUT_MS: 60000
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
         run: >
           pytest tests/unit/io/
           -n auto
-          -m "not may_fail_auto_streaming and not release and not benchmark and not docs"
+          -m "not release and not benchmark and not docs"
           --cov --cov-report xml:async.xml --cov-fail-under=0
 
       - name: Report Rust coverage
@@ -225,7 +210,6 @@ jobs:
             coverage-python.lcov
             py-polars/main.xml
             py-polars/in-memory.xml
-            py-polars/auto-streaming.xml
             py-polars/small-morsel.xml
             py-polars/async.xml
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -54,23 +54,11 @@ jobs:
             variant: null
           - os: windows-latest
             python-version: '3.14'
-            variant: auto_new_streaming
-            ideal_morsel_size: 100000
-          - os: windows-latest
-            python-version: '3.14'
             variant: engine_affinity_in_memory
             ideal_morsel_size: 100000
           - os: ubuntu-latest
             python-version: '3.14'
             variant: null
-            ideal_morsel_size: 4
-          - os: ubuntu-latest
-            python-version: '3.14'
-            variant: auto_new_streaming
-            ideal_morsel_size: 100000
-          - os: ubuntu-latest
-            python-version: '3.14'
-            variant: auto_new_streaming
             ideal_morsel_size: 4
           - os: ubuntu-latest
             python-version: '3.14'
@@ -151,8 +139,7 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.python-version != '3.14t' && !matrix.variant
         env:
           POLARS_TIMEOUT_MS: 60000
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
-        run: pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS"
+        run: pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS"
 
       - name: Run Python tests - POLARS_ENGINE_AFFINITY=in-memory
         if: github.event_name == 'pull_request' && matrix.python-version != '3.14t' && matrix.variant == 'engine_affinity_in_memory'
@@ -161,31 +148,22 @@ jobs:
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS"
 
-      - name: Run tests with new streaming engine
-        if: github.event_name == 'pull_request' && matrix.python-version != '3.14t' && matrix.variant == 'auto_new_streaming'
-        env:
-          POLARS_AUTO_STREAMING: 1
-          POLARS_TIMEOUT_MS: 60000
-        run: pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS"
-
       - name: Run tests async reader tests
         if: github.event_name == 'pull_request' && matrix.os != 'windows-latest' && matrix.python-version != '3.14t' && !matrix.variant
         env:
           POLARS_FORCE_ASYNC: 1
           POLARS_TIMEOUT_MS: 60000
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
-        run: pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/
+        run: pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/
 
       - name: Run tests multiscan force empty capabilities
         if: github.event_name == 'pull_request' && matrix.python-version != '3.14t' && !matrix.variant
         env:
           POLARS_FORCE_EMPTY_READER_CAPABILITIES: 1
           POLARS_TIMEOUT_MS: 60000
-        # TODO: Fix and re-enable may_fail_auto_streaming tests
         run: |
-          pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_multiscan.py
-          pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_scan_row_deletion.py
-          pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_iceberg.py
+          pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_multiscan.py
+          pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_scan_row_deletion.py
+          pytest -n auto -m "not release and not benchmark and not docs$EXTRA_PYTEST_MARKERS" tests/unit/io/test_iceberg.py
 
       - name: Check import without optional dependencies
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.14' || matrix.python-version == '3.14t')

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -80,9 +80,9 @@ pre-commit: fmt lint clippy  ## Run all code formatting, lint, and clippy qualit
 test: .venv build  ## Run fast unittests
 	POLARS_TIMEOUT_MS=60000 $(VENV_BIN)/pytest -n auto $(PYTEST_ARGS)
 
-.PHONY: test-streaming
-test-streaming: .venv build  ## Run fast unittests with the streaming engine
-	POLARS_TIMEOUT_MS=60000 POLARS_AUTO_STREAMING=1 $(VENV_BIN)/pytest -n auto -m "not may_fail_auto_streaming and not docs and not benchmark and not ci_only" $(PYTEST_ARGS)
+.PHONY: test-in-memory
+test-in-memory: .venv build  ## Run fast unittests with the in-memory engine
+	POLARS_TIMEOUT_MS=60000 POLARS_ENGINE_AFFINITY=in-memory $(VENV_BIN)/pytest -n auto $(PYTEST_ARGS)
 
 .PHONY: test-all
 test-all: .venv build  ## Run all tests

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -297,7 +297,6 @@ markers = [
   "release: Tests that should be run on a Polars release build.",
   "slow: Tests with a longer than average runtime.",
   "write_disk: Tests that write to disk",
-  "may_fail_auto_streaming: Test that may fail when automatically using the streaming engine for all lazy queries.",
   "may_fail_cloud: Test that may fail when automatically using the cloud distributed engine for all lazy queries.",
   "may_fail_strict: Test that may fail strict mode.",
 ]

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -6,8 +6,6 @@ import polars as pl
 import polars.selectors as cs
 
 
-# TODO: this is slow in streaming
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.slow
 def test_with_columns_quadratic_19503() -> None:
     num_columns = 10_000

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2669,7 +2669,6 @@ def test_selection_regex_and_multicol() -> None:
 
 
 @pytest.mark.parametrize("subset", ["a", cs.starts_with("x", "a")])
-@pytest.mark.may_fail_auto_streaming  # Flaky in CI, see https://github.com/pola-rs/polars/issues/20943
 @pytest.mark.may_fail_cloud
 def test_unique_on_sorted(subset: Any) -> None:
     df = pl.DataFrame(data={"a": [1, 1, 3], "b": [1, 2, 3]})

--- a/py-polars/tests/unit/dataframe/test_shape.py
+++ b/py-polars/tests/unit/dataframe/test_shape.py
@@ -3,8 +3,6 @@ import pytest
 import polars as pl
 
 
-# TODO: remove this skip when streaming raises
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_raise_invalid_shape_19108() -> None:
     df = pl.DataFrame({"foo": [1, 2], "bar": [3, 4]})

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -458,7 +458,6 @@ def test_power_by_expression() -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: chunking
-@pytest.mark.may_fail_auto_streaming
 def test_expression_appends() -> None:
     df = pl.DataFrame({"a": [1, 1, 2]})
 

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
@@ -176,7 +176,6 @@ def test_concat_arr_zero_fields() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_concat_arr_scalar() -> None:
     lit = pl.lit([b"A"], dtype=pl.Array(pl.Binary, 1))

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -156,7 +156,6 @@ def test_df_to_numpy_zero_copy_path() -> None:
 
 
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming
 def test_df_to_numpy_zero_copy_path_temporal() -> None:
     values = [datetime(1970 + i, 1, 1) for i in range(12)]
     s = pl.Series(values)

--- a/py-polars/tests/unit/interop/test_from_dataframe.py
+++ b/py-polars/tests/unit/interop/test_from_dataframe.py
@@ -119,7 +119,6 @@ def test_from_dataframe_chunked() -> None:
     assert result.n_chunks() == 2
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: chunking
 def test_from_dataframe_chunked_string() -> None:
     df = pl.Series("a", ["a", None, "bc", "d", None, "efg"]).to_frame()

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2052,7 +2052,6 @@ def test_csv_ragged_lines(chunk_override: None) -> None:
             pl.read_csv(io.StringIO(s), has_header=True, truncate_ragged_lines=False)
 
 
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_provide_schema(chunk_override: None) -> None:
     # can be used to overload schema with ragged csv files
     assert pl.read_csv(

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -56,7 +56,6 @@ def test_defer_validate_true() -> None:
 
 
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
 def test_defer_validate_false() -> None:
     lf = pl.defer(
         lambda: pl.DataFrame({"a": np.ones(3)}),

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1326,9 +1326,6 @@ def test_parquet_nested_struct_17933() -> None:
     test_round_trip(df)
 
 
-# This is fixed with POLARS_FORCE_MULTISCAN=1. Without it we have
-# first_metadata.unwrap() on None.
-@pytest.mark.may_fail_auto_streaming
 def test_parquet_pyarrow_map() -> None:
     xs = [
         [

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -896,7 +896,6 @@ def test_cse_chunks_18124() -> None:
     ).collect().shape == (4, 4)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_eager_cse_during_struct_expansion_18411() -> None:
     df = pl.DataFrame({"foo": [0, 0, 0, 1, 1]})
     vc = pl.col("foo").value_counts()
@@ -925,7 +924,6 @@ def test_cse_as_struct_19253() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.skip('Fix this test after setting default engine to "streaming"')
 def test_cse_as_struct_value_counts_20927() -> None:
     q = pl.LazyFrame({"x": [i for i in range(1, 6) for _ in range(i)]}).select(

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1221,7 +1221,6 @@ def test_lazy_cache_same_key() -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: inspects logs
-@pytest.mark.may_fail_auto_streaming
 def test_lazy_cache_hit(plmonkeypatch: PlMonkeyPatch, capfd: Any) -> None:
     plmonkeypatch.setenv("POLARS_VERBOSE", "1")
 

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1244,7 +1244,6 @@ def test_predicate_pushdown_auto_disable_strict() -> None:
     assert plan.index("FILTER") > plan.index("MARKER")
 
 
-@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
 def test_predicate_pushdown_map_elements_io_plugin_22860() -> None:
     def generator(
         with_columns: list[str] | None,

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -161,7 +161,6 @@ def test_engine_monitoring_requires_polars_cloud(
         StreamingEngine(monitoring=True)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_in_memory_engine_monitoring() -> None:
     module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):
@@ -306,7 +305,6 @@ def test_no_monitoring_no_observer() -> None:
     module.QueryCloudObserver.assert_not_called()
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_in_memory_engine_planned_without_physical() -> None:
     """The in-memory engine is observed with an IR-only planned query.
 

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1436,7 +1436,6 @@ def test_grouped_minmax_after_reverse_on_sorted_column_26141(
     assert_frame_equal(out, expected_df)
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.parametrize("agg_by", [pl.Expr.min_by, pl.Expr.max_by])
 def test_min_max_by_series_length_mismatch_26049(
     agg_by: Callable[[pl.Expr, pl.Expr], pl.Expr],

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -43,7 +43,6 @@ def test_map_no_dtype_set_8531() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_error_on_reducing_map() -> None:
     df = pl.DataFrame(
         {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -225,7 +225,6 @@ def test_map_groups_multiple_all_literal(
     assert_frame_equal(out, expected, check_row_order=maintain_order)
 
 
-@pytest.mark.may_fail_auto_streaming  # reason: alternate error message
 def test_map_groups_multiple_all_literal_elementwise_raises() -> None:
     df = pl.DataFrame({"g": [10, 10, 20], "a": [1, 2, 3], "b": [2, 3, 4]})
     q = (

--- a/py-polars/tests/unit/operations/test_ewm.py
+++ b/py-polars/tests/unit/operations/test_ewm.py
@@ -246,7 +246,6 @@ def test_ewm_param_validation() -> None:
 
 
 # https://github.com/pola-rs/polars/issues/4951
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: chunking
 def test_ewm_with_multiple_chunks() -> None:
     df0 = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3229,7 +3229,6 @@ def test_group_by_f16_agg_28353(agg: str, args: list[float]) -> None:
     assert_frame_equal(out16, out64, check_row_order=False, rel_tol=1e-3, abs_tol=1e-4)
 
 
-@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
 @pytest.mark.parametrize("agg", ["any", "all"])
 @pytest.mark.parametrize("ignore_nulls", [True, False])
 @pytest.mark.parametrize("null_frac", [0.0, 0.3])
@@ -3255,7 +3254,6 @@ def test_group_by_bool_agg_any_all_single_chunk_28684(
     assert_series_equal(out["b"], expected, check_names=False)
 
 
-@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
 @pytest.mark.parametrize("agg", ["min", "max"])
 @pytest.mark.parametrize("set_sorted", [False, True])
 @pytest.mark.parametrize("null_frac", [0.0, 0.3])
@@ -3281,7 +3279,6 @@ def test_group_by_bool_agg_min_max_single_chunk_28684(
     assert_series_equal(out["b"], expected, check_names=False)
 
 
-@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
 def test_group_by_agg_primitive_opt_single_chunk_28684() -> None:
     # must be large enough to trigger chunk fragmentation
     n = 20_000

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -339,7 +339,6 @@ def test_rolling_kernels_group_by_dynamic_7548() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming  # Inconsistently fails in CI
 def test_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -80,7 +80,6 @@ def test_is_first_last_distinct_list(data: list[list[Any] | None]) -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_is_first_last_distinct_list_inner_nested() -> None:
     df = pl.DataFrame({"a": [[[1, 2]], [[1, 2]]]})
     err_msg = "only allowed if the inner type is not nested"

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -355,7 +355,6 @@ def test_sorted_flag() -> None:
     pl.Series([{"a": 1}], dtype=pl.Object).set_sorted(descending=True)
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_sorted_flag_after_joins() -> None:
     np.random.seed(1)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1186,7 +1186,6 @@ def test_asof_join_nearest_by_date() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_asof_join_string() -> None:
     # These set_sorted() calls are invalid, so the code is technically incorrect.
     # However, this code used to work in the past and we'd like to know when it

--- a/py-polars/tests/unit/operations/test_scalar.py
+++ b/py-polars/tests/unit/operations/test_scalar.py
@@ -6,7 +6,6 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_invalid_broadcast() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1291,7 +1291,6 @@ def test_sort_by_empty_list_eval_25433() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_sort_already_sorted_no_rechunk_25733() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     df2 = pl.DataFrame({"a": [3, 4], "b": [5, 6]})


### PR DESCRIPTION
This PR removes the auto-streaming config from the CI

:robot: This PR was generated using Opus 5.1, and verified by hand by me.