### PR TITLE
perf: Avoid gather for >= 75% cold keys in streaming group-by

### DIFF
--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -284,6 +284,39 @@ impl HashKeys {
         }
     }
 
+    /// Same as gen_idxs_per_partition, but only at the given subset indices.
+    ///
+    /// # Safety
+    /// The subset indices must be in-bounds.
+    pub unsafe fn gen_idxs_per_partition_subset(
+        &self,
+        subset: &[IdxSize],
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+        sketches: &mut [CardinalitySketch],
+        partition_nulls: bool,
+    ) {
+        unsafe {
+            if sketches.is_empty() {
+                self.gen_idxs_per_partition_subset_impl::<false>(
+                    subset,
+                    partitioner,
+                    partition_idxs,
+                    sketches,
+                    partition_nulls | self.null_is_valid(),
+                );
+            } else {
+                self.gen_idxs_per_partition_subset_impl::<true>(
+                    subset,
+                    partitioner,
+                    partition_idxs,
+                    sketches,
+                    partition_nulls | self.null_is_valid(),
+                );
+            }
+        }
+    }
+
     fn gen_idxs_per_partition_impl<const BUILD_SKETCHES: bool>(
         &self,
         partitioner: &HashPartitioner,
@@ -311,6 +344,36 @@ impl HashKeys {
                 }
             }
         });
+    }
+
+    /// # Safety
+    /// The subset indices must be in-bounds.
+    unsafe fn gen_idxs_per_partition_subset_impl<const BUILD_SKETCHES: bool>(
+        &self,
+        subset: &[IdxSize],
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+        sketches: &mut [CardinalitySketch],
+        partition_nulls: bool,
+    ) {
+        assert!(partition_idxs.len() == partitioner.num_partitions());
+        assert!(!BUILD_SKETCHES || sketches.len() == partitioner.num_partitions());
+
+        let null_p = partitioner.null_partition();
+        unsafe {
+            self.for_each_hash_subset(subset, |idx, opt_h| {
+                if let Some(h) = opt_h {
+                    // SAFETY: we assured the number of partitions matches.
+                    let p = partitioner.hash_to_partition(h);
+                    partition_idxs.get_unchecked_mut(p).push(idx);
+                    if BUILD_SKETCHES {
+                        sketches.get_unchecked_mut(p).insert(h);
+                    }
+                } else if partition_nulls {
+                    partition_idxs.get_unchecked_mut(null_p).push(idx);
+                }
+            });
+        }
     }
 
     pub fn sketch_cardinality(&self, sketch: &mut CardinalitySketch) {

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -215,11 +215,26 @@ impl GroupBySinkState {
                     }
 
                     // Store cold keys.
-                    // TODO: don't always gather, if majority cold simply store all and remember offsets into it.
                     if !cold_idxs.is_empty() {
-                        unsafe {
-                            let cold_keys = hash_keys.gather_unchecked(&cold_idxs);
-                            let cold_df = df.take_slice_unchecked_impl(&cold_idxs, false);
+                        let mut cold_keys = hash_keys;
+                        let mut cold_df = df;
+
+                        // 75% or more cold, don't gather.
+                        if cold_idxs.len() as u64 >= cold_df.height() as u64 * 3 / 4 {
+                            unsafe {
+                                cold_keys.gen_idxs_per_partition_subset(
+                                    &cold_idxs,
+                                    &partitioner,
+                                    &mut local.morsel_idxs_values_per_p,
+                                    &mut local.sketch_per_p,
+                                    true,
+                                );
+                            }
+                        } else {
+                            unsafe {
+                                cold_keys = cold_keys.gather_unchecked(&cold_idxs);
+                                cold_df = cold_df.take_slice_unchecked_impl(&cold_idxs, false);
+                            }
 
                             cold_keys.gen_idxs_per_partition(
                                 &partitioner,
@@ -227,12 +242,13 @@ impl GroupBySinkState {
                                 &mut local.sketch_per_p,
                                 true,
                             );
-                            local
-                                .morsel_idxs_offsets_per_p
-                                .extend(local.morsel_idxs_values_per_p.iter().map(|vp| vp.len()));
-                            let sf = SpillFrame::new(cold_df, spill_ctx).await;
-                            local.cold_morsels.push((input_idx, seq, cold_keys, sf));
                         }
+
+                        local
+                            .morsel_idxs_offsets_per_p
+                            .extend(local.morsel_idxs_values_per_p.iter().map(|vp| vp.len()));
+                        let sf = SpillFrame::new(cold_df, spill_ctx).await;
+                        local.cold_morsels.push((input_idx, seq, cold_keys, sf));
                     }
 
                     // If we have too many evicted rows, flush them.


### PR DESCRIPTION
If a morsel has >= 75% cold keys the overhead of gathering into a contiguous dataframe to avoid storing the <= 25% hot keys until later aggregation is not worth it. This was especially silly if you had 100% cold keys 😓 