### PR TITLE
feat: Fuse filters in (inner) join operation

### DIFF
--- a/crates/polars-descriptions/src/ir.rs
+++ b/crates/polars-descriptions/src/ir.rs
@@ -52,7 +52,7 @@ pub enum IrPropsDescription {
         how: String,
         left_on: Vec<String>,
         right_on: Vec<String>,
-        residual: Option<Vec<String>>,
+        fused_predicate: Option<Vec<String>>,
         nulls_equal: bool,
         coalesce: String,
         maintain_order: String,

--- a/crates/polars-descriptions/src/ir.rs
+++ b/crates/polars-descriptions/src/ir.rs
@@ -52,7 +52,6 @@ pub enum IrPropsDescription {
         how: String,
         left_on: Vec<String>,
         right_on: Vec<String>,
-        /// Extra match condition on top of the keys.
         residual: Option<Vec<String>>,
         nulls_equal: bool,
         coalesce: String,

--- a/crates/polars-descriptions/src/ir.rs
+++ b/crates/polars-descriptions/src/ir.rs
@@ -52,6 +52,8 @@ pub enum IrPropsDescription {
         how: String,
         left_on: Vec<String>,
         right_on: Vec<String>,
+        /// Extra match condition on top of the keys.
+        residual: Option<Vec<String>>,
         nulls_equal: bool,
         coalesce: String,
         maintain_order: String,

--- a/crates/polars-descriptions/src/physical.rs
+++ b/crates/polars-descriptions/src/physical.rs
@@ -102,7 +102,7 @@ pub enum PhysicalPropsDescription {
         how: String,
         left_on: Vec<String>,
         right_on: Vec<String>,
-        residual: Option<Vec<String>>,
+        fused_predicate: Option<Vec<String>>,
         nulls_equal: bool,
         coalesce: String,
         maintain_order: String,

--- a/crates/polars-descriptions/src/physical.rs
+++ b/crates/polars-descriptions/src/physical.rs
@@ -102,6 +102,7 @@ pub enum PhysicalPropsDescription {
         how: String,
         left_on: Vec<String>,
         right_on: Vec<String>,
+        residual: Option<Vec<String>>,
         nulls_equal: bool,
         coalesce: String,
         maintain_order: String,

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -708,6 +708,8 @@ fn create_physical_plan_impl(
             schema,
             ..
         } => {
+            options.ensure_executable()?;
+
             let schema_left = lp_arena.get(input_left).schema(lp_arena).into_owned();
             let schema_right = lp_arena.get(input_right).schema(lp_arena).into_owned();
 

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -191,9 +191,13 @@ pub trait CrossJoinFilter: Send + Sync {
     /// Evaluates the filter predicate on `df`, returning a boolean mask.
     fn evaluate(&self, df: &DataFrame) -> PolarsResult<BooleanChunked>;
 
-    fn apply(&self, df: DataFrame) -> PolarsResult<DataFrame> {
+    fn apply(&self, df: DataFrame, parallel: bool) -> PolarsResult<DataFrame> {
         let mask = self.evaluate(&df)?;
-        df.filter_seq(&mask)
+        if parallel {
+            df.filter(&mask)
+        } else {
+            df.filter_seq(&mask)
+        }
     }
 }
 
@@ -391,8 +395,7 @@ impl JoinType {
         matches!(self, JoinType::Inner | JoinType::Left | JoinType::Right)
     }
 
-    /// Whether the physical join implementations can execute this `how` with the given
-    /// (already-resolved) match-condition algorithm without silently dropping it.
+    /// Whether the physical join implementations can execute this `how`
     pub fn supports_non_equi_options(&self, options: &Option<JoinTypeOptions>) -> bool {
         // A residual is only ever attached to an inner join; see `JoinTypeOptionsIR::Equi`.
         if matches!(options, Some(JoinTypeOptions::Residual(_))) {

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -251,16 +251,6 @@ pub enum JoinTypeOptions {
     Residual(CrossJoinOptions),
 }
 
-impl JoinTypeOptions {
-    pub fn is_iejoin(&self) -> bool {
-        match self {
-            #[cfg(feature = "iejoin")]
-            Self::IEJoin(_) => true,
-            _ => false,
-        }
-    }
-}
-
 impl Display for JoinType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use JoinType::*;
@@ -393,22 +383,6 @@ impl JoinType {
     /// Joins supported in join where with non-equi conditions
     pub fn supports_non_equi(&self) -> bool {
         matches!(self, JoinType::Inner | JoinType::Left | JoinType::Right)
-    }
-
-    /// Whether the physical join implementations can execute this `how`
-    pub fn supports_non_equi_options(&self, options: &Option<JoinTypeOptions>) -> bool {
-        // A residual is only ever attached to an inner join; see `JoinTypeOptionsIR::Equi`.
-        if matches!(options, Some(JoinTypeOptions::Residual(_))) {
-            return matches!(self, JoinType::Inner);
-        }
-        options.is_none()
-            || matches!(self, JoinType::Inner | JoinType::Cross)
-            || self.is_ie()
-            || self.is_range()
-            || (matches!(self, JoinType::Left | JoinType::Right)
-                && options.as_ref().map(|o| o.is_iejoin()).unwrap_or(false))
-            || (matches!(self, JoinType::Left)
-                && matches!(options, Some(JoinTypeOptions::Cross(_))))
     }
 }
 

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -248,7 +248,7 @@ pub enum JoinTypeOptions {
     IEJoin(IEJoinOptions),
     Cross(CrossJoinOptions),
     /// A predicate fused into an equi join's match condition, on top of its keys.
-    Residual(CrossJoinOptions),
+    FusedPredicate(CrossJoinOptions),
 }
 
 impl Display for JoinType {

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -243,6 +243,8 @@ pub enum JoinTypeOptions {
     #[cfg(feature = "iejoin")]
     IEJoin(IEJoinOptions),
     Cross(CrossJoinOptions),
+    /// A predicate fused into an equi join's match condition, on top of its keys.
+    Residual(CrossJoinOptions),
 }
 
 impl JoinTypeOptions {
@@ -392,6 +394,10 @@ impl JoinType {
     /// Whether the physical join implementations can execute this `how` with the given
     /// (already-resolved) match-condition algorithm without silently dropping it.
     pub fn supports_non_equi_options(&self, options: &Option<JoinTypeOptions>) -> bool {
+        // A residual is only ever attached to an inner join; see `JoinTypeOptionsIR::Equi`.
+        if matches!(options, Some(JoinTypeOptions::Residual(_))) {
+            return matches!(self, JoinType::Inner);
+        }
         options.is_none()
             || matches!(self, JoinType::Inner | JoinType::Cross)
             || self.is_ie()

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -189,7 +189,7 @@ pub(super) fn fused_cross_filter(
                 unsafe { joined.hstack_mut_unchecked(&right_columns) };
 
                 if !emit_unmatched_left {
-                    cross_join_options.predicate.apply(joined)
+                    cross_join_options.predicate.apply(joined, false)
                 } else {
                     let mask = cross_join_options.predicate.evaluate(&joined)?;
 

--- a/crates/polars-ops/src/frame/join/merge_join.rs
+++ b/crates/polars-ops/src/frame/join/merge_join.rs
@@ -244,6 +244,8 @@ pub fn gather_and_postprocess(
         (gather_left, gather_right) = (gather_probe, gather_build);
     }
 
+    let left_keys_coalesced_away = should_coalesce && matches!(args.how, JoinType::Right);
+
     // Remove non-payload columns
     for col in left
         .columns()
@@ -266,10 +268,14 @@ pub fn gather_and_postprocess(
         .cloned()
         .collect_vec()
     {
-        if left_on.contains(&col) && should_coalesce {
+        if right_on.contains(&col) && should_coalesce {
             continue;
         }
-        let renamed = match left.schema().contains(&col) {
+        // A right column takes the suffix only if it collides with a left column that
+        // survives coalescing, which drops the left keys on a right join.
+        let collides =
+            left.schema().contains(&col) && !(left_keys_coalesced_away && left_on.contains(&col));
+        let renamed = match collides {
             true => Cow::Owned(format_pl_smallstr!("{}{}", col, args.suffix())),
             false => Cow::Borrowed(&col),
         };
@@ -313,14 +319,14 @@ pub fn gather_and_postprocess(
     if should_coalesce {
         match args.how {
             JoinType::Inner | JoinType::Left => {
-                for c in left_on {
+                for c in right_on {
                     if right.schema().contains(c) {
                         right.drop_in_place(c.as_str())?;
                     }
                 }
             },
             JoinType::Right => {
-                for c in right_on {
+                for c in left_on {
                     if left.schema().contains(c) {
                         left.drop_in_place(c.as_str())?;
                     }

--- a/crates/polars-ops/src/frame/join/merge_join.rs
+++ b/crates/polars-ops/src/frame/join/merge_join.rs
@@ -271,8 +271,8 @@ pub fn gather_and_postprocess(
         if right_on.contains(&col) && should_coalesce {
             continue;
         }
-        // A right column takes the suffix only if it collides with a left column that
-        // survives coalescing, which drops the left keys on a right join.
+        // A right column takes the suffix only where it collides with a left column
+        // that survives coalescing.
         let collides =
             left.schema().contains(&col) && !(left_keys_coalesced_away && left_on.contains(&col));
         let renamed = match collides {

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -139,8 +139,7 @@ pub trait DataFrameJoinOps: IntoDf {
     ) -> PolarsResult<DataFrame> {
         let left_df = self.to_df();
 
-        // A correctness fallback: the streaming hash join applies the residual per
-        // candidate instead of materializing every pair.
+        // This join has no per-candidate match condition, so it filters after the fact.
         if let Some(JoinTypeOptions::Residual(residual_options)) = &options {
             debug_assert!(args.slice.is_none());
             let predicate = residual_options.predicate.clone();

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -140,9 +140,9 @@ pub trait DataFrameJoinOps: IntoDf {
         let left_df = self.to_df();
 
         // This join has no per-candidate match condition, so it filters after the fact.
-        if let Some(JoinTypeOptions::Residual(residual_options)) = &options {
+        if let Some(JoinTypeOptions::FusedPredicate(fused_options)) = &options {
             debug_assert!(args.slice.is_none());
-            let predicate = residual_options.predicate.clone();
+            let predicate = fused_options.predicate.clone();
             let joined = self._join_impl(
                 other,
                 selected_left,

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -149,6 +149,23 @@ pub trait DataFrameJoinOps: IntoDf {
             args.how,
         );
 
+        // A correctness fallback: the streaming hash join applies the residual per
+        // candidate instead of materializing every pair.
+        if let Some(JoinTypeOptions::Residual(residual_options)) = &options {
+            debug_assert!(args.slice.is_none());
+            let predicate = residual_options.predicate.clone();
+            let joined = self._join_impl(
+                other,
+                selected_left,
+                selected_right,
+                args,
+                None,
+                _check_rechunk,
+                _verbose,
+            )?;
+            return predicate.apply(joined);
+        }
+
         #[cfg(feature = "cross_join")]
         if let Some(JoinTypeOptions::Cross(cross_options)) = &options {
             assert!(args.slice.is_none());

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -139,13 +139,6 @@ pub trait DataFrameJoinOps: IntoDf {
     ) -> PolarsResult<DataFrame> {
         let left_df = self.to_df();
 
-        polars_ensure!(
-            args.how.supports_non_equi_options(&options),
-            InvalidOperation:
-            "'{}' join is not supported with non-equi join conditions",
-            args.how,
-        );
-
         // A correctness fallback: the streaming hash join applies the residual per
         // candidate instead of materializing every pair.
         if let Some(JoinTypeOptions::Residual(residual_options)) = &options {

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -139,9 +139,6 @@ pub trait DataFrameJoinOps: IntoDf {
     ) -> PolarsResult<DataFrame> {
         let left_df = self.to_df();
 
-        // Backstop: a non-equality match condition combined with a join type whose
-        // implementation does not yet track unmatched rows must not silently produce
-        // inner-join results.
         polars_ensure!(
             args.how.supports_non_equi_options(&options),
             InvalidOperation:
@@ -163,7 +160,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 _check_rechunk,
                 _verbose,
             )?;
-            return predicate.apply(joined);
+            return predicate.apply(joined, true);
         }
 
         #[cfg(feature = "cross_join")]

--- a/crates/polars-plan/src/plans/aexpr/properties/general.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties/general.rs
@@ -154,6 +154,30 @@ pub fn is_prop<P: Fn(&AExpr) -> bool>(
     true
 }
 
+/// Whether `ae` runs a nested evaluation that can fail.
+///
+/// `inputs_rev` skips these subtrees, so a walk over inputs alone never sees them.
+fn evaluates_fallible(ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
+    let mut stack: UnitVec<Node> = unitvec![];
+
+    match ae {
+        AExpr::Eval { evaluation, .. } => stack.push(*evaluation),
+        #[cfg(feature = "dtype-struct")]
+        AExpr::StructEval { evaluation, .. } => stack.extend(evaluation.iter().map(ExprIR::node)),
+        _ => return false,
+    }
+
+    while let Some(node) = stack.pop() {
+        let ae = expr_arena.get(node);
+        if ae.is_fallible_top_level(expr_arena) || evaluates_fallible(ae, expr_arena) {
+            return true;
+        }
+        ae.children_rev(&mut stack);
+    }
+
+    false
+}
+
 /// Checks if the top-level expression node is elementwise. If this is the case, then `stack` will
 /// be extended further with any nested expression nodes.
 pub fn is_elementwise(stack: &mut UnitVec<Node>, ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
@@ -228,7 +252,7 @@ impl ExprPushdownGroup {
         match self {
             ExprPushdownGroup::Pushable | ExprPushdownGroup::Fallible => {
                 // Downgrade to unpushable if fallible
-                if ae.is_fallible_top_level(expr_arena) {
+                if ae.is_fallible_top_level(expr_arena) || evaluates_fallible(ae, expr_arena) {
                     *self = ExprPushdownGroup::Fallible;
                 }
 

--- a/crates/polars-plan/src/plans/aexpr/properties/general.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties/general.rs
@@ -158,24 +158,19 @@ pub fn is_prop<P: Fn(&AExpr) -> bool>(
 ///
 /// `inputs_rev` skips these subtrees, so a walk over inputs alone never sees them.
 fn evaluates_fallible(ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
-    let mut stack: UnitVec<Node> = unitvec![];
-
-    match ae {
-        AExpr::Eval { evaluation, .. } => stack.push(*evaluation),
+    let roots: UnitVec<Node> = match ae {
+        AExpr::Eval { evaluation, .. } => unitvec![*evaluation],
         #[cfg(feature = "dtype-struct")]
-        AExpr::StructEval { evaluation, .. } => stack.extend(evaluation.iter().map(ExprIR::node)),
+        AExpr::StructEval { evaluation, .. } => evaluation.iter().map(ExprIR::node).collect(),
         _ => return false,
-    }
+    };
 
-    while let Some(node) = stack.pop() {
-        let ae = expr_arena.get(node);
-        if ae.is_fallible_top_level(expr_arena) || evaluates_fallible(ae, expr_arena) {
-            return true;
-        }
-        ae.children_rev(&mut stack);
-    }
-
-    false
+    // `iter` walks children rather than inputs, so it descends into nested evaluations.
+    roots.iter().any(|root| {
+        expr_arena
+            .iter(*root)
+            .any(|(_, ae)| ae.is_fallible_top_level(expr_arena))
+    })
 }
 
 /// Checks if the top-level expression node is elementwise. If this is the case, then `stack` will

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
@@ -369,7 +369,10 @@ pub fn resolve_join(
         match &options.args.how {
             #[cfg(feature = "asof_join")]
             JoinType::AsOf(_) => JoinTypeOptionsIR::AsOf { on },
-            _ => JoinTypeOptionsIR::Equi { on, residual: None },
+            _ => JoinTypeOptionsIR::Equi {
+                on,
+                fused_predicate: None,
+            },
         }
     };
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
@@ -369,7 +369,7 @@ pub fn resolve_join(
         match &options.args.how {
             #[cfg(feature = "asof_join")]
             JoinType::AsOf(_) => JoinTypeOptionsIR::AsOf { on },
-            _ => JoinTypeOptionsIR::Equi { on },
+            _ => JoinTypeOptionsIR::Equi { on, residual: None },
         }
     };
 

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -248,7 +248,13 @@ impl<'a> IRDisplay<'a> {
                     write!(f, "\n{:indent$}END {name} JOIN", "")
                 } else {
                     let how = &options.args.how;
-                    write!(f, "{:indent$}{how} JOIN:{build_side}", "")?;
+                    let residual = match options.options.residual() {
+                        Some(residual) => {
+                            format!("\n{:indent$}RESIDUAL: {}", "", self.display_expr(residual))
+                        },
+                        None => String::new(),
+                    };
+                    write!(f, "{:indent$}{how} JOIN:{build_side}{residual}", "")?;
                     write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
                     self.with_root(*input_left)
                         ._format(f, sub_indent, seen_caches)?;
@@ -1050,6 +1056,10 @@ pub fn write_ir_non_recursive(
                 write!(f, "{:indent$}{how} JOIN", "")?;
                 write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
                 write!(f, "\n{:indent$}RIGHT PLAN ON: {right_on}", "")?;
+                if let Some(residual) = options.options.residual() {
+                    let residual = residual.display(expr_arena);
+                    write!(f, "\n{:indent$}RESIDUAL: {residual}", "")?;
+                }
             }
 
             Ok(())

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -248,13 +248,17 @@ impl<'a> IRDisplay<'a> {
                     write!(f, "\n{:indent$}END {name} JOIN", "")
                 } else {
                     let how = &options.args.how;
-                    let residual = match options.options.residual() {
-                        Some(residual) => {
-                            format!("\n{:indent$}RESIDUAL: {}", "", self.display_expr(residual))
+                    let fused_predicate = match options.options.fused_predicate() {
+                        Some(fused_predicate) => {
+                            format!(
+                                "\n{:indent$}FUSED PREDICATE: {}",
+                                "",
+                                self.display_expr(fused_predicate)
+                            )
                         },
                         None => String::new(),
                     };
-                    write!(f, "{:indent$}{how} JOIN:{build_side}{residual}", "")?;
+                    write!(f, "{:indent$}{how} JOIN:{build_side}{fused_predicate}", "")?;
                     write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
                     self.with_root(*input_left)
                         ._format(f, sub_indent, seen_caches)?;
@@ -1056,9 +1060,9 @@ pub fn write_ir_non_recursive(
                 write!(f, "{:indent$}{how} JOIN", "")?;
                 write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
                 write!(f, "\n{:indent$}RIGHT PLAN ON: {right_on}", "")?;
-                if let Some(residual) = options.options.residual() {
-                    let residual = residual.display(expr_arena);
-                    write!(f, "\n{:indent$}RESIDUAL: {residual}", "")?;
+                if let Some(fused_predicate) = options.options.fused_predicate() {
+                    let fused_predicate = fused_predicate.display(expr_arena);
+                    write!(f, "\n{:indent$}FUSED PREDICATE: {fused_predicate}", "")?;
                 }
             }
 

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -398,6 +398,22 @@ impl<'a> Exprs<'a> {
                 .chain(on.iter().map(pair_rhs as _)),
         )
     }
+
+    /// [`Self::pair_sides`], then `extra` if there is one.
+    pub(crate) fn pair_sides_then(on: &'a [(ExprIR, ExprIR)], extra: Option<&'a ExprIR>) -> Self {
+        if extra.is_none() {
+            return Self::pair_sides(on);
+        }
+        Self::Boxed(Box::new(
+            on.iter()
+                .map(pair_lhs as fn(&'a (ExprIR, ExprIR)) -> &'a ExprIR)
+                .chain(
+                    on.iter()
+                        .map(pair_rhs as fn(&'a (ExprIR, ExprIR)) -> &'a ExprIR),
+                )
+                .chain(extra),
+        ))
+    }
 }
 
 fn pair_lhs((lhs, _): &(ExprIR, ExprIR)) -> &ExprIR {
@@ -450,8 +466,17 @@ impl<'a> ExprsMut<'a> {
     /// Collects the borrows because two disjoint `&mut` iterators over one slice of pairs
     /// cannot be built in safe Rust.
     pub(crate) fn pair_sides(on: &'a mut [(ExprIR, ExprIR)]) -> Self {
+        Self::pair_sides_then(on, None)
+    }
+
+    /// [`Self::pair_sides`], then `extra` if there is one. Must match
+    /// [`Exprs::pair_sides_then`].
+    pub(crate) fn pair_sides_then(
+        on: &'a mut [(ExprIR, ExprIR)],
+        extra: Option<&'a mut ExprIR>,
+    ) -> Self {
         let (lhs, rhs): (Vec<_>, Vec<_>) = on.iter_mut().map(|(l, r)| (l, r)).unzip();
-        Self::Boxed(Box::new(lhs.into_iter().chain(rhs)))
+        Self::Boxed(Box::new(lhs.into_iter().chain(rhs).chain(extra)))
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/join_order/cluster.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/cluster.rs
@@ -138,7 +138,7 @@ fn reorderable(options: &JoinOptionsIR) -> bool {
         && matches!(args.validation, JoinValidation::ManyToMany)
         // A forced build side refers to this specific join, so leave it alone.
         && args.build_side.is_none()
-        && matches!(&options.options, JoinTypeOptionsIR::Equi { on } if !on.is_empty())
+        && matches!(&options.options, JoinTypeOptionsIR::Equi { on, residual: None } if !on.is_empty())
 }
 
 /// A leaf as found, with the renames that carry its columns into the root namespace.

--- a/crates/polars-plan/src/plans/optimizer/join_order/cluster.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/cluster.rs
@@ -138,7 +138,7 @@ fn reorderable(options: &JoinOptionsIR) -> bool {
         && matches!(args.validation, JoinValidation::ManyToMany)
         // A forced build side refers to this specific join, so leave it alone.
         && args.build_side.is_none()
-        && matches!(&options.options, JoinTypeOptionsIR::Equi { on, residual: None } if !on.is_empty())
+        && matches!(&options.options, JoinTypeOptionsIR::Equi { on, fused_predicate: None } if !on.is_empty())
 }
 
 /// A leaf as found, with the renames that carry its columns into the root namespace.

--- a/crates/polars-plan/src/plans/optimizer/join_order/enumerate.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/enumerate.rs
@@ -145,7 +145,10 @@ mod tests {
             allow_parallel: true,
             force_parallel: false,
             args: JoinArgs::default(),
-            options: JoinTypeOptionsIR::Equi { on: Vec::new() },
+            options: JoinTypeOptionsIR::Equi {
+                on: Vec::new(),
+                residual: None,
+            },
         })
     }
 

--- a/crates/polars-plan/src/plans/optimizer/join_order/enumerate.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/enumerate.rs
@@ -147,7 +147,7 @@ mod tests {
             args: JoinArgs::default(),
             options: JoinTypeOptionsIR::Equi {
                 on: Vec::new(),
-                residual: None,
+                fused_predicate: None,
             },
         })
     }

--- a/crates/polars-plan/src/plans/optimizer/join_order/rebuild.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/rebuild.rs
@@ -39,7 +39,7 @@ pub(super) fn rebuild(
         // Field-by-field rather than struct-update syntax, which would clone the
         // old key vector only to overwrite it.
         let options = Arc::new(JoinOptionsIR {
-            options: JoinTypeOptionsIR::Equi { on },
+            options: JoinTypeOptionsIR::Equi { on, residual: None },
             args: cluster.options.args.clone(),
             allow_parallel: cluster.options.allow_parallel,
             force_parallel: cluster.options.force_parallel,

--- a/crates/polars-plan/src/plans/optimizer/join_order/rebuild.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_order/rebuild.rs
@@ -39,7 +39,10 @@ pub(super) fn rebuild(
         // Field-by-field rather than struct-update syntax, which would clone the
         // old key vector only to overwrite it.
         let options = Arc::new(JoinOptionsIR {
-            options: JoinTypeOptionsIR::Equi { on, residual: None },
+            options: JoinTypeOptionsIR::Equi {
+                on,
+                fused_predicate: None,
+            },
             args: cluster.options.args.clone(),
             allow_parallel: cluster.options.allow_parallel,
             force_parallel: cluster.options.force_parallel,

--- a/crates/polars-plan/src/plans/optimizer/join_predicate_fusion.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_predicate_fusion.rs
@@ -21,7 +21,7 @@ use crate::plans::{
 use crate::utils::{aexpr_to_leaf_names_iter, rename_columns};
 
 /// Fuse `Filter(join)` predicates that span both inputs into the join's match condition.
-pub(super) fn fuse_residual_predicates(
+pub(super) fn fuse_predicates(
     root: Node,
     ir_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
@@ -41,14 +41,14 @@ pub(super) fn fuse_residual_predicates(
     Ok(())
 }
 
-/// A residual is only sound on an inner equi join, and a slice must stay above the filter
+/// A fused predicate is only sound on an inner equi join, and a slice must stay above the filter
 /// that feeds it.
 fn is_fusable_join(options: &JoinOptionsIR) -> bool {
     matches!(options.args.how, JoinType::Inner)
         && options.args.slice.is_none()
         && matches!(
             &options.options,
-            JoinTypeOptionsIR::Equi { on, residual: None } if !on.is_empty()
+            JoinTypeOptionsIR::Equi { on, fused_predicate: None } if !on.is_empty()
         )
 }
 
@@ -133,7 +133,7 @@ fn try_fuse(
             continue;
         }
 
-        // An equality is cheaper as a key than as a residual.
+        // An equality is cheaper as a key than as a fused predicate.
         if let Some(pair) = as_key_pair(
             minterm,
             expr_arena,
@@ -174,7 +174,7 @@ fn try_fuse(
     if let Some(fused) = fused {
         options_mut
             .options
-            .set_residual(ExprIR::from_node(fused, expr_arena));
+            .set_fused_predicate(ExprIR::from_node(fused, expr_arena));
     }
     let join = IR::Join {
         input_left,

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -163,11 +163,6 @@ pub fn optimize(
         });
     };
 
-    // Everything below is written against `Filter`-over-join.
-    if get_or_init_members!().has_joins_or_unions {
-        residual_join::unfuse_residual_joins(root, ir_arena)?;
-    }
-
     let mut repeat_slice_pd_after_filter_pd = false;
 
     if opt_flags.slice_pushdown() {

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -19,6 +19,7 @@ mod flatten_union;
 mod fused;
 mod join_build_side;
 mod join_order;
+mod join_predicate_fusion;
 mod join_utils;
 pub(crate) use join_utils::ExprOrigin;
 pub mod call_dsl_resolvers;
@@ -32,7 +33,6 @@ mod ir_traversal;
 mod parquet_metadata_prune;
 mod predicate_pushdown;
 mod projection_pushdown;
-mod residual_join;
 mod simplify_expr;
 pub mod simplify_ordering;
 mod slice_pushdown_expr;
@@ -219,10 +219,10 @@ pub fn optimize(
         root = join_order::join_order(root, ir_arena, expr_arena)?;
     }
 
-    // After join ordering, and before projection pushdown drops what only the residual
+    // After join ordering, and before projection pushdown drops what only the fused predicate
     // reads.
     if opt_flags.predicate_pushdown() && get_or_init_members!().has_joins_or_unions {
-        residual_join::fuse_residual_predicates(root, ir_arena, expr_arena)?;
+        join_predicate_fusion::fuse_predicates(root, ir_arena, expr_arena)?;
     }
 
     if opt_flags.projection_pushdown() {

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -32,6 +32,7 @@ mod ir_traversal;
 mod parquet_metadata_prune;
 mod predicate_pushdown;
 mod projection_pushdown;
+mod residual_join;
 mod simplify_expr;
 pub mod simplify_ordering;
 mod slice_pushdown_expr;
@@ -162,6 +163,11 @@ pub fn optimize(
         });
     };
 
+    // Everything below is written against `Filter`-over-join.
+    if get_or_init_members!().has_joins_or_unions {
+        residual_join::unfuse_residual_joins(root, ir_arena)?;
+    }
+
     let mut repeat_slice_pd_after_filter_pd = false;
 
     if opt_flags.slice_pushdown() {
@@ -216,6 +222,12 @@ pub fn optimize(
     // before projection pushdown so projections follow the final join order.
     if opt_flags.join_order() && get_or_init_members!().has_joins_or_unions {
         root = join_order::join_order(root, ir_arena, expr_arena)?;
+    }
+
+    // After join ordering, and before projection pushdown drops what only the residual
+    // reads.
+    if opt_flags.predicate_pushdown() && get_or_init_members!().has_joins_or_unions {
+        residual_join::fuse_residual_predicates(root, ir_arena, expr_arena)?;
     }
 
     if opt_flags.projection_pushdown() {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
@@ -566,7 +566,7 @@ pub fn try_rewrite_join_type(
         );
         // Important
         assert!(
-            matches!(existing, JoinTypeOptionsIR::Equi { ref on, residual: None } if on.is_empty())
+            matches!(existing, JoinTypeOptionsIR::Equi { ref on, fused_predicate: None } if on.is_empty())
         );
 
         Ok(())
@@ -1082,7 +1082,7 @@ fn try_rewrite_outer_join_algorithm(
         JoinTypeOptionsIR::CrossAndFilter { predicate },
     );
     assert!(
-        matches!(existing, JoinTypeOptionsIR::Equi { ref on, residual: None } if on.is_empty())
+        matches!(existing, JoinTypeOptionsIR::Equi { ref on, fused_predicate: None } if on.is_empty())
     );
     Ok(())
 }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
@@ -565,7 +565,9 @@ pub fn try_rewrite_join_type(
             },
         );
         // Important
-        assert!(matches!(existing, JoinTypeOptionsIR::Equi { ref on } if on.is_empty()));
+        assert!(
+            matches!(existing, JoinTypeOptionsIR::Equi { ref on, residual: None } if on.is_empty())
+        );
 
         Ok(())
     })()?;
@@ -1079,7 +1081,9 @@ fn try_rewrite_outer_join_algorithm(
         &mut Arc::make_mut(options).options,
         JoinTypeOptionsIR::CrossAndFilter { predicate },
     );
-    assert!(matches!(existing, JoinTypeOptionsIR::Equi { ref on } if on.is_empty()));
+    assert!(
+        matches!(existing, JoinTypeOptionsIR::Equi { ref on, residual: None } if on.is_empty())
+    );
     Ok(())
 }
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -3,7 +3,7 @@ mod group_by;
 mod hive;
 mod join;
 mod keys;
-mod utils;
+pub(super) mod utils;
 
 pub use dynamic::{DynamicPred, DynamicPredWeakRef, PredicateExpr, TrivialPredicateExpr};
 use polars_buffer::Buffer;

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -15,7 +15,7 @@ pub(super) struct PredicateDedupState {
     min_terms: ScratchIndexSet<CanonicalExprId>,
 }
 
-fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
+pub(crate) fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
     arena.add(AExpr::BinaryExpr {
         left,
         op: Operator::And,

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use edge::Edge;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{Column, DataType, ScratchIndexMap, ScratchIndexSet};
+use polars_core::prelude::{Column, DataType, PlIndexMap, ScratchIndexMap, ScratchIndexSet};
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
 use polars_ops::frame::{JoinCoalesce, JoinType};
@@ -898,10 +898,22 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     has_cross_filter = true;
                 }
 
+                // A residual reads output columns the final projection may not ask for.
+                let residual_names: Vec<PlSmallStr> = options
+                    .options
+                    .residual()
+                    .map(|residual| {
+                        aexpr_to_leaf_names_iter(residual.node(), self.expr_arena)
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let reads_in_residual = |name: &PlSmallStr| residual_names.contains(name);
+
                 // Add accumulated projections
                 for output_name in output_schema_arc
                     .iter_names()
-                    .filter(|name| is_projected_in_output(name))
+                    .filter(|name| is_projected_in_output(name) || reads_in_residual(name))
                     .chain(pred_used_names_iter.into_iter().flatten())
                 {
                     match ExprOrigin::get_column_origin(
@@ -974,11 +986,13 @@ impl ProjectionPushdownVisitor<'_, '_> {
                             return false;
                         };
 
+                        // Coalescing drops the right key, so a residual reading it counts
+                        // as a use.
                         let projected = if input_schema_left.contains(name.as_str()) {
                             let name = format_pl_smallstr!("{}{}", name, options.args.suffix());
-                            is_projected_in_output(&name)
+                            is_projected_in_output(&name) || reads_in_residual(&name)
                         } else {
-                            is_projected_in_output(name)
+                            is_projected_in_output(name) || reads_in_residual(name)
                         };
 
                         !projected
@@ -1029,6 +1043,40 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 let opt_projected_names = out_edge.compute_projected_names(output_schema_arc);
 
                 *output_schema_arc = new_output_schema;
+
+                // Narrowing an input can remove a name collision, dropping the suffix from
+                // the right column. The rename map below need not mention a column that
+                // only the residual reads.
+                if !residual_names.is_empty() {
+                    let mut renames: PlIndexMap<PlSmallStr, PlSmallStr> = PlIndexMap::default();
+
+                    for name in residual_names.iter() {
+                        if output_schema_arc.contains(name) {
+                            continue;
+                        }
+                        let Some(stripped) = name.strip_suffix(options.args.suffix().as_str())
+                        else {
+                            continue;
+                        };
+                        renames.insert(name.clone(), PlSmallStr::from_str(stripped));
+                    }
+
+                    if !renames.is_empty() {
+                        let JoinTypeOptionsIR::Equi {
+                            residual: Some(residual),
+                            ..
+                        } = &mut Arc::make_mut(options).options
+                        else {
+                            unreachable!()
+                        };
+
+                        residual.set_node(rename_columns(
+                            residual.node(),
+                            self.expr_arena,
+                            &renames,
+                        ));
+                    }
+                }
 
                 if let Some(projected_names) = &opt_projected_names {
                     let orig_to_new_name_map = self.rename_map.get();

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -1044,9 +1044,9 @@ impl ProjectionPushdownVisitor<'_, '_> {
 
                 *output_schema_arc = new_output_schema;
 
-                // Narrowing an input can remove a name collision, dropping the suffix from
-                // the right column. The rename map below need not mention a column that
-                // only the residual reads.
+                // Narrowing an input can remove a name collision, dropping the suffix
+                // from the right column. The map below covers only projected names, so a
+                // column read solely by the residual is renamed here.
                 if !residual_names.is_empty() {
                     let mut renames: PlIndexMap<PlSmallStr, PlSmallStr> = PlIndexMap::default();
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -898,22 +898,23 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     has_cross_filter = true;
                 }
 
-                // A residual reads output columns the final projection may not ask for.
-                let residual_names: Vec<PlSmallStr> = options
+                // A fused predicate reads output columns the final projection may not ask for.
+                let fused_predicate_names: Vec<PlSmallStr> = options
                     .options
-                    .residual()
-                    .map(|residual| {
-                        aexpr_to_leaf_names_iter(residual.node(), self.expr_arena)
+                    .fused_predicate()
+                    .map(|fused_predicate| {
+                        aexpr_to_leaf_names_iter(fused_predicate.node(), self.expr_arena)
                             .cloned()
                             .collect()
                     })
                     .unwrap_or_default();
-                let reads_in_residual = |name: &PlSmallStr| residual_names.contains(name);
+                let reads_in_fused_predicate =
+                    |name: &PlSmallStr| fused_predicate_names.contains(name);
 
                 // Add accumulated projections
                 for output_name in output_schema_arc
                     .iter_names()
-                    .filter(|name| is_projected_in_output(name) || reads_in_residual(name))
+                    .filter(|name| is_projected_in_output(name) || reads_in_fused_predicate(name))
                     .chain(pred_used_names_iter.into_iter().flatten())
                 {
                     match ExprOrigin::get_column_origin(
@@ -986,13 +987,13 @@ impl ProjectionPushdownVisitor<'_, '_> {
                             return false;
                         };
 
-                        // Coalescing drops the right key, so a residual reading it counts
+                        // Coalescing drops the right key, so a fused predicate reading it counts
                         // as a use.
                         let projected = if input_schema_left.contains(name.as_str()) {
                             let name = format_pl_smallstr!("{}{}", name, options.args.suffix());
-                            is_projected_in_output(&name) || reads_in_residual(&name)
+                            is_projected_in_output(&name) || reads_in_fused_predicate(&name)
                         } else {
-                            is_projected_in_output(name) || reads_in_residual(name)
+                            is_projected_in_output(name) || reads_in_fused_predicate(name)
                         };
 
                         !projected
@@ -1046,11 +1047,11 @@ impl ProjectionPushdownVisitor<'_, '_> {
 
                 // Narrowing an input can remove a name collision, dropping the suffix
                 // from the right column. The map below covers only projected names, so a
-                // column read solely by the residual is renamed here.
-                if !residual_names.is_empty() {
+                // column read solely by the fused predicate is renamed here.
+                if !fused_predicate_names.is_empty() {
                     let mut renames: PlIndexMap<PlSmallStr, PlSmallStr> = PlIndexMap::default();
 
-                    for name in residual_names.iter() {
+                    for name in fused_predicate_names.iter() {
                         if output_schema_arc.contains(name) {
                             continue;
                         }
@@ -1063,15 +1064,15 @@ impl ProjectionPushdownVisitor<'_, '_> {
 
                     if !renames.is_empty() {
                         let JoinTypeOptionsIR::Equi {
-                            residual: Some(residual),
+                            fused_predicate: Some(fused_predicate),
                             ..
                         } = &mut Arc::make_mut(options).options
                         else {
                             unreachable!()
                         };
 
-                        residual.set_node(rename_columns(
-                            residual.node(),
+                        fused_predicate.set_node(rename_columns(
+                            fused_predicate.node(),
                             self.expr_arena,
                             &renames,
                         ));

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use polars_core::error::PolarsResult;
 use polars_core::prelude::Schema;
 use polars_ops::frame::JoinArgs;
-use polars_utils::aliases::{PlHashSet, PlIndexMap};
+use polars_utils::aliases::{PlIndexMap, PlIndexSet};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::pl_str::PlSmallStr;
@@ -27,7 +27,7 @@ pub(super) fn fuse_residual_predicates(
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<()> {
     let mut stack: UnitVec<Node> = unitvec![root];
-    let mut seen = PlHashSet::default();
+    let mut seen = PlIndexSet::default();
 
     while let Some(node) = stack.pop() {
         if !seen.insert(node) {
@@ -102,12 +102,12 @@ fn try_fuse(
 
     let right_names = right_output_to_input(&left_schema, &right_schema, &options, expr_arena)?;
 
-    let mut left_key_names: PlHashSet<PlSmallStr> = options
+    let mut left_key_names: PlIndexSet<PlSmallStr> = options
         .options
         .left_on()
         .map(|key| key.output_name().clone())
         .collect();
-    let mut right_key_names: PlHashSet<PlSmallStr> = options
+    let mut right_key_names: PlIndexSet<PlSmallStr> = options
         .options
         .right_on()
         .map(|key| key.output_name().clone())
@@ -292,8 +292,8 @@ fn name_key_pair(
     args: &JoinArgs,
     left_schema: &Schema,
     right_schema: &Schema,
-    left_key_names: &mut PlHashSet<PlSmallStr>,
-    right_key_names: &mut PlHashSet<PlSmallStr>,
+    left_key_names: &mut PlIndexSet<PlSmallStr>,
+    right_key_names: &mut PlIndexSet<PlSmallStr>,
 ) -> (ExprIR, ExprIR) {
     if !left_key_names.insert(left_key.output_name().clone()) {
         let name = unique_key_name(left_key.output_name(), left_key_names, left_schema);
@@ -312,7 +312,7 @@ fn name_key_pair(
     (left_key, right_key)
 }
 
-fn unique_key_name(base: &str, taken: &PlHashSet<PlSmallStr>, schema: &Schema) -> PlSmallStr {
+fn unique_key_name(base: &str, taken: &PlIndexSet<PlSmallStr>, schema: &Schema) -> PlSmallStr {
     (0..)
         .map(|i| format_pl_smallstr!("__POLARS_JOIN_KEY_{i}_{base}"))
         .find(|name| !taken.contains(name) && !schema.contains(name))
@@ -329,7 +329,7 @@ fn right_output_to_input(
     options: &JoinOptionsIR,
     expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<PlIndexMap<PlSmallStr, PlSmallStr>> {
-    let mut coalesced: PlHashSet<PlSmallStr> = PlHashSet::default();
+    let mut coalesced: PlIndexSet<PlSmallStr> = PlIndexSet::default();
     if options.args.should_coalesce() {
         for key in options.options.right_on() {
             coalesced.insert(key.field(right_schema, expr_arena)?.name);

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use polars_core::error::PolarsResult;
 use polars_core::prelude::Schema;
 use polars_ops::frame::JoinArgs;
-use polars_utils::aliases::PlHashSet;
+use polars_utils::aliases::{PlHashSet, PlIndexMap};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::{format_pl_smallstr, unitvec};
 
-use super::join_utils::{ExprOrigin, remove_suffix};
+use super::join_utils::ExprOrigin;
 use super::predicate_pushdown::utils::{combine_by_and, contains_dynamic_pred};
 use crate::dsl::Operator;
 use crate::plans::options::JoinTypeOptionsIR;
@@ -17,6 +17,7 @@ use crate::plans::{
     AExpr, ExprIR, ExprPushdownGroup, IR, JoinOptionsIR, JoinType, MintermIter, OutputName,
     is_row_separable_rec,
 };
+use crate::utils::{aexpr_to_leaf_names_iter, rename_columns};
 
 /// Visit every node reachable from `root` once, parents before their inputs.
 fn for_each_ir_node(
@@ -140,6 +141,8 @@ fn try_fuse(
     let right_schema = ir_arena.get(input_right).schema(ir_arena).into_owned();
     let suffix = options.args.suffix().clone();
 
+    let right_names = right_output_to_input(&left_schema, &right_schema, &options, expr_arena)?;
+
     let mut left_key_names: PlHashSet<PlSmallStr> = options
         .options
         .key_pairs()
@@ -185,6 +188,7 @@ fn try_fuse(
             &right_schema,
             &options.args,
             &suffix,
+            &right_names,
             &mut left_key_names,
             &mut right_key_names,
         )? {
@@ -246,6 +250,7 @@ fn try_as_key_pair(
     right_schema: &Schema,
     args: &JoinArgs,
     suffix: &str,
+    right_names: &PlIndexMap<PlSmallStr, PlSmallStr>,
     left_key_names: &mut PlHashSet<PlSmallStr>,
     right_key_names: &mut PlHashSet<PlSmallStr>,
 ) -> PolarsResult<Option<(ExprIR, ExprIR)>> {
@@ -280,9 +285,17 @@ fn try_as_key_pair(
         _ => return Ok(None),
     };
 
+    // The right side is in the join's output namespace, where a name can belong to a
+    // different input column than the one it shares a name with.
+    if !aexpr_to_leaf_names_iter(right_node, expr_arena)
+        .all(|name| right_names.contains_key(name.as_str()))
+    {
+        return Ok(None);
+    }
+    let right_node = rename_columns(right_node, expr_arena, right_names);
+
     let mut left_key = ExprIR::from_node(left_node, expr_arena);
     let mut right_key = ExprIR::from_node(right_node, expr_arena);
-    remove_suffix(&mut right_key, expr_arena, right_schema, suffix);
 
     // Key pairs are matched without coercion.
     if left_key.field(left_schema, expr_arena)?.dtype
@@ -311,4 +324,37 @@ fn unique_key_name(base: &str, taken: &PlHashSet<PlSmallStr>, schema: &Schema) -
         .map(|i| format_pl_smallstr!("__POLARS_JOIN_KEY_{i}_{base}"))
         .find(|name| !taken.contains(name) && !schema.contains(name))
         .unwrap()
+}
+
+/// Maps each right input column reachable in the join's output to its output name.
+///
+/// A coalescing join drops the right key columns, and the rest take the join suffix where
+/// they collide with a left column, so an output name need not be the input name.
+fn right_output_to_input(
+    left_schema: &Schema,
+    right_schema: &Schema,
+    options: &JoinOptionsIR,
+    expr_arena: &Arena<AExpr>,
+) -> PolarsResult<PlIndexMap<PlSmallStr, PlSmallStr>> {
+    let mut coalesced: PlHashSet<PlSmallStr> = PlHashSet::default();
+    if options.args.should_coalesce() {
+        for key in options.options.right_on() {
+            coalesced.insert(key.field(right_schema, expr_arena)?.name);
+        }
+    }
+
+    let suffix = options.args.suffix();
+    let mut out = PlIndexMap::default();
+    for name in right_schema.iter_names() {
+        if coalesced.contains(name) {
+            continue;
+        }
+        let output_name = if left_schema.contains(name) {
+            format_pl_smallstr!("{}{}", name, suffix)
+        } else {
+            name.clone()
+        };
+        out.insert(output_name, name.clone());
+    }
+    Ok(out)
 }

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -113,7 +113,6 @@ fn try_fuse(
         .map(|key| key.output_name().clone())
         .collect();
 
-    // Classify every minterm before rebuilding the two predicates from them.
     let mut promoted: Vec<(ExprIR, ExprIR)> = Vec::new();
     let mut fused: UnitVec<Node> = unitvec![];
     let mut kept: UnitVec<Node> = unitvec![];
@@ -205,8 +204,8 @@ fn try_fuse(
 ///
 /// A promoted key runs on all rows of its input, not only on the candidate pairs the
 /// filter would have seen, so it must not fail or draw randomly on rows the query
-/// excludes. Fallibility is tracked per known function and does not cover every way an
-/// expression can raise, so this accepts only operations that cannot.
+/// excludes. Fallibility is tracked per known function rather than proven, so this
+/// admits only operations that cannot raise at all.
 fn can_promote_key(node: Node, expr_arena: &Arena<AExpr>) -> bool {
     expr_arena.iter(node).all(|(_, ae)| match ae {
         AExpr::Column(_) | AExpr::Literal(_) => true,

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -20,11 +20,11 @@ use crate::plans::{
 };
 use crate::utils::{aexpr_to_leaf_names_iter, rename_columns};
 
-/// Visit every node reachable from `root` once, parents before their inputs.
-fn for_each_ir_node(
+/// Fuse `Filter(join)` predicates that span both inputs into the join's match condition.
+pub(super) fn fuse_residual_predicates(
     root: Node,
     ir_arena: &mut Arena<IR>,
-    mut visit: impl FnMut(Node, &mut Arena<IR>) -> PolarsResult<()>,
+    expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<()> {
     let mut stack: UnitVec<Node> = unitvec![root];
     let mut seen = PlHashSet::default();
@@ -33,22 +33,12 @@ fn for_each_ir_node(
         if !seen.insert(node) {
             continue;
         }
+        // Read the inputs before fusing, which replaces what `node` holds.
         ir_arena.get(node).copy_inputs(&mut stack);
-        visit(node, ir_arena)?;
+        try_fuse(node, ir_arena, expr_arena)?;
     }
 
     Ok(())
-}
-
-/// Fuse `Filter(join)` predicates that span both inputs into the join's match condition.
-pub(super) fn fuse_residual_predicates(
-    root: Node,
-    ir_arena: &mut Arena<IR>,
-    expr_arena: &mut Arena<AExpr>,
-) -> PolarsResult<()> {
-    for_each_ir_node(root, ir_arena, |node, ir_arena| {
-        try_fuse(node, ir_arena, expr_arena)
-    })
 }
 
 /// A residual is only sound on an inner equi join, and a slice must stay above the filter
@@ -63,7 +53,7 @@ fn is_fusable_join(options: &JoinOptionsIR) -> bool {
 }
 
 /// Elementwise and infallible, so the join can evaluate it per candidate pair.
-fn is_fusable_predicate(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+fn can_fuse_predicate(node: Node, expr_arena: &Arena<AExpr>) -> bool {
     let mut group = ExprPushdownGroup::Pushable;
     group.update_with_expr_rec(expr_arena.get(node), expr_arena, None);
 
@@ -80,7 +70,7 @@ fn try_fuse(
     let IR::Filter { input, predicate } = ir_arena.get(node) else {
         return Ok(());
     };
-    let (input, predicate) = (*input, predicate.clone());
+    let (input, predicate) = (*input, predicate.node());
 
     let IR::Join {
         input_left,
@@ -98,10 +88,10 @@ fn try_fuse(
         (*input_left, *input_right, schema.clone(), options.clone());
 
     // A single unfusable term leaves the whole filter alone.
-    let minterms = MintermIter::new(predicate.node(), expr_arena).collect::<Vec<_>>();
+    let minterms = MintermIter::new(predicate, expr_arena).collect::<Vec<_>>();
     if !minterms
         .iter()
-        .all(|node| is_fusable_predicate(*node, expr_arena))
+        .all(|node| can_fuse_predicate(*node, expr_arena))
     {
         return Ok(());
     }
@@ -114,21 +104,19 @@ fn try_fuse(
 
     let mut left_key_names: PlHashSet<PlSmallStr> = options
         .options
-        .key_pairs()
-        .into_iter()
-        .flatten()
-        .map(|(left, _)| left.output_name().clone())
+        .left_on()
+        .map(|key| key.output_name().clone())
         .collect();
     let mut right_key_names: PlHashSet<PlSmallStr> = options
         .options
-        .key_pairs()
-        .into_iter()
-        .flatten()
-        .map(|(_, right)| right.output_name().clone())
+        .right_on()
+        .map(|key| key.output_name().clone())
         .collect();
+
+    // Classify every minterm before rebuilding the two predicates from them.
     let mut promoted: Vec<(ExprIR, ExprIR)> = Vec::new();
-    let mut fused: Option<Node> = None;
-    let mut kept: Option<Node> = None;
+    let mut fused: UnitVec<Node> = unitvec![];
+    let mut kept: UnitVec<Node> = unitvec![];
     for minterm in minterms {
         // Coalescing on an inner join keeps the left name, so no right-join callback.
         let origin = ExprOrigin::get_expr_origin(
@@ -142,38 +130,43 @@ fn try_fuse(
 
         // Anything reading a single input is the existing pushdown's job.
         if !matches!(origin, ExprOrigin::Both) {
-            kept = Some(match kept.take() {
-                None => minterm,
-                Some(acc) => combine_by_and(acc, minterm, expr_arena),
-            });
+            kept.push(minterm);
             continue;
         }
 
         // An equality is cheaper as a key than as a residual.
-        if let Some(pair) = try_as_key_pair(
+        if let Some(pair) = as_key_pair(
             minterm,
             expr_arena,
             &left_schema,
             &right_schema,
             &options.args,
-            &suffix,
             &right_names,
-            &mut left_key_names,
-            &mut right_key_names,
         )? {
-            promoted.push(pair);
+            promoted.push(name_key_pair(
+                pair,
+                &options.args,
+                &left_schema,
+                &right_schema,
+                &mut left_key_names,
+                &mut right_key_names,
+            ));
             continue;
         }
 
-        fused = Some(match fused.take() {
-            None => minterm,
-            Some(acc) => combine_by_and(acc, minterm, expr_arena),
-        });
+        fused.push(minterm);
     }
 
-    if fused.is_none() && promoted.is_empty() {
+    if fused.is_empty() && promoted.is_empty() {
         return Ok(());
     }
+
+    let fused = fused
+        .into_iter()
+        .reduce(|left, right| combine_by_and(left, right, expr_arena));
+    let kept = kept
+        .into_iter()
+        .reduce(|left, right| combine_by_and(left, right, expr_arena));
 
     let options_mut = Arc::make_mut(&mut options);
     for (left, right) in promoted {
@@ -214,7 +207,7 @@ fn try_fuse(
 /// filter would have seen, so it must not fail or draw randomly on rows the query
 /// excludes. Fallibility is tracked per known function and does not cover every way an
 /// expression can raise, so this accepts only operations that cannot.
-fn is_promotable(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+fn can_promote_key(node: Node, expr_arena: &Arena<AExpr>) -> bool {
     expr_arena.iter(node).all(|(_, ae)| match ae {
         AExpr::Column(_) | AExpr::Literal(_) => true,
         AExpr::Cast { options, .. } => !options.is_strict(),
@@ -222,20 +215,17 @@ fn is_promotable(node: Node, expr_arena: &Arena<AExpr>) -> bool {
     })
 }
 
-/// Rewrite a both-sided equality minterm into a join key pair, if it is one.
+/// Read a both-sided equality minterm as a join key pair, if it is one.
 ///
-/// Keys are returned in their input namespaces, renamed where a coalescing join would
-/// otherwise drop the right payload column, or where two keys would share a name.
-fn try_as_key_pair(
+/// Keys come back in their input namespaces, carrying whatever name their expression
+/// gives them; [`name_key_pair`] settles the collisions that leaves.
+fn as_key_pair(
     minterm: Node,
     expr_arena: &mut Arena<AExpr>,
     left_schema: &Schema,
     right_schema: &Schema,
     args: &JoinArgs,
-    suffix: &str,
     right_names: &PlIndexMap<PlSmallStr, PlSmallStr>,
-    left_key_names: &mut PlHashSet<PlSmallStr>,
-    right_key_names: &mut PlHashSet<PlSmallStr>,
 ) -> PolarsResult<Option<(ExprIR, ExprIR)>> {
     // Validation counts the rows per key, which a promoted equality would change.
     if args.validation.needs_checks() {
@@ -258,6 +248,7 @@ fn try_as_key_pair(
         return Ok(None);
     }
 
+    let suffix = args.suffix();
     let left_origin =
         ExprOrigin::get_expr_origin(left, expr_arena, left_schema, right_schema, suffix, None)?;
     let right_origin =
@@ -268,7 +259,7 @@ fn try_as_key_pair(
         _ => return Ok(None),
     };
 
-    if !is_promotable(left_node, expr_arena) || !is_promotable(right_node, expr_arena) {
+    if !can_promote_key(left_node, expr_arena) || !can_promote_key(right_node, expr_arena) {
         return Ok(None);
     }
 
@@ -281,8 +272,8 @@ fn try_as_key_pair(
     }
     let right_node = rename_columns(right_node, expr_arena, right_names);
 
-    let mut left_key = ExprIR::from_node(left_node, expr_arena);
-    let mut right_key = ExprIR::from_node(right_node, expr_arena);
+    let left_key = ExprIR::from_node(left_node, expr_arena);
+    let right_key = ExprIR::from_node(right_node, expr_arena);
 
     // Key pairs are matched without coercion.
     if left_key.field(left_schema, expr_arena)?.dtype
@@ -291,11 +282,26 @@ fn try_as_key_pair(
         return Ok(None);
     }
 
+    Ok(Some((left_key, right_key)))
+}
+
+/// Aliases a promoted key pair away from the names already spoken for.
+///
+/// The taken sets grow as pairs are named, so two promotions cannot land on one name.
+fn name_key_pair(
+    (mut left_key, mut right_key): (ExprIR, ExprIR),
+    args: &JoinArgs,
+    left_schema: &Schema,
+    right_schema: &Schema,
+    left_key_names: &mut PlHashSet<PlSmallStr>,
+    right_key_names: &mut PlHashSet<PlSmallStr>,
+) -> (ExprIR, ExprIR) {
     if !left_key_names.insert(left_key.output_name().clone()) {
         let name = unique_key_name(left_key.output_name(), left_key_names, left_schema);
         left_key = ExprIR::new(left_key.node(), OutputName::Alias(name.clone()));
         left_key_names.insert(name);
     }
+
     // Coalescing drops the right payload column that shares a name with a right key.
     let right_name = right_key.output_name().clone();
     if args.should_coalesce() || !right_key_names.insert(right_name.clone()) {
@@ -303,7 +309,8 @@ fn try_as_key_pair(
         right_key = ExprIR::new(right_key.node(), OutputName::Alias(name.clone()));
         right_key_names.insert(name);
     }
-    Ok(Some((left_key, right_key)))
+
+    (left_key, right_key)
 }
 
 fn unique_key_name(base: &str, taken: &PlHashSet<PlSmallStr>, schema: &Schema) -> PlSmallStr {
@@ -313,7 +320,7 @@ fn unique_key_name(base: &str, taken: &PlHashSet<PlSmallStr>, schema: &Schema) -
         .unwrap()
 }
 
-/// Maps each right input column reachable in the join's output to its output name.
+/// Maps each right column reachable in the join's output back to its input name.
 ///
 /// A coalescing join drops the right key columns, and the rest take the join suffix where
 /// they collide with a left column, so an output name need not be the input name.

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -211,6 +211,31 @@ fn try_fuse(
 ///
 /// Keys are returned in their input namespaces, renamed where a coalescing join would
 /// otherwise drop the right payload column, or where two keys would share a name.
+/// Whether an expression is safe to evaluate on every input row.
+///
+/// A promoted key runs on all rows of its input, not only on the candidate pairs the
+/// filter would have seen, so it must not fail or draw randomly on rows the query
+/// excludes. Fallibility is tracked per known function and does not cover every way an
+/// expression can raise, so this accepts only operations that cannot.
+fn is_promotable(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    let mut stack: UnitVec<Node> = unitvec![node];
+
+    while let Some(node) = stack.pop() {
+        let ae = expr_arena.get(node);
+        let total = match ae {
+            AExpr::Column(_) | AExpr::Literal(_) => true,
+            AExpr::Cast { options, .. } => !options.is_strict(),
+            _ => false,
+        };
+        if !total {
+            return false;
+        }
+        ae.children_rev(&mut stack);
+    }
+
+    true
+}
+
 fn try_as_key_pair(
     minterm: Node,
     expr_arena: &mut Arena<AExpr>,
@@ -252,6 +277,10 @@ fn try_as_key_pair(
         (ExprOrigin::Right, ExprOrigin::Left) => (right, left),
         _ => return Ok(None),
     };
+
+    if !is_promotable(left_node, expr_arena) || !is_promotable(right_node, expr_arena) {
+        return Ok(None);
+    }
 
     // The right side is in the join's output namespace, where a name can belong to a
     // different input column than the one it shares a name with.

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -1,0 +1,314 @@
+use std::sync::Arc;
+
+use polars_core::error::PolarsResult;
+use polars_core::prelude::Schema;
+use polars_ops::frame::JoinArgs;
+use polars_utils::aliases::PlHashSet;
+use polars_utils::arena::{Arena, Node};
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::{format_pl_smallstr, unitvec};
+
+use super::join_utils::{ExprOrigin, remove_suffix};
+use super::predicate_pushdown::utils::{combine_by_and, contains_dynamic_pred};
+use crate::dsl::Operator;
+use crate::plans::options::JoinTypeOptionsIR;
+use crate::plans::{
+    AExpr, ExprIR, ExprPushdownGroup, IR, JoinOptionsIR, JoinType, MintermIter, OutputName,
+    is_row_separable_rec,
+};
+
+/// Visit every node reachable from `root` once, parents before their inputs.
+fn for_each_ir_node(
+    root: Node,
+    ir_arena: &mut Arena<IR>,
+    mut visit: impl FnMut(Node, &mut Arena<IR>) -> PolarsResult<()>,
+) -> PolarsResult<()> {
+    let mut stack: UnitVec<Node> = unitvec![root];
+    let mut seen = PlHashSet::default();
+
+    while let Some(node) = stack.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        ir_arena.get(node).copy_inputs(&mut stack);
+        visit(node, ir_arena)?;
+    }
+
+    Ok(())
+}
+
+/// Split fused residuals back out into a `Filter` above their join.
+///
+/// Undoes [`fuse_residual_predicates`] for optimized IR that re-enters the optimizer.
+pub(super) fn unfuse_residual_joins(root: Node, ir_arena: &mut Arena<IR>) -> PolarsResult<()> {
+    for_each_ir_node(root, ir_arena, |node, ir_arena| {
+        let IR::Join { options, .. } = ir_arena.get(node) else {
+            return Ok(());
+        };
+        if !options.options.has_residual() {
+            return Ok(());
+        }
+
+        let mut join = ir_arena.get(node).clone();
+        let IR::Join { options, .. } = &mut join else {
+            unreachable!()
+        };
+        let residual = Arc::make_mut(options).options.take_residual().unwrap();
+
+        // The join moves to a fresh node so `node` keeps holding whatever the parents
+        // already point at.
+        let join = ir_arena.add(join);
+        ir_arena.replace(
+            node,
+            IR::Filter {
+                input: join,
+                predicate: residual,
+            },
+        );
+        Ok(())
+    })
+}
+
+/// Fuse `Filter(join)` predicates that span both inputs into the join's match condition.
+pub(super) fn fuse_residual_predicates(
+    root: Node,
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<()> {
+    for_each_ir_node(root, ir_arena, |node, ir_arena| {
+        try_fuse(node, ir_arena, expr_arena)
+    })
+}
+
+/// A residual is only sound on an inner equi join, and a slice must stay above the filter
+/// that feeds it.
+fn is_fusable_join(options: &JoinOptionsIR) -> bool {
+    matches!(options.args.how, JoinType::Inner)
+        && options.args.slice.is_none()
+        && matches!(
+            &options.options,
+            JoinTypeOptionsIR::Equi { on, residual: None } if !on.is_empty()
+        )
+}
+
+/// Elementwise and infallible, so the join can evaluate it per candidate pair.
+fn is_fusable_predicate(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    let mut group = ExprPushdownGroup::Pushable;
+    group.update_with_expr_rec(expr_arena.get(node), expr_arena, None);
+
+    matches!(group, ExprPushdownGroup::Pushable)
+        && is_row_separable_rec(node, expr_arena)
+        && !contains_dynamic_pred(node, expr_arena)
+}
+
+fn try_fuse(
+    node: Node,
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<()> {
+    let IR::Filter { input, predicate } = ir_arena.get(node) else {
+        return Ok(());
+    };
+    let (input, predicate) = (*input, predicate.clone());
+
+    let IR::Join {
+        input_left,
+        input_right,
+        schema,
+        options,
+    } = ir_arena.get(input)
+    else {
+        return Ok(());
+    };
+    if !is_fusable_join(options) {
+        return Ok(());
+    }
+    let (input_left, input_right, schema, mut options) =
+        (*input_left, *input_right, schema.clone(), options.clone());
+
+    // A single unfusable term leaves the whole filter alone.
+    let minterms = MintermIter::new(predicate.node(), expr_arena).collect::<Vec<_>>();
+    if !minterms
+        .iter()
+        .all(|node| is_fusable_predicate(*node, expr_arena))
+    {
+        return Ok(());
+    }
+
+    let left_schema = ir_arena.get(input_left).schema(ir_arena).into_owned();
+    let right_schema = ir_arena.get(input_right).schema(ir_arena).into_owned();
+    let suffix = options.args.suffix().clone();
+
+    let mut left_key_names: PlHashSet<PlSmallStr> = options
+        .options
+        .key_pairs()
+        .into_iter()
+        .flatten()
+        .map(|(left, _)| left.output_name().clone())
+        .collect();
+    let mut right_key_names: PlHashSet<PlSmallStr> = options
+        .options
+        .key_pairs()
+        .into_iter()
+        .flatten()
+        .map(|(_, right)| right.output_name().clone())
+        .collect();
+    let mut promoted: Vec<(ExprIR, ExprIR)> = Vec::new();
+    let mut fused: Option<Node> = None;
+    let mut kept: Option<Node> = None;
+    for minterm in minterms {
+        // Coalescing on an inner join keeps the left name, so no right-join callback.
+        let origin = ExprOrigin::get_expr_origin(
+            minterm,
+            expr_arena,
+            &left_schema,
+            &right_schema,
+            &suffix,
+            None,
+        )?;
+
+        // Anything reading a single input is the existing pushdown's job.
+        if !matches!(origin, ExprOrigin::Both) {
+            kept = Some(match kept.take() {
+                None => minterm,
+                Some(acc) => combine_by_and(acc, minterm, expr_arena),
+            });
+            continue;
+        }
+
+        // An equality is cheaper as a key than as a residual.
+        if let Some(pair) = try_as_key_pair(
+            minterm,
+            expr_arena,
+            &left_schema,
+            &right_schema,
+            &options.args,
+            &suffix,
+            &mut left_key_names,
+            &mut right_key_names,
+        )? {
+            promoted.push(pair);
+            continue;
+        }
+
+        fused = Some(match fused.take() {
+            None => minterm,
+            Some(acc) => combine_by_and(acc, minterm, expr_arena),
+        });
+    }
+
+    if fused.is_none() && promoted.is_empty() {
+        return Ok(());
+    }
+
+    let options_mut = Arc::make_mut(&mut options);
+    for (left, right) in promoted {
+        options_mut.options.push_key_pair(left, right);
+    }
+    if let Some(fused) = fused {
+        options_mut
+            .options
+            .set_residual(ExprIR::from_node(fused, expr_arena));
+    }
+    let join = IR::Join {
+        input_left,
+        input_right,
+        schema,
+        options,
+    };
+
+    // The fused join replaces the filter rather than the original join node, which other
+    // branches may still reference with a different filter above it.
+    let fused_node = match kept {
+        None => join,
+        Some(kept) => {
+            let join = ir_arena.add(join);
+            IR::Filter {
+                input: join,
+                predicate: ExprIR::from_node(kept, expr_arena),
+            }
+        },
+    };
+    ir_arena.replace(node, fused_node);
+
+    Ok(())
+}
+
+/// Rewrite a both-sided equality minterm into a join key pair, if it is one.
+///
+/// Keys are returned in their input namespaces, renamed where a coalescing join would
+/// otherwise drop the right payload column, or where two keys would share a name.
+fn try_as_key_pair(
+    minterm: Node,
+    expr_arena: &mut Arena<AExpr>,
+    left_schema: &Schema,
+    right_schema: &Schema,
+    args: &JoinArgs,
+    suffix: &str,
+    left_key_names: &mut PlHashSet<PlSmallStr>,
+    right_key_names: &mut PlHashSet<PlSmallStr>,
+) -> PolarsResult<Option<(ExprIR, ExprIR)>> {
+    // Validation counts the rows per key, which a promoted equality would change.
+    if args.validation.needs_checks() {
+        return Ok(None);
+    }
+
+    let AExpr::BinaryExpr { left, op, right } = expr_arena.get(minterm) else {
+        return Ok(None);
+    };
+    let (left, right) = (*left, *right);
+
+    // A key pair matches nulls only when `nulls_equal` is set; `==` never does and
+    // `eq_missing` always does.
+    let matches_nulls = match op {
+        Operator::Eq => false,
+        Operator::EqValidity => true,
+        _ => return Ok(None),
+    };
+    if matches_nulls != args.nulls_equal {
+        return Ok(None);
+    }
+
+    let left_origin =
+        ExprOrigin::get_expr_origin(left, expr_arena, left_schema, right_schema, suffix, None)?;
+    let right_origin =
+        ExprOrigin::get_expr_origin(right, expr_arena, left_schema, right_schema, suffix, None)?;
+    let (left_node, right_node) = match (left_origin, right_origin) {
+        (ExprOrigin::Left, ExprOrigin::Right) => (left, right),
+        (ExprOrigin::Right, ExprOrigin::Left) => (right, left),
+        _ => return Ok(None),
+    };
+
+    let mut left_key = ExprIR::from_node(left_node, expr_arena);
+    let mut right_key = ExprIR::from_node(right_node, expr_arena);
+    remove_suffix(&mut right_key, expr_arena, right_schema, suffix);
+
+    // Key pairs are matched without coercion.
+    if left_key.field(left_schema, expr_arena)?.dtype
+        != right_key.field(right_schema, expr_arena)?.dtype
+    {
+        return Ok(None);
+    }
+
+    if !left_key_names.insert(left_key.output_name().clone()) {
+        let name = unique_key_name(left_key.output_name(), left_key_names, left_schema);
+        left_key = ExprIR::new(left_key.node(), OutputName::Alias(name.clone()));
+        left_key_names.insert(name);
+    }
+    // Coalescing drops the right payload column that shares a name with a right key.
+    let right_name = right_key.output_name().clone();
+    if args.should_coalesce() || !right_key_names.insert(right_name.clone()) {
+        let name = unique_key_name(&right_name, right_key_names, right_schema);
+        right_key = ExprIR::new(right_key.node(), OutputName::Alias(name.clone()));
+        right_key_names.insert(name);
+    }
+    Ok(Some((left_key, right_key)))
+}
+
+fn unique_key_name(base: &str, taken: &PlHashSet<PlSmallStr>, schema: &Schema) -> PlSmallStr {
+    (0..)
+        .map(|i| format_pl_smallstr!("__POLARS_JOIN_KEY_{i}_{base}"))
+        .find(|name| !taken.contains(name) && !schema.contains(name))
+        .unwrap()
+}

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -12,6 +12,7 @@ use polars_utils::{format_pl_smallstr, unitvec};
 use super::join_utils::ExprOrigin;
 use super::predicate_pushdown::utils::{combine_by_and, contains_dynamic_pred};
 use crate::dsl::Operator;
+use crate::plans::iterator::ArenaExprIter;
 use crate::plans::options::JoinTypeOptionsIR;
 use crate::plans::{
     AExpr, ExprIR, ExprPushdownGroup, IR, JoinOptionsIR, JoinType, MintermIter, OutputName,
@@ -207,10 +208,6 @@ fn try_fuse(
     Ok(())
 }
 
-/// Rewrite a both-sided equality minterm into a join key pair, if it is one.
-///
-/// Keys are returned in their input namespaces, renamed where a coalescing join would
-/// otherwise drop the right payload column, or where two keys would share a name.
 /// Whether an expression is safe to evaluate on every input row.
 ///
 /// A promoted key runs on all rows of its input, not only on the candidate pairs the
@@ -218,24 +215,17 @@ fn try_fuse(
 /// excludes. Fallibility is tracked per known function and does not cover every way an
 /// expression can raise, so this accepts only operations that cannot.
 fn is_promotable(node: Node, expr_arena: &Arena<AExpr>) -> bool {
-    let mut stack: UnitVec<Node> = unitvec![node];
-
-    while let Some(node) = stack.pop() {
-        let ae = expr_arena.get(node);
-        let total = match ae {
-            AExpr::Column(_) | AExpr::Literal(_) => true,
-            AExpr::Cast { options, .. } => !options.is_strict(),
-            _ => false,
-        };
-        if !total {
-            return false;
-        }
-        ae.children_rev(&mut stack);
-    }
-
-    true
+    expr_arena.iter(node).all(|(_, ae)| match ae {
+        AExpr::Column(_) | AExpr::Literal(_) => true,
+        AExpr::Cast { options, .. } => !options.is_strict(),
+        _ => false,
+    })
 }
 
+/// Rewrite a both-sided equality minterm into a join key pair, if it is one.
+///
+/// Keys are returned in their input namespaces, renamed where a coalescing join would
+/// otherwise drop the right payload column, or where two keys would share a name.
 fn try_as_key_pair(
     minterm: Node,
     expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-plan/src/plans/optimizer/residual_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/residual_join.rs
@@ -39,38 +39,6 @@ fn for_each_ir_node(
     Ok(())
 }
 
-/// Split fused residuals back out into a `Filter` above their join.
-///
-/// Undoes [`fuse_residual_predicates`] for optimized IR that re-enters the optimizer.
-pub(super) fn unfuse_residual_joins(root: Node, ir_arena: &mut Arena<IR>) -> PolarsResult<()> {
-    for_each_ir_node(root, ir_arena, |node, ir_arena| {
-        let IR::Join { options, .. } = ir_arena.get(node) else {
-            return Ok(());
-        };
-        if !options.options.has_residual() {
-            return Ok(());
-        }
-
-        let mut join = ir_arena.get(node).clone();
-        let IR::Join { options, .. } = &mut join else {
-            unreachable!()
-        };
-        let residual = Arc::make_mut(options).options.take_residual().unwrap();
-
-        // The join moves to a fresh node so `node` keeps holding whatever the parents
-        // already point at.
-        let join = ir_arena.add(join);
-        ir_arena.replace(
-            node,
-            IR::Filter {
-                input: join,
-                predicate: residual,
-            },
-        );
-        Ok(())
-    })
-}
-
 /// Fuse `Filter(join)` predicates that span both inputs into the join's match condition.
 pub(super) fn fuse_residual_predicates(
     root: Node,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -503,7 +503,9 @@ impl SlicePushDown {
                     mut options,
                 },
                 Some(state),
-            ) if !matches!(options.options, JoinTypeOptionsIR::CrossAndFilter { .. }) => {
+            ) if !matches!(options.options, JoinTypeOptionsIR::CrossAndFilter { .. })
+                && !options.options.has_residual() =>
+            {
                 if let Some(existing_slice) = &mut Arc::make_mut(&mut options).args.slice {
                     return if let Some(combined) = combine_outer_inner_slice(
                         state,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -504,7 +504,7 @@ impl SlicePushDown {
                 },
                 Some(state),
             ) if !matches!(options.options, JoinTypeOptionsIR::CrossAndFilter { .. })
-                && !options.options.has_residual() =>
+                && !options.options.has_fused_predicate() =>
             {
                 if let Some(existing_slice) = &mut Arc::make_mut(&mut options).args.slice {
                     return if let Some(combined) = combine_outer_inner_slice(

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -757,13 +757,6 @@ impl JoinTypeOptionsIR {
         }
     }
 
-    pub(crate) fn take_residual(&mut self) -> Option<ExprIR> {
-        match self {
-            Self::Equi { residual, .. } => residual.take(),
-            _ => None,
-        }
-    }
-
     pub(crate) fn push_key_pair(&mut self, left: ExprIR, right: ExprIR) {
         let Self::Equi { on, .. } = self else {
             panic!("key pairs can only be added to equi joins")

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -365,10 +365,13 @@ impl JoinOptionsIR {
 
         let how = &self.args.how;
         let supported = match &self.options {
-            Equi { residual: None, .. } => true,
+            Equi {
+                fused_predicate: None,
+                ..
+            } => true,
             Equi {
                 on,
-                residual: Some(_),
+                fused_predicate: Some(_),
             } => how.is_inner() && !on.is_empty() && self.args.slice.is_none(),
             #[cfg(feature = "asof_join")]
             AsOf { .. } => how.is_asof(),
@@ -433,7 +436,7 @@ impl JoinOptionsIR {
 #[strum(serialize_all = "snake_case")]
 pub enum JoinTypeOptionsIR {
     /// The match condition is `left == right` for every key pair, and, if there is a
-    /// `residual`, that predicate as well.
+    /// `fused_predicate`, that predicate as well.
     ///
     /// An empty `on` is a plain cross join.
     Equi {
@@ -442,7 +445,7 @@ pub enum JoinTypeOptionsIR {
         /// candidate pair. A pair survives only on `true`; `false` and null reject it.
         ///
         /// Only ever set on an inner join with a non-empty `on` and no attached slice.
-        residual: Option<ExprIR>,
+        fused_predicate: Option<ExprIR>,
     },
     /// Backwards/forwards/nearest match on a single key pair. The strategy, tolerance
     /// and `by` group keys live in [`JoinType::AsOf`].
@@ -480,7 +483,7 @@ impl Default for JoinTypeOptionsIR {
     fn default() -> Self {
         Self::Equi {
             on: Vec::new(),
-            residual: None,
+            fused_predicate: None,
         }
     }
 }
@@ -565,12 +568,12 @@ impl JoinTypeOptionsIR {
                 Ok(Some(JoinTypeOptions::IEJoin(ie_options)))
             },
             Equi {
-                residual: Some(residual),
+                fused_predicate: Some(fused_predicate),
                 ..
             } => {
-                let predicate = plan(&residual)?;
+                let predicate = plan(&fused_predicate)?;
 
-                Ok(Some(JoinTypeOptions::Residual(CrossJoinOptions {
+                Ok(Some(JoinTypeOptions::FusedPredicate(CrossJoinOptions {
                     predicate,
                 })))
             },
@@ -663,8 +666,12 @@ impl JoinTypeOptionsIR {
     ///
     /// The order must stay in sync with [`Self::exprs_mut`].
     pub fn exprs(&self) -> Exprs<'_> {
-        if let Self::Equi { on, residual } = self {
-            return Exprs::pair_sides_then(on, residual.as_ref());
+        if let Self::Equi {
+            on,
+            fused_predicate,
+        } = self
+        {
+            return Exprs::pair_sides_then(on, fused_predicate.as_ref());
         }
         if let Some(on) = self.key_pairs() {
             return Exprs::pair_sides(on);
@@ -685,8 +692,12 @@ impl JoinTypeOptionsIR {
     /// See [`Self::exprs`]. Yields in the same order.
     pub fn exprs_mut(&mut self) -> ExprsMut<'_> {
         // Checked first so the mutable borrow does not span the match below.
-        if let Self::Equi { on, residual } = self {
-            return ExprsMut::pair_sides_then(on, residual.as_mut());
+        if let Self::Equi {
+            on,
+            fused_predicate,
+        } = self
+        {
+            return ExprsMut::pair_sides_then(on, fused_predicate.as_mut());
         }
         if self.key_pairs().is_some() {
             return ExprsMut::pair_sides(self.key_pairs_mut().unwrap());
@@ -732,27 +743,29 @@ impl JoinTypeOptionsIR {
     /// The match condition is exactly `left == right` for every key pair.
     ///
     /// True for [`Self::AsOf`] too: its strategy and tolerance live in [`JoinType::AsOf`],
-    /// not in the match condition. False once a residual is attached.
+    /// not in the match condition. False once a fused predicate is attached.
     pub fn is_pure_equi(&self) -> bool {
         !self.is_non_equi()
     }
 
     /// The match condition has a non-equality component.
     ///
-    /// Use [`Self::key_pairs`] instead where what is needed is paired keys: a residual
+    /// Use [`Self::key_pairs`] instead where what is needed is paired keys: a fused predicate
     /// join has those as well.
     pub fn is_non_equi(&self) -> bool {
-        self.key_pairs().is_none() || self.has_residual()
+        self.key_pairs().is_none() || self.has_fused_predicate()
     }
 
-    pub fn has_residual(&self) -> bool {
-        self.residual().is_some()
+    pub fn has_fused_predicate(&self) -> bool {
+        self.fused_predicate().is_some()
     }
 
     /// The fused match condition, if any. See [`Self::Equi`].
-    pub fn residual(&self) -> Option<&ExprIR> {
+    pub fn fused_predicate(&self) -> Option<&ExprIR> {
         match self {
-            Self::Equi { residual, .. } => residual.as_ref(),
+            Self::Equi {
+                fused_predicate, ..
+            } => fused_predicate.as_ref(),
             _ => None,
         }
     }
@@ -764,12 +777,18 @@ impl JoinTypeOptionsIR {
         on.push((left, right));
     }
 
-    pub(crate) fn set_residual(&mut self, new: ExprIR) {
-        let Self::Equi { residual, .. } = self else {
-            panic!("residuals are only supported on equi joins")
+    pub(crate) fn set_fused_predicate(&mut self, new: ExprIR) {
+        let Self::Equi {
+            fused_predicate, ..
+        } = self
+        else {
+            panic!("a fused predicate is only supported on equi joins")
         };
-        assert!(residual.is_none(), "residual would be overwritten");
-        *residual = Some(new);
+        assert!(
+            fused_predicate.is_none(),
+            "fused_predicate would be overwritten"
+        );
+        *fused_predicate = Some(new);
     }
 }
 

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -394,10 +394,18 @@ impl JoinOptionsIR {
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
 #[strum(serialize_all = "snake_case")]
 pub enum JoinTypeOptionsIR {
-    /// The match condition is `left == right` for every key pair.
+    /// The match condition is `left == right` for every key pair, and, if there is a
+    /// `residual`, that predicate as well.
     ///
     /// An empty `on` is a plain cross join.
-    Equi { on: Vec<(ExprIR, ExprIR)> },
+    Equi {
+        on: Vec<(ExprIR, ExprIR)>,
+        /// Boolean match condition in the join's output namespace, evaluated per
+        /// candidate pair. A pair survives only on `true`; `false` and null reject it.
+        ///
+        /// Only ever set on an inner join with a non-empty `on` and no attached slice.
+        residual: Option<ExprIR>,
+    },
     /// Backwards/forwards/nearest match on a single key pair. The strategy, tolerance
     /// and `by` group keys live in [`JoinType::AsOf`].
     #[cfg(feature = "asof_join")]
@@ -432,7 +440,10 @@ pub enum JoinTypeOptionsIR {
 
 impl Default for JoinTypeOptionsIR {
     fn default() -> Self {
-        Self::Equi { on: Vec::new() }
+        Self::Equi {
+            on: Vec::new(),
+            residual: None,
+        }
     }
 }
 
@@ -515,6 +526,16 @@ impl JoinTypeOptionsIR {
             IEJoin { ie_options, .. } | Range { ie_options, .. } => {
                 Ok(Some(JoinTypeOptions::IEJoin(ie_options)))
             },
+            Equi {
+                residual: Some(residual),
+                ..
+            } => {
+                let predicate = plan(&residual)?;
+
+                Ok(Some(JoinTypeOptions::Residual(CrossJoinOptions {
+                    predicate,
+                })))
+            },
             Equi { .. } => Ok(None),
             #[cfg(feature = "asof_join")]
             AsOf { .. } => Ok(None),
@@ -527,7 +548,7 @@ impl JoinTypeOptionsIR {
     /// They cannot share an or-pattern arm because rustc rejects `#[cfg]` on one alternative.
     pub fn key_pairs(&self) -> Option<&[(ExprIR, ExprIR)]> {
         match self {
-            Self::Equi { on } => Some(on),
+            Self::Equi { on, .. } => Some(on),
             #[cfg(feature = "asof_join")]
             Self::AsOf { on } => Some(on),
             _ => None,
@@ -537,7 +558,7 @@ impl JoinTypeOptionsIR {
     /// See [`Self::key_pairs`].
     fn key_pairs_mut(&mut self) -> Option<&mut Vec<(ExprIR, ExprIR)>> {
         match self {
-            Self::Equi { on } => Some(on),
+            Self::Equi { on, .. } => Some(on),
             #[cfg(feature = "asof_join")]
             Self::AsOf { on } => Some(on),
             _ => None,
@@ -604,6 +625,9 @@ impl JoinTypeOptionsIR {
     ///
     /// The order must stay in sync with [`Self::exprs_mut`].
     pub fn exprs(&self) -> Exprs<'_> {
+        if let Self::Equi { on, residual } = self {
+            return Exprs::pair_sides_then(on, residual.as_ref());
+        }
         if let Some(on) = self.key_pairs() {
             return Exprs::pair_sides(on);
         }
@@ -623,6 +647,9 @@ impl JoinTypeOptionsIR {
     /// See [`Self::exprs`]. Yields in the same order.
     pub fn exprs_mut(&mut self) -> ExprsMut<'_> {
         // Checked first so the mutable borrow does not span the match below.
+        if let Self::Equi { on, residual } = self {
+            return ExprsMut::pair_sides_then(on, residual.as_mut());
+        }
         if self.key_pairs().is_some() {
             return ExprsMut::pair_sides(self.key_pairs_mut().unwrap());
         }
@@ -667,14 +694,51 @@ impl JoinTypeOptionsIR {
     /// The match condition is exactly `left == right` for every key pair.
     ///
     /// True for [`Self::AsOf`] too: its strategy and tolerance live in [`JoinType::AsOf`],
-    /// not in the match condition.
+    /// not in the match condition. False once a residual is attached.
     pub fn is_pure_equi(&self) -> bool {
         !self.is_non_equi()
     }
 
     /// The match condition has a non-equality component.
+    ///
+    /// Use [`Self::key_pairs`] instead where what is needed is paired keys: a residual
+    /// join has those as well.
     pub fn is_non_equi(&self) -> bool {
-        self.key_pairs().is_none()
+        self.key_pairs().is_none() || self.has_residual()
+    }
+
+    pub fn has_residual(&self) -> bool {
+        self.residual().is_some()
+    }
+
+    /// The fused match condition, if any. See [`Self::Equi`].
+    pub fn residual(&self) -> Option<&ExprIR> {
+        match self {
+            Self::Equi { residual, .. } => residual.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn take_residual(&mut self) -> Option<ExprIR> {
+        match self {
+            Self::Equi { residual, .. } => residual.take(),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn push_key_pair(&mut self, left: ExprIR, right: ExprIR) {
+        let Self::Equi { on, .. } = self else {
+            panic!("key pairs can only be added to equi joins")
+        };
+        on.push((left, right));
+    }
+
+    pub(crate) fn set_residual(&mut self, new: ExprIR) {
+        let Self::Equi { residual, .. } = self else {
+            panic!("residuals are only supported on equi joins")
+        };
+        assert!(residual.is_none(), "residual would be overwritten");
+        *residual = Some(new);
     }
 }
 

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -5,7 +5,7 @@ use polars_core::prelude::*;
 use polars_core::utils::SuperTypeOptions;
 #[cfg(feature = "iejoin")]
 use polars_ops::frame::IEJoinOptions;
-use polars_ops::frame::{CrossJoinFilter, CrossJoinOptions, JoinArgs, JoinTypeOptions};
+use polars_ops::frame::{CrossJoinFilter, CrossJoinOptions, JoinArgs, JoinType, JoinTypeOptions};
 use polars_utils::bool::UnsafeBool;
 use polars_utils::itertools::Itertools;
 #[cfg(feature = "serde")]
@@ -354,6 +354,44 @@ impl JoinOptionsIR {
     /// The match condition has a non-equality component, held in `options`.
     pub fn is_non_equi(&self) -> bool {
         self.options.is_non_equi()
+    }
+
+    /// Errors if no engine can execute this `args.how` with this match condition.
+    ///
+    /// Whether a non-equi condition ends up executable depends on how far the optimizer
+    /// managed to lower it, so this can only be answered once the plan is optimized.
+    pub fn ensure_executable(&self) -> PolarsResult<()> {
+        use JoinTypeOptionsIR::*;
+
+        let how = &self.args.how;
+        let supported = match &self.options {
+            Equi { residual: None, .. } => true,
+            Equi {
+                on,
+                residual: Some(_),
+            } => how.is_inner() && !on.is_empty() && self.args.slice.is_none(),
+            #[cfg(feature = "asof_join")]
+            AsOf { .. } => how.is_asof(),
+            #[cfg(feature = "iejoin")]
+            IEJoin { .. } | Range { .. } => {
+                how.is_ie()
+                    || how.is_range()
+                    || how.is_inner()
+                    || how.is_cross()
+                    || matches!(how, JoinType::Left | JoinType::Right)
+            },
+            CrossAndFilter { .. } => {
+                how.is_inner() || how.is_cross() || matches!(how, JoinType::Left)
+            },
+        };
+
+        polars_ensure!(
+            supported,
+            InvalidOperation:
+            "'{}' join is not supported with non-equi join conditions",
+            how,
+        );
+        Ok(())
     }
 
     pub(crate) fn shallow_eq(&self, other: &Self, expr_cmp: &impl ExpressionComparator) -> bool {

--- a/crates/polars-plan/src/plans/stats/node.rs
+++ b/crates/polars-plan/src/plans/stats/node.rs
@@ -206,7 +206,7 @@ pub(super) fn node_stats_with_cache(
             ..
         } => {
             // As-of, inequality and range matches are not modelled.
-            let JoinTypeOptionsIR::Equi { on } = &options.options else {
+            let JoinTypeOptionsIR::Equi { on, residual } = &options.options else {
                 return None;
             };
             let left = node_stats_with_cache(*input_left, ir_arena, expr_arena, cache)?;
@@ -232,6 +232,23 @@ pub(super) fn node_stats_with_cache(
                 max_rows: join_max_rows(how, &left, &right),
                 columns: join_columns(&left, &right),
             };
+
+            // Only narrows `filtered`; an estimated selectivity is not an upper bound, so
+            // `max_rows` and the key-domain columns are carried over untouched.
+            let stats = match residual {
+                None => stats,
+                Some(residual) => {
+                    let filtered = apply_predicate(
+                        stats.filtered,
+                        stats.unfiltered,
+                        residual.node(),
+                        expr_arena,
+                        stats.columns.as_deref(),
+                    );
+                    stats.filter(filtered)
+                },
+            };
+
             Some(match options.args.slice {
                 None => stats,
                 Some(slice) => stats.slice(slice),

--- a/crates/polars-plan/src/plans/stats/node.rs
+++ b/crates/polars-plan/src/plans/stats/node.rs
@@ -206,7 +206,11 @@ pub(super) fn node_stats_with_cache(
             ..
         } => {
             // As-of, inequality and range matches are not modelled.
-            let JoinTypeOptionsIR::Equi { on, residual } = &options.options else {
+            let JoinTypeOptionsIR::Equi {
+                on,
+                fused_predicate,
+            } = &options.options
+            else {
                 return None;
             };
             let left = node_stats_with_cache(*input_left, ir_arena, expr_arena, cache)?;
@@ -235,13 +239,13 @@ pub(super) fn node_stats_with_cache(
 
             // Only narrows `filtered`; an estimated selectivity is not an upper bound, so
             // `max_rows` and the key-domain columns are carried over untouched.
-            let stats = match residual {
+            let stats = match fused_predicate {
                 None => stats,
-                Some(residual) => {
+                Some(fused_predicate) => {
                     let filtered = apply_predicate(
                         stats.filtered,
                         stats.unfiltered,
-                        residual.node(),
+                        fused_predicate.node(),
                         expr_arena,
                         stats.columns.as_deref(),
                     );

--- a/crates/polars-plan/src/plans/to_description.rs
+++ b/crates/polars-plan/src/plans/to_description.rs
@@ -184,10 +184,10 @@ pub fn ir_props(ir: &IR, expr_arena: &Arena<AExpr>) -> IrPropsDescription {
                 how: args.how.to_string(),
                 left_on: fmt_exprs(&left_on, expr_arena),
                 right_on: fmt_exprs(&right_on, expr_arena),
-                residual: o
+                fused_predicate: o
                     .options
-                    .residual()
-                    .map(|residual| fmt_predicate(residual, expr_arena)),
+                    .fused_predicate()
+                    .map(|fused_predicate| fmt_predicate(fused_predicate, expr_arena)),
                 nulls_equal: args.nulls_equal,
                 coalesce: fmt_from_static_str(args.coalesce),
                 maintain_order: fmt_from_static_str(args.maintain_order),

--- a/crates/polars-plan/src/plans/to_description.rs
+++ b/crates/polars-plan/src/plans/to_description.rs
@@ -184,6 +184,10 @@ pub fn ir_props(ir: &IR, expr_arena: &Arena<AExpr>) -> IrPropsDescription {
                 how: args.how.to_string(),
                 left_on: fmt_exprs(&left_on, expr_arena),
                 right_on: fmt_exprs(&right_on, expr_arena),
+                residual: o
+                    .options
+                    .residual()
+                    .map(|residual| fmt_predicate(residual, expr_arena)),
                 nulls_equal: args.nulls_equal,
                 coalesce: fmt_from_static_str(args.coalesce),
                 maintain_order: fmt_from_static_str(args.maintain_order),

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -631,9 +631,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
                             JoinType::Cross if options.is_non_equi() => {
                                 return Err(PyNotImplementedError::new_err("nested loop join"));
                             },
-                            _ if options.options.has_residual() => {
+                            _ if options.options.has_fused_predicate() => {
                                 return Err(PyNotImplementedError::new_err(
-                                    "join with a residual predicate",
+                                    "join with a fused predicate",
                                 ));
                             },
                             _ => name.into_any().unbind(),

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -631,6 +631,11 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
                             JoinType::Cross if options.is_non_equi() => {
                                 return Err(PyNotImplementedError::new_err("nested loop join"));
                             },
+                            _ if options.options.has_residual() => {
+                                return Err(PyNotImplementedError::new_err(
+                                    "join with a residual predicate",
+                                ));
+                            },
                             _ => name.into_any().unbind(),
                         },
                         options.args.nulls_equal,

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -32,27 +32,27 @@ use crate::morsel::{SourceToken, get_ideal_morsel_size};
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::in_memory_source::InMemorySourceNode;
 
-/// Where one of the residual's input columns is found at probe time.
-struct ResidualColumn {
+/// Where one of the fused predicate's input columns is found at probe time.
+struct FusedColumn {
     is_left: bool,
     /// Index into that side's payload.
     index: usize,
 }
 
 /// One side of the candidate pairs: the rows to gather from, and the indices into them.
-struct ResidualSide<'a> {
+struct MatchSide<'a> {
     payload: &'a DataFrame,
     matches: &'a mut [IdxSize],
 }
 
 /// A match condition on top of the equi keys, applied to candidate pairs.
-struct ResidualPredicate {
+struct FusedPredicate {
     expr: StreamExpr,
     /// The columns the predicate reads, in the order it was compiled against.
-    columns: Vec<ResidualColumn>,
+    columns: Vec<FusedColumn>,
 }
 
-impl ResidualPredicate {
+impl FusedPredicate {
     fn new(
         expr: StreamExpr,
         schema: &Schema,
@@ -64,19 +64,19 @@ impl ResidualPredicate {
             .map(|name| {
                 // Payload schemas are keyed by output name.
                 let column = if let Some(index) = left_payload_schema.index_of(name) {
-                    ResidualColumn {
+                    FusedColumn {
                         is_left: true,
                         index,
                     }
                 } else if let Some(index) = right_payload_schema.index_of(name) {
-                    ResidualColumn {
+                    FusedColumn {
                         is_left: false,
                         index,
                     }
                 } else {
                     polars_bail!(
                         ColumnNotFound:
-                        "join residual reads '{name}', which the join does not output"
+                        "fused predicate reads '{name}', which the join does not output"
                     )
                 };
                 Ok(column)
@@ -93,15 +93,15 @@ impl ResidualPredicate {
     async fn retain_matches(
         &self,
         left_is_build: bool,
-        build: ResidualSide<'_>,
-        probe: ResidualSide<'_>,
+        build: MatchSide<'_>,
+        probe: MatchSide<'_>,
         state: &ExecutionState,
     ) -> PolarsResult<usize> {
-        let ResidualSide {
+        let MatchSide {
             payload: build_payload,
             matches: build_match,
         } = build;
-        let ResidualSide {
+        let MatchSide {
             payload: probe_payload,
             matches: probe_match,
         } = probe;
@@ -189,7 +189,7 @@ struct EquiJoinParams {
     left_payload_schema: Arc<Schema>,
     right_payload_schema: Arc<Schema>,
     args: JoinArgs,
-    residual: Option<ResidualPredicate>,
+    fused_predicate: Option<FusedPredicate>,
     random_state: PlRandomState,
     sample_limit: usize,
 }
@@ -942,7 +942,7 @@ impl ProbeState {
         let probe_limit = get_ideal_morsel_size() as IdxSize;
         let mark_matches = params.emit_unmatched_build();
         let emit_unmatched = params.emit_unmatched_probe();
-        assert!(params.residual.is_none() || (!mark_matches && !emit_unmatched));
+        assert!(params.fused_predicate.is_none() || (!mark_matches && !emit_unmatched));
 
         let (key_selectors, payload_selector, build_payload_schema, probe_payload_schema);
         if params.left_is_build.unwrap() {
@@ -1110,18 +1110,18 @@ impl ProbeState {
                                 matches_before_limit,
                             ) as usize;
 
-                            if let Some(residual) = &params.residual
+                            if let Some(fused_predicate) = &params.fused_predicate
                                 && !table_match.is_empty()
                             {
                                 rechunk_once(&mut payload, &mut payload_rechunked);
-                                let kept = residual
+                                let kept = fused_predicate
                                     .retain_matches(
                                         params.left_is_build.unwrap(),
-                                        ResidualSide {
+                                        MatchSide {
                                             payload: &p.payload,
                                             matches: &mut table_match,
                                         },
-                                        ResidualSide {
+                                        MatchSide {
                                             payload: &payload,
                                             matches: &mut probe_match[probe_start..],
                                         },
@@ -1378,7 +1378,7 @@ impl EquiJoinNode {
         output_schema: Arc<Schema>,
         left_key_selectors: Vec<StreamExpr>,
         right_key_selectors: Vec<StreamExpr>,
-        residual: Option<(StreamExpr, Arc<Schema>)>,
+        fused_predicate: Option<(StreamExpr, Arc<Schema>)>,
         args: JoinArgs,
         num_pipelines: usize,
     ) -> PolarsResult<Self> {
@@ -1451,16 +1451,16 @@ impl EquiJoinNode {
         let right_payload_schema =
             Arc::new(select_schema(&right_input_schema, &right_payload_select));
 
-        // Unmatched-row bookkeeping would count a candidate before the residual runs, and
+        // Unmatched-row bookkeeping would count a candidate before the fused predicate runs, and
         // the ordered probe would evaluate it a partition group at a time.
         assert!(
-            residual.is_none()
+            fused_predicate.is_none()
                 || (matches!(args.how, JoinType::Inner)
                     && args.maintain_order == MaintainOrderJoin::None)
         );
-        let residual = residual
+        let fused_predicate = fused_predicate
             .map(|(expr, schema)| {
-                ResidualPredicate::new(expr, &schema, &left_payload_schema, &right_payload_schema)
+                FusedPredicate::new(expr, &schema, &left_payload_schema, &right_payload_schema)
             })
             .transpose()?;
 
@@ -1479,7 +1479,7 @@ impl EquiJoinNode {
                 left_payload_schema,
                 right_payload_schema,
                 args,
-                residual,
+                fused_predicate,
                 random_state: PlRandomState::default(),
                 sample_limit,
             },

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -147,10 +147,7 @@ impl ResidualPredicate {
                 None => mask.values().clone(),
             };
 
-            // SAFETY: `keep` holds one bit per pair in the batch, so `start + i < end`,
-            // and `end <= n`. `kept` starts the batch at most at `start` and advances once
-            // per surviving pair, so `kept <= start + i`: the write trails the read and
-            // never clobbers a pair still to be inspected.
+            // SAFETY: We are in bounds
             for i in keep.true_idx_iter() {
                 debug_assert!(start + i < end);
                 debug_assert!(kept <= start + i);

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -42,16 +42,14 @@ struct ResidualColumn {
 /// A match condition on top of the equi keys, applied to candidate pairs.
 struct ResidualPredicate {
     expr: StreamExpr,
-    /// The columns the predicate reads. It was compiled against exactly this schema, in
-    /// this order.
-    schema: Arc<Schema>,
+    /// The columns the predicate reads, in the order it was compiled against.
     columns: Vec<ResidualColumn>,
 }
 
 impl ResidualPredicate {
     fn new(
         expr: StreamExpr,
-        schema: Arc<Schema>,
+        schema: &Schema,
         left_payload_schema: &Schema,
         right_payload_schema: &Schema,
     ) -> PolarsResult<Self> {
@@ -79,11 +77,7 @@ impl ResidualPredicate {
             })
             .try_collect_vec()?;
 
-        Ok(Self {
-            expr,
-            schema,
-            columns,
-        })
+        Ok(Self { expr, columns })
     }
 
     /// Drops the candidate pairs the predicate rejects.
@@ -119,8 +113,7 @@ impl ResidualPredicate {
             let columns = self
                 .columns
                 .iter()
-                .zip(self.schema.iter_names())
-                .map(|(column, name)| {
+                .map(|column| {
                     let (payload, idxs) = if column.is_left == left_is_build {
                         (build_payload, &build_match[start..end])
                     } else {
@@ -129,9 +122,8 @@ impl ResidualPredicate {
                             &probe_match[probe_start + start..probe_start + end],
                         )
                     };
-                    let gathered =
-                        unsafe { payload.columns()[column.index].take_slice_unchecked(idxs) };
-                    gathered.with_name(name.clone())
+                    // Payload columns already carry their output name.
+                    unsafe { payload.columns()[column.index].take_slice_unchecked(idxs) }
                 })
                 .collect();
             let df = unsafe { DataFrame::new_unchecked(len, columns) };
@@ -142,10 +134,6 @@ impl ResidualPredicate {
                 .await?;
             let mask = mask.as_materialized_series().bool()?.rechunk();
             let mask = mask.downcast_as_array();
-            polars_ensure!(
-                mask.len() == len,
-                ShapeMismatch: "join residual produced {} values for {len} rows", mask.len(),
-            );
 
             // A null is not a match.
             let keep = match mask.validity() {
@@ -168,32 +156,6 @@ impl ResidualPredicate {
 
         Ok(())
     }
-}
-
-/// Drop the candidate pairs the join's residual rejects, if it has one.
-async fn apply_residual(
-    params: &EquiJoinParams,
-    build_payload: &DataFrame,
-    build_match: &mut Vec<IdxSize>,
-    probe_payload: &DataFrame,
-    probe_match: &mut Vec<IdxSize>,
-    probe_start: usize,
-    state: &ExecutionState,
-) -> PolarsResult<()> {
-    let Some(residual) = &params.residual else {
-        return Ok(());
-    };
-    residual
-        .retain_matches(
-            params.left_is_build.unwrap(),
-            build_payload,
-            build_match,
-            probe_payload,
-            probe_match,
-            probe_start,
-            state,
-        )
-        .await
 }
 
 struct EquiJoinParams {
@@ -1000,11 +962,6 @@ impl ProbeState {
                 select_keys(&df, key_selectors, params, &state.in_memory_exec_state).await?;
             let mut payload = select_payload(df, payload_selector);
             let mut payload_rechunked = false; // We don't eagerly rechunk because there might be no matches.
-            if params.residual.is_some() {
-                // A residual gathers from the payload on every probe call.
-                payload.rechunk_mut();
-                payload_rechunked = true;
-            }
             let mut total_matches = 0;
 
             // Use selectivity estimate to reserve for morsel builders.
@@ -1060,7 +1017,6 @@ impl ProbeState {
 
                         while probe_group_start < probe_group_end {
                             let matches_before_limit = probe_limit - probe_match.len() as IdxSize;
-                            let probe_start = probe_match.len();
                             table_match.clear();
                             probe_group_start += p.hash_table.probe_subset(
                                 &hash_keys,
@@ -1071,17 +1027,6 @@ impl ProbeState {
                                 emit_unmatched,
                                 matches_before_limit,
                             ) as usize;
-
-                            apply_residual(
-                                params,
-                                &p.payload,
-                                &mut table_match,
-                                &payload,
-                                &mut probe_match,
-                                probe_start,
-                                &state.in_memory_exec_state,
-                            )
-                            .await?;
 
                             if emit_unmatched {
                                 build_out.opt_gather_extend(
@@ -1152,16 +1097,23 @@ impl ProbeState {
                                 matches_before_limit,
                             ) as usize;
 
-                            apply_residual(
-                                params,
-                                &p.payload,
-                                &mut table_match,
-                                &payload,
-                                &mut probe_match,
-                                probe_start,
-                                &state.in_memory_exec_state,
-                            )
-                            .await?;
+                            if let Some(residual) = &params.residual {
+                                if !payload_rechunked {
+                                    payload.rechunk_mut();
+                                    payload_rechunked = true;
+                                }
+                                residual
+                                    .retain_matches(
+                                        params.left_is_build.unwrap(),
+                                        &p.payload,
+                                        &mut table_match,
+                                        &payload,
+                                        &mut probe_match,
+                                        probe_start,
+                                        &state.in_memory_exec_state,
+                                    )
+                                    .await?;
+                            }
 
                             if table_match.is_empty() {
                                 continue;
@@ -1489,7 +1441,7 @@ impl EquiJoinNode {
 
         let residual = residual
             .map(|(expr, schema)| {
-                ResidualPredicate::new(expr, schema, &left_payload_schema, &right_payload_schema)
+                ResidualPredicate::new(expr, &schema, &left_payload_schema, &right_payload_schema)
             })
             .transpose()?;
 

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -147,10 +147,19 @@ impl ResidualPredicate {
                 None => mask.values().clone(),
             };
 
-            // `kept <= start + i`, so this never overwrites a candidate still to be read.
+            // SAFETY: `keep` holds one bit per pair in the batch, so `start + i < end`,
+            // and `end <= n`. `kept` starts the batch at most at `start` and advances once
+            // per surviving pair, so `kept <= start + i`: the write trails the read and
+            // never clobbers a pair still to be inspected.
             for i in keep.true_idx_iter() {
-                build_match[kept] = build_match[start + i];
-                probe_match[kept] = probe_match[start + i];
+                debug_assert!(start + i < end);
+                debug_assert!(kept <= start + i);
+                unsafe {
+                    let build = *build_match.get_unchecked(start + i);
+                    let probe = *probe_match.get_unchecked(start + i);
+                    *build_match.get_unchecked_mut(kept) = build;
+                    *probe_match.get_unchecked_mut(kept) = probe;
+                }
                 kept += 1;
             }
 

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -39,6 +39,12 @@ struct ResidualColumn {
     index: usize,
 }
 
+/// One side of the candidate pairs: the rows to gather from, and the indices into them.
+struct ResidualSide<'a> {
+    payload: &'a DataFrame,
+    matches: &'a mut Vec<IdxSize>,
+}
+
 /// A match condition on top of the equi keys, applied to candidate pairs.
 struct ResidualPredicate {
     expr: StreamExpr,
@@ -87,13 +93,20 @@ impl ResidualPredicate {
     async fn retain_matches(
         &self,
         left_is_build: bool,
-        build_payload: &DataFrame,
-        build_match: &mut Vec<IdxSize>,
-        probe_payload: &DataFrame,
-        probe_match: &mut Vec<IdxSize>,
+        build: ResidualSide<'_>,
+        probe: ResidualSide<'_>,
         probe_start: usize,
         state: &ExecutionState,
     ) -> PolarsResult<()> {
+        let ResidualSide {
+            payload: build_payload,
+            matches: build_match,
+        } = build;
+        let ResidualSide {
+            payload: probe_payload,
+            matches: probe_match,
+        } = probe;
+
         let n = build_match.len();
         assert_eq!(n, probe_match.len() - probe_start);
         if n == 0 {
@@ -1107,10 +1120,14 @@ impl ProbeState {
                                 residual
                                     .retain_matches(
                                         params.left_is_build.unwrap(),
-                                        &p.payload,
-                                        &mut table_match,
-                                        &payload,
-                                        &mut probe_match,
+                                        ResidualSide {
+                                            payload: &p.payload,
+                                            matches: &mut table_match,
+                                        },
+                                        ResidualSide {
+                                            payload: &payload,
+                                            matches: &mut probe_match,
+                                        },
                                         probe_start,
                                         &state.in_memory_exec_state,
                                     )

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -39,12 +39,6 @@ struct FusedColumn {
     index: usize,
 }
 
-/// One side of the candidate pairs: the rows to gather from, and the indices into them.
-struct MatchSide<'a> {
-    payload: &'a DataFrame,
-    matches: &'a mut [IdxSize],
-}
-
 /// A match condition on top of the equi keys, applied to candidate pairs.
 struct FusedPredicate {
     expr: StreamExpr,
@@ -88,24 +82,17 @@ impl FusedPredicate {
 
     /// Compacts the candidate pairs the predicate accepts to the front of both slices.
     ///
-    /// `build` and `probe` describe the same pairs positionally. Returns how many
+    /// The two match slices describe the same pairs positionally. Returns how many
     /// survived, which the caller truncates its own buffers to.
     async fn retain_matches(
         &self,
         left_is_build: bool,
-        build: MatchSide<'_>,
-        probe: MatchSide<'_>,
+        build_payload: &DataFrame,
+        build_match: &mut [IdxSize],
+        probe_payload: &DataFrame,
+        probe_match: &mut [IdxSize],
         state: &ExecutionState,
     ) -> PolarsResult<usize> {
-        let MatchSide {
-            payload: build_payload,
-            matches: build_match,
-        } = build;
-        let MatchSide {
-            payload: probe_payload,
-            matches: probe_match,
-        } = probe;
-
         let n = build_match.len();
         assert_eq!(n, probe_match.len());
 
@@ -147,17 +134,30 @@ impl FusedPredicate {
                 None => mask.values().clone(),
             };
 
-            // SAFETY: We are in bounds
-            for i in keep.true_idx_iter() {
-                debug_assert!(start + i < end);
-                debug_assert!(kept <= start + i);
-                unsafe {
-                    let build = *build_match.get_unchecked(start + i);
-                    let probe = *probe_match.get_unchecked(start + i);
-                    *build_match.get_unchecked_mut(kept) = build;
-                    *probe_match.get_unchecked_mut(kept) = probe;
-                }
-                kept += 1;
+            match keep.set_bits() {
+                0 => {},
+                // The batch survives whole, so it moves as one block.
+                set if set == len => {
+                    if kept != start {
+                        build_match.copy_within(start..end, kept);
+                        probe_match.copy_within(start..end, kept);
+                    }
+                    kept += len;
+                },
+                // SAFETY: We are in bounds
+                _ => {
+                    for i in keep.true_idx_iter() {
+                        debug_assert!(start + i < end);
+                        debug_assert!(kept <= start + i);
+                        unsafe {
+                            let build = *build_match.get_unchecked(start + i);
+                            let probe = *probe_match.get_unchecked(start + i);
+                            *build_match.get_unchecked_mut(kept) = build;
+                            *probe_match.get_unchecked_mut(kept) = probe;
+                        }
+                        kept += 1;
+                    }
+                },
             }
 
             start = end;
@@ -1117,14 +1117,10 @@ impl ProbeState {
                                 let kept = fused_predicate
                                     .retain_matches(
                                         params.left_is_build.unwrap(),
-                                        MatchSide {
-                                            payload: &p.payload,
-                                            matches: &mut table_match,
-                                        },
-                                        MatchSide {
-                                            payload: &payload,
-                                            matches: &mut probe_match[probe_start..],
-                                        },
+                                        &p.payload,
+                                        &mut table_match,
+                                        &payload,
+                                        &mut probe_match[probe_start..],
                                         &state.in_memory_exec_state,
                                     )
                                     .await?;

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -158,6 +158,14 @@ impl ResidualPredicate {
     }
 }
 
+/// Rechunks on the first gather from `payload`, which a morsel with no matches skips.
+fn rechunk_once(payload: &mut DataFrame, rechunked: &mut bool) {
+    if !*rechunked {
+        payload.rechunk_mut();
+        *rechunked = true;
+    }
+}
+
 struct EquiJoinParams {
     left_is_build: Option<bool>,
     preserve_order_build: bool,
@@ -961,7 +969,7 @@ impl ProbeState {
             let hash_keys =
                 select_keys(&df, key_selectors, params, &state.in_memory_exec_state).await?;
             let mut payload = select_payload(df, payload_selector);
-            let mut payload_rechunked = false; // We don't eagerly rechunk because there might be no matches.
+            let mut payload_rechunked = false;
             let mut total_matches = 0;
 
             // Use selectivity estimate to reserve for morsel builders.
@@ -1045,10 +1053,7 @@ impl ProbeState {
                             if probe_match.len() >= probe_limit as usize
                                 || probe_group_start == probe_partitions.len()
                             {
-                                if !payload_rechunked {
-                                    payload.rechunk_mut();
-                                    payload_rechunked = true;
-                                }
+                                rechunk_once(&mut payload, &mut payload_rechunked);
                                 probe_out.gather_extend(
                                     &payload,
                                     &probe_match,
@@ -1098,10 +1103,7 @@ impl ProbeState {
                             ) as usize;
 
                             if let Some(residual) = &params.residual {
-                                if !payload_rechunked {
-                                    payload.rechunk_mut();
-                                    payload_rechunked = true;
-                                }
+                                rechunk_once(&mut payload, &mut payload_rechunked);
                                 residual
                                     .retain_matches(
                                         params.left_is_build.unwrap(),
@@ -1135,10 +1137,7 @@ impl ProbeState {
                             };
 
                             if probe_match.len() >= probe_limit as usize {
-                                if !payload_rechunked {
-                                    payload.rechunk_mut();
-                                    payload_rechunked = true;
-                                }
+                                rechunk_once(&mut payload, &mut payload_rechunked);
                                 probe_out.gather_extend(
                                     &payload,
                                     &probe_match,
@@ -1160,9 +1159,7 @@ impl ProbeState {
                 }
 
                 if !probe_match.is_empty() {
-                    if !payload_rechunked {
-                        payload.rechunk_mut();
-                    }
+                    rechunk_once(&mut payload, &mut payload_rechunked);
                     probe_out.gather_extend(&payload, &probe_match, ShareStrategy::Always);
                     probe_match.clear();
                     let out_morsel = new_morsel(&mut build_out, &mut probe_out);

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -42,7 +42,7 @@ struct ResidualColumn {
 /// One side of the candidate pairs: the rows to gather from, and the indices into them.
 struct ResidualSide<'a> {
     payload: &'a DataFrame,
-    matches: &'a mut Vec<IdxSize>,
+    matches: &'a mut [IdxSize],
 }
 
 /// A match condition on top of the equi keys, applied to candidate pairs.
@@ -86,18 +86,17 @@ impl ResidualPredicate {
         Ok(Self { expr, columns })
     }
 
-    /// Drops the candidate pairs the predicate rejects.
+    /// Compacts the candidate pairs the predicate accepts to the front of both slices.
     ///
-    /// `probe_match` keeps earlier survivors in front, so only its tail from `probe_start`
-    /// is touched. Both vectors are compacted in step and stay parallel.
+    /// `build` and `probe` describe the same pairs positionally. Returns how many
+    /// survived, which the caller truncates its own buffers to.
     async fn retain_matches(
         &self,
         left_is_build: bool,
         build: ResidualSide<'_>,
         probe: ResidualSide<'_>,
-        probe_start: usize,
         state: &ExecutionState,
-    ) -> PolarsResult<()> {
+    ) -> PolarsResult<usize> {
         let ResidualSide {
             payload: build_payload,
             matches: build_match,
@@ -108,10 +107,7 @@ impl ResidualPredicate {
         } = probe;
 
         let n = build_match.len();
-        assert_eq!(n, probe_match.len() - probe_start);
-        if n == 0 {
-            return Ok(());
-        }
+        assert_eq!(n, probe_match.len());
 
         // `probe_subset` can hand back far more candidates than the morsel limit, so the
         // gathered predicate inputs are bounded here instead.
@@ -130,10 +126,7 @@ impl ResidualPredicate {
                     let (payload, idxs) = if column.is_left == left_is_build {
                         (build_payload, &build_match[start..end])
                     } else {
-                        (
-                            probe_payload,
-                            &probe_match[probe_start + start..probe_start + end],
-                        )
+                        (probe_payload, &probe_match[start..end])
                     };
                     // Payload columns already carry their output name.
                     unsafe { payload.columns()[column.index].take_slice_unchecked(idxs) }
@@ -157,17 +150,14 @@ impl ResidualPredicate {
             // `kept <= start + i`, so this never overwrites a candidate still to be read.
             for i in keep.true_idx_iter() {
                 build_match[kept] = build_match[start + i];
-                probe_match[probe_start + kept] = probe_match[probe_start + start + i];
+                probe_match[kept] = probe_match[start + i];
                 kept += 1;
             }
 
             start = end;
         }
 
-        build_match.truncate(kept);
-        probe_match.truncate(probe_start + kept);
-
-        Ok(())
+        Ok(kept)
     }
 }
 
@@ -1115,9 +1105,11 @@ impl ProbeState {
                                 matches_before_limit,
                             ) as usize;
 
-                            if let Some(residual) = &params.residual {
+                            if let Some(residual) = &params.residual
+                                && !table_match.is_empty()
+                            {
                                 rechunk_once(&mut payload, &mut payload_rechunked);
-                                residual
+                                let kept = residual
                                     .retain_matches(
                                         params.left_is_build.unwrap(),
                                         ResidualSide {
@@ -1126,12 +1118,13 @@ impl ProbeState {
                                         },
                                         ResidualSide {
                                             payload: &payload,
-                                            matches: &mut probe_match,
+                                            matches: &mut probe_match[probe_start..],
                                         },
-                                        probe_start,
                                         &state.in_memory_exec_state,
                                     )
                                     .await?;
+                                table_match.truncate(kept);
+                                probe_match.truncate(probe_start + kept);
                             }
 
                             if table_match.is_empty() {
@@ -1453,6 +1446,13 @@ impl EquiJoinNode {
         let right_payload_schema =
             Arc::new(select_schema(&right_input_schema, &right_payload_select));
 
+        // Unmatched-row bookkeeping would count a candidate before the residual runs, and
+        // the ordered probe would evaluate it a partition group at a time.
+        assert!(
+            residual.is_none()
+                || (matches!(args.how, JoinType::Inner)
+                    && args.maintain_order == MaintainOrderJoin::None)
+        );
         let residual = residual
             .map(|(expr, schema)| {
                 ResidualPredicate::new(expr, &schema, &left_payload_schema, &right_payload_schema)

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -161,7 +161,7 @@ impl ResidualPredicate {
     }
 }
 
-/// Rechunks on the first gather from `payload`, which a morsel with no matches skips.
+/// Rechunks `payload` the first time rows are gathered from it.
 fn rechunk_once(payload: &mut DataFrame, rechunked: &mut bool) {
     if !*rechunked {
         payload.rechunk_mut();
@@ -936,7 +936,6 @@ impl ProbeState {
         let probe_limit = get_ideal_morsel_size() as IdxSize;
         let mark_matches = params.emit_unmatched_build();
         let emit_unmatched = params.emit_unmatched_probe();
-        // Unmatched-row bookkeeping would count a candidate before the residual runs.
         assert!(params.residual.is_none() || (!mark_matches && !emit_unmatched));
 
         let (key_selectors, payload_selector, build_payload_schema, probe_payload_schema);

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -32,6 +32,170 @@ use crate::morsel::{SourceToken, get_ideal_morsel_size};
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::in_memory_source::InMemorySourceNode;
 
+/// Where one of the residual's input columns is found at probe time.
+struct ResidualColumn {
+    is_left: bool,
+    /// Index into that side's payload.
+    index: usize,
+}
+
+/// A match condition on top of the equi keys, applied to candidate pairs.
+struct ResidualPredicate {
+    expr: StreamExpr,
+    /// The columns the predicate reads. It was compiled against exactly this schema, in
+    /// this order.
+    schema: Arc<Schema>,
+    columns: Vec<ResidualColumn>,
+}
+
+impl ResidualPredicate {
+    fn new(
+        expr: StreamExpr,
+        schema: Arc<Schema>,
+        left_payload_schema: &Schema,
+        right_payload_schema: &Schema,
+    ) -> PolarsResult<Self> {
+        let columns = schema
+            .iter_names()
+            .map(|name| {
+                // Payload schemas are keyed by output name.
+                let column = if let Some(index) = left_payload_schema.index_of(name) {
+                    ResidualColumn {
+                        is_left: true,
+                        index,
+                    }
+                } else if let Some(index) = right_payload_schema.index_of(name) {
+                    ResidualColumn {
+                        is_left: false,
+                        index,
+                    }
+                } else {
+                    polars_bail!(
+                        ColumnNotFound:
+                        "join residual reads '{name}', which the join does not output"
+                    )
+                };
+                Ok(column)
+            })
+            .try_collect_vec()?;
+
+        Ok(Self {
+            expr,
+            schema,
+            columns,
+        })
+    }
+
+    /// Drops the candidate pairs the predicate rejects.
+    ///
+    /// `probe_match` keeps earlier survivors in front, so only its tail from `probe_start`
+    /// is touched. Both vectors are compacted in step and stay parallel.
+    async fn retain_matches(
+        &self,
+        left_is_build: bool,
+        build_payload: &DataFrame,
+        build_match: &mut Vec<IdxSize>,
+        probe_payload: &DataFrame,
+        probe_match: &mut Vec<IdxSize>,
+        probe_start: usize,
+        state: &ExecutionState,
+    ) -> PolarsResult<()> {
+        let n = build_match.len();
+        assert_eq!(n, probe_match.len() - probe_start);
+        if n == 0 {
+            return Ok(());
+        }
+
+        // `probe_subset` can hand back far more candidates than the morsel limit, so the
+        // gathered predicate inputs are bounded here instead.
+        let batch_size = get_ideal_morsel_size();
+        let mut kept = 0;
+        let mut start = 0;
+
+        while start < n {
+            let end = (start + batch_size).min(n);
+            let len = end - start;
+
+            let columns = self
+                .columns
+                .iter()
+                .zip(self.schema.iter_names())
+                .map(|(column, name)| {
+                    let (payload, idxs) = if column.is_left == left_is_build {
+                        (build_payload, &build_match[start..end])
+                    } else {
+                        (
+                            probe_payload,
+                            &probe_match[probe_start + start..probe_start + end],
+                        )
+                    };
+                    let gathered =
+                        unsafe { payload.columns()[column.index].take_slice_unchecked(idxs) };
+                    gathered.with_name(name.clone())
+                })
+                .collect();
+            let df = unsafe { DataFrame::new_unchecked(len, columns) };
+
+            let mask = self
+                .expr
+                .evaluate_preserve_len_broadcast(&df, state)
+                .await?;
+            let mask = mask.as_materialized_series().bool()?.rechunk();
+            let mask = mask.downcast_as_array();
+            polars_ensure!(
+                mask.len() == len,
+                ShapeMismatch: "join residual produced {} values for {len} rows", mask.len(),
+            );
+
+            // A null is not a match.
+            let keep = match mask.validity() {
+                Some(validity) => mask.values() & validity,
+                None => mask.values().clone(),
+            };
+
+            // `kept <= start + i`, so this never overwrites a candidate still to be read.
+            for i in keep.true_idx_iter() {
+                build_match[kept] = build_match[start + i];
+                probe_match[probe_start + kept] = probe_match[probe_start + start + i];
+                kept += 1;
+            }
+
+            start = end;
+        }
+
+        build_match.truncate(kept);
+        probe_match.truncate(probe_start + kept);
+
+        Ok(())
+    }
+}
+
+/// Drop the candidate pairs the join's residual rejects, if it has one.
+async fn apply_residual(
+    params: &EquiJoinParams,
+    build_payload: &DataFrame,
+    build_match: &mut Vec<IdxSize>,
+    probe_payload: &DataFrame,
+    probe_match: &mut Vec<IdxSize>,
+    probe_start: usize,
+    state: &ExecutionState,
+) -> PolarsResult<()> {
+    let Some(residual) = &params.residual else {
+        return Ok(());
+    };
+    residual
+        .retain_matches(
+            params.left_is_build.unwrap(),
+            build_payload,
+            build_match,
+            probe_payload,
+            probe_match,
+            probe_start,
+            state,
+        )
+        .await
+}
+
 struct EquiJoinParams {
     left_is_build: Option<bool>,
     preserve_order_build: bool,
@@ -46,6 +210,7 @@ struct EquiJoinParams {
     left_payload_schema: Arc<Schema>,
     right_payload_schema: Arc<Schema>,
     args: JoinArgs,
+    residual: Option<ResidualPredicate>,
     random_state: PlRandomState,
     sample_limit: usize,
 }
@@ -798,6 +963,8 @@ impl ProbeState {
         let probe_limit = get_ideal_morsel_size() as IdxSize;
         let mark_matches = params.emit_unmatched_build();
         let emit_unmatched = params.emit_unmatched_probe();
+        // Unmatched-row bookkeeping would count a candidate before the residual runs.
+        assert!(params.residual.is_none() || (!mark_matches && !emit_unmatched));
 
         let (key_selectors, payload_selector, build_payload_schema, probe_payload_schema);
         if params.left_is_build.unwrap() {
@@ -833,6 +1000,11 @@ impl ProbeState {
                 select_keys(&df, key_selectors, params, &state.in_memory_exec_state).await?;
             let mut payload = select_payload(df, payload_selector);
             let mut payload_rechunked = false; // We don't eagerly rechunk because there might be no matches.
+            if params.residual.is_some() {
+                // A residual gathers from the payload on every probe call.
+                payload.rechunk_mut();
+                payload_rechunked = true;
+            }
             let mut total_matches = 0;
 
             // Use selectivity estimate to reserve for morsel builders.
@@ -888,6 +1060,7 @@ impl ProbeState {
 
                         while probe_group_start < probe_group_end {
                             let matches_before_limit = probe_limit - probe_match.len() as IdxSize;
+                            let probe_start = probe_match.len();
                             table_match.clear();
                             probe_group_start += p.hash_table.probe_subset(
                                 &hash_keys,
@@ -898,6 +1071,17 @@ impl ProbeState {
                                 emit_unmatched,
                                 matches_before_limit,
                             ) as usize;
+
+                            apply_residual(
+                                params,
+                                &p.payload,
+                                &mut table_match,
+                                &payload,
+                                &mut probe_match,
+                                probe_start,
+                                &state.in_memory_exec_state,
+                            )
+                            .await?;
 
                             if emit_unmatched {
                                 build_out.opt_gather_extend(
@@ -956,6 +1140,7 @@ impl ProbeState {
                         let mut offset = 0;
                         while offset < idxs_in_p.len() {
                             let matches_before_limit = probe_limit - probe_match.len() as IdxSize;
+                            let probe_start = probe_match.len();
                             table_match.clear();
                             offset += p.hash_table.probe_subset(
                                 &hash_keys,
@@ -966,6 +1151,17 @@ impl ProbeState {
                                 emit_unmatched,
                                 matches_before_limit,
                             ) as usize;
+
+                            apply_residual(
+                                params,
+                                &p.payload,
+                                &mut table_match,
+                                &payload,
+                                &mut probe_match,
+                                probe_start,
+                                &state.in_memory_exec_state,
+                            )
+                            .await?;
 
                             if table_match.is_empty() {
                                 continue;
@@ -1218,6 +1414,7 @@ impl EquiJoinNode {
         output_schema: Arc<Schema>,
         left_key_selectors: Vec<StreamExpr>,
         right_key_selectors: Vec<StreamExpr>,
+        residual: Option<(StreamExpr, Arc<Schema>)>,
         args: JoinArgs,
         num_pipelines: usize,
     ) -> PolarsResult<Self> {
@@ -1289,6 +1486,13 @@ impl EquiJoinNode {
         let left_payload_schema = Arc::new(select_schema(&left_input_schema, &left_payload_select));
         let right_payload_schema =
             Arc::new(select_schema(&right_input_schema, &right_payload_select));
+
+        let residual = residual
+            .map(|(expr, schema)| {
+                ResidualPredicate::new(expr, schema, &left_payload_schema, &right_payload_schema)
+            })
+            .transpose()?;
+
         Ok(Self {
             state,
             params: EquiJoinParams {
@@ -1304,6 +1508,7 @@ impl EquiJoinNode {
                 left_payload_schema,
                 right_payload_schema,
                 args,
+                residual,
                 random_state: PlRandomState::default(),
                 sample_limit,
             },

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -806,16 +806,16 @@ fn visualize_plan_rec(
                 args,
             );
             if let PhysNodeKind::EquiJoin {
-                residual: Some(residual),
+                fused_predicate: Some(fused_predicate),
                 ..
             } = &phys_sm[node_key].kind
             {
-                let residual = fmt_exprs_to_label(
-                    std::slice::from_ref(residual),
+                let fused_predicate = fmt_exprs_to_label(
+                    std::slice::from_ref(fused_predicate),
                     expr_arena,
                     FormatExprStyle::NoAliases,
                 );
-                label.push_str(&format!("\nresidual: {residual}"));
+                label.push_str(&format!("\nfused predicate: {fused_predicate}"));
             }
             (label, &[*input_left, *input_right][..])
         },

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -772,6 +772,7 @@ fn visualize_plan_rec(
             left_on,
             right_on,
             args,
+            ..
         }
         | PhysNodeKind::SemiAntiJoin {
             input_left,
@@ -798,12 +799,24 @@ fn visualize_plan_rec(
                 } if args.how.is_anti() => "is-not-in",
                 _ => unreachable!(),
             };
-            let label = fmt_join_label(
+            let mut label = fmt_join_label(
                 base_label,
                 &fmt_exprs_to_label(left_on, expr_arena, FormatExprStyle::NoAliases),
                 &fmt_exprs_to_label(right_on, expr_arena, FormatExprStyle::NoAliases),
                 args,
             );
+            if let PhysNodeKind::EquiJoin {
+                residual: Some(residual),
+                ..
+            } = &phys_sm[node_key].kind
+            {
+                let residual = fmt_exprs_to_label(
+                    std::slice::from_ref(residual),
+                    expr_arena,
+                    FormatExprStyle::NoAliases,
+                );
+                label.push_str(&format!("\nresidual: {residual}"));
+            }
             (label, &[*input_left, *input_right][..])
         },
         #[cfg(feature = "iejoin")]

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -991,6 +991,7 @@ pub fn try_build_streaming_group_by(
                 left_on: trans_keys.clone(),
                 right_on: trans_keys,
                 args,
+                residual: None,
             },
         ));
         post_select_input = PhysStream::first(join_key);

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -991,7 +991,7 @@ pub fn try_build_streaming_group_by(
                 left_on: trans_keys.clone(),
                 right_on: trans_keys,
                 args,
-                residual: None,
+                fused_predicate: None,
             },
         ));
         post_select_input = PhysStream::first(join_key);

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1054,6 +1054,8 @@ pub fn lower_ir(
             #[cfg(feature = "iejoin")]
             const RANGE_JOIN_PREFER_DESCENDING: bool = false;
 
+            options.ensure_executable()?;
+
             #[allow(unused_mut)]
             let (mut input_left, mut input_right) = (*input_left, *input_right);
             let input_left_schema = IR::schema_with_cache(input_left, ir_arena, schema_cache);

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1210,8 +1210,8 @@ pub fn lower_ir(
             #[cfg(not(feature = "asof_join"))]
             let use_streaming_asof_join = false;
 
-            // A non-equality match condition is only handled natively by the range-join
-            // node; anything else falls back to the in-memory engine.
+            // A non-equality match condition is native to the range-join node, and to the
+            // equi join as a residual; anything else falls back to the in-memory engine.
             let match_condition_supported =
                 options.is_pure_equi() || options.has_residual() || args.how.is_range();
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1066,6 +1066,10 @@ pub fn lower_ir(
             let mut tmp_right_col_names: Vec<Option<PlSmallStr>> = Vec::new();
             let args = options.args.clone();
             let options = options.options.clone();
+            // Only the hash equi join evaluates a residual natively; other strategies get
+            // a `Filter` on top, and the in-memory fallback applies it from `options`.
+            let residual = options.residual().cloned();
+            let mut residual_is_native = false;
             #[cfg(feature = "asof_join")]
             let asof_options = || match args.how {
                 JoinType::AsOf(ref asof_options) => asof_options,
@@ -1206,7 +1210,8 @@ pub fn lower_ir(
 
             // A non-equality match condition is only handled natively by the range-join
             // node; anything else falls back to the in-memory engine.
-            let match_condition_supported = options.is_pure_equi() || args.how.is_range();
+            let match_condition_supported =
+                options.is_pure_equi() || options.has_residual() || args.how.is_range();
 
             if (args.how.is_equi()
                 || args.how.is_semi_anti()
@@ -1375,16 +1380,20 @@ pub fn lower_ir(
                             output_bool: false,
                         },
                     )),
-                    _ if args.how.is_equi() => phys_sm.insert(PhysNode::new(
-                        output_schema,
-                        PhysNodeKind::EquiJoin {
-                            input_left: trans_input_left,
-                            input_right: trans_input_right,
-                            left_on: trans_left_on,
-                            right_on: trans_right_on,
-                            args: args.clone(),
-                        },
-                    )),
+                    _ if args.how.is_equi() => {
+                        residual_is_native = residual.is_some();
+                        phys_sm.insert(PhysNode::new(
+                            output_schema,
+                            PhysNodeKind::EquiJoin {
+                                input_left: trans_input_left,
+                                input_right: trans_input_right,
+                                left_on: trans_left_on,
+                                right_on: trans_right_on,
+                                args: args.clone(),
+                                residual: residual.clone(),
+                            },
+                        ))
+                    },
                     _ if args.how.is_cross() => phys_sm.insert(PhysNode::new(
                         output_schema,
                         PhysNodeKind::CrossJoin {
@@ -1396,6 +1405,15 @@ pub fn lower_ir(
                     _ => unreachable!(),
                 };
                 let mut stream = PhysStream::first(node);
+                if let Some(residual) = residual
+                    && !residual_is_native
+                {
+                    // A residual join never carries a slice.
+                    debug_assert!(args.slice.is_none());
+                    stream = build_filter_stream(
+                        stream, residual, expr_arena, phys_sm, expr_cache, ctx,
+                    )?;
+                }
                 if let Some((offset, len)) = args.slice {
                     stream = build_slice_stream(stream, offset, len, phys_sm);
                 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1071,8 +1071,7 @@ pub fn lower_ir(
             let options = options.options.clone();
             // Only the hash equi join evaluates a residual natively; other strategies get
             // a `Filter` on top, and the in-memory fallback applies it from `options`.
-            let residual = options.residual().cloned();
-            let mut residual_is_native = false;
+            let mut residual = options.residual().cloned();
             #[cfg(feature = "asof_join")]
             let asof_options = || match args.how {
                 JoinType::AsOf(ref asof_options) => asof_options,
@@ -1388,8 +1387,10 @@ pub fn lower_ir(
                         // bulk-probing per partition, so it would evaluate the residual
                         // once per consecutive partition group: a row or two at a time
                         // with shuffled keys. A filter over the output is cheaper.
-                        residual_is_native =
-                            residual.is_some() && args.maintain_order == MaintainOrderJoin::None;
+                        let native = match args.maintain_order {
+                            MaintainOrderJoin::None => residual.take(),
+                            _ => None,
+                        };
                         phys_sm.insert(PhysNode::new(
                             output_schema,
                             PhysNodeKind::EquiJoin {
@@ -1398,7 +1399,7 @@ pub fn lower_ir(
                                 left_on: trans_left_on,
                                 right_on: trans_right_on,
                                 args: args.clone(),
-                                residual: residual_is_native.then(|| residual.clone().unwrap()),
+                                residual: native,
                             },
                         ))
                     },
@@ -1413,9 +1414,8 @@ pub fn lower_ir(
                     _ => unreachable!(),
                 };
                 let mut stream = PhysStream::first(node);
-                if let Some(residual) = residual
-                    && !residual_is_native
-                {
+                // Anything the join did not take over is applied as a filter instead.
+                if let Some(residual) = residual {
                     // A residual join never carries a slice.
                     debug_assert!(args.slice.is_none());
                     stream = build_filter_stream(

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1383,10 +1383,7 @@ pub fn lower_ir(
                         },
                     )),
                     _ if args.how.is_equi() => {
-                        // An order-preserving probe follows the probe morsel rather than
-                        // bulk-probing per partition, so it would evaluate the residual
-                        // once per consecutive partition group: a row or two at a time
-                        // with shuffled keys. A filter over the output is cheaper.
+                        // Only the unordered probe evaluates a residual in bulk.
                         let native = match args.maintain_order {
                             MaintainOrderJoin::None => residual.take(),
                             _ => None,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1069,9 +1069,9 @@ pub fn lower_ir(
             let mut tmp_right_col_names: Vec<Option<PlSmallStr>> = Vec::new();
             let args = options.args.clone();
             let options = options.options.clone();
-            // Only the hash equi join evaluates a residual natively; other strategies get
+            // Only the hash equi join evaluates a fused predicate natively; other strategies get
             // a `Filter` on top, and the in-memory fallback applies it from `options`.
-            let mut residual = options.residual().cloned();
+            let mut fused_predicate = options.fused_predicate().cloned();
             #[cfg(feature = "asof_join")]
             let asof_options = || match args.how {
                 JoinType::AsOf(ref asof_options) => asof_options,
@@ -1211,9 +1211,9 @@ pub fn lower_ir(
             let use_streaming_asof_join = false;
 
             // A non-equality match condition is native to the range-join node, and to the
-            // equi join as a residual; anything else falls back to the in-memory engine.
+            // equi join as a fused predicate; anything else falls back to the in-memory engine.
             let match_condition_supported =
-                options.is_pure_equi() || options.has_residual() || args.how.is_range();
+                options.is_pure_equi() || options.has_fused_predicate() || args.how.is_range();
 
             if (args.how.is_equi()
                 || args.how.is_semi_anti()
@@ -1383,9 +1383,9 @@ pub fn lower_ir(
                         },
                     )),
                     _ if args.how.is_equi() => {
-                        // Only the unordered probe evaluates a residual in bulk.
+                        // Only the unordered probe evaluates a fused predicate in bulk.
                         let native = match args.maintain_order {
-                            MaintainOrderJoin::None => residual.take(),
+                            MaintainOrderJoin::None => fused_predicate.take(),
                             _ => None,
                         };
                         phys_sm.insert(PhysNode::new(
@@ -1396,7 +1396,7 @@ pub fn lower_ir(
                                 left_on: trans_left_on,
                                 right_on: trans_right_on,
                                 args: args.clone(),
-                                residual: native,
+                                fused_predicate: native,
                             },
                         ))
                     },
@@ -1412,11 +1412,16 @@ pub fn lower_ir(
                 };
                 let mut stream = PhysStream::first(node);
                 // Anything the join did not take over is applied as a filter instead.
-                if let Some(residual) = residual {
-                    // A residual join never carries a slice.
+                if let Some(fused_predicate) = fused_predicate {
+                    // A fused predicate join never carries a slice.
                     debug_assert!(args.slice.is_none());
                     stream = build_filter_stream(
-                        stream, residual, expr_arena, phys_sm, expr_cache, ctx,
+                        stream,
+                        fused_predicate,
+                        expr_arena,
+                        phys_sm,
+                        expr_cache,
+                        ctx,
                     )?;
                 }
                 if let Some((offset, len)) = args.slice {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -15,6 +15,7 @@ use polars_expr::dispatch::function_expr_to_udf;
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_ops::frame::JoinType;
+use polars_ops::prelude::MaintainOrderJoin;
 use polars_plan::constants::get_literal_name;
 use polars_plan::dsl::default_values::DefaultFieldValues;
 use polars_plan::dsl::deletion::DeletionFilesList;
@@ -1383,7 +1384,12 @@ pub fn lower_ir(
                         },
                     )),
                     _ if args.how.is_equi() => {
-                        residual_is_native = residual.is_some();
+                        // An order-preserving probe follows the probe morsel rather than
+                        // bulk-probing per partition, so it would evaluate the residual
+                        // once per consecutive partition group: a row or two at a time
+                        // with shuffled keys. A filter over the output is cheaper.
+                        residual_is_native =
+                            residual.is_some() && args.maintain_order == MaintainOrderJoin::None;
                         phys_sm.insert(PhysNode::new(
                             output_schema,
                             PhysNodeKind::EquiJoin {
@@ -1392,7 +1398,7 @@ pub fn lower_ir(
                                 left_on: trans_left_on,
                                 right_on: trans_right_on,
                                 args: args.clone(),
-                                residual: residual.clone(),
+                                residual: residual_is_native.then(|| residual.clone().unwrap()),
                             },
                         ))
                     },

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -463,7 +463,7 @@ pub enum PhysNodeKind {
         args: JoinArgs,
         /// Extra match condition, in the join's output namespace, applied per candidate
         /// pair. See `JoinTypeOptionsIR::Equi`.
-        residual: Option<ExprIR>,
+        fused_predicate: Option<ExprIR>,
     },
 
     MergeJoin {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -461,6 +461,9 @@ pub enum PhysNodeKind {
         left_on: Vec<ExprIR>,
         right_on: Vec<ExprIR>,
         args: JoinArgs,
+        /// Extra match condition, in the join's output namespace, applied per candidate
+        /// pair. See `JoinTypeOptionsIR::Equi`.
+        residual: Option<ExprIR>,
     },
 
     MergeJoin {

--- a/crates/polars-stream/src/physical_plan/to_description.rs
+++ b/crates/polars-stream/src/physical_plan/to_description.rs
@@ -515,12 +515,15 @@ pub fn phys_props(
             left_on,
             right_on,
             args,
-            ..
+            residual,
         } => (
             PhysicalPropsDescription::EquiJoin {
                 how: format!("{}", args.how),
                 left_on: fmt_exprs(left_on, expr_arena),
                 right_on: fmt_exprs(right_on, expr_arena),
+                residual: residual
+                    .as_ref()
+                    .map(|r| fmt_exprs(&[r.clone()], expr_arena)),
                 nulls_equal: args.nulls_equal,
                 coalesce: fmt_from_static_str(args.coalesce),
                 maintain_order: fmt_from_static_str(args.maintain_order),

--- a/crates/polars-stream/src/physical_plan/to_description.rs
+++ b/crates/polars-stream/src/physical_plan/to_description.rs
@@ -515,13 +515,13 @@ pub fn phys_props(
             left_on,
             right_on,
             args,
-            residual,
+            fused_predicate,
         } => (
             PhysicalPropsDescription::EquiJoin {
                 how: format!("{}", args.how),
                 left_on: fmt_exprs(left_on, expr_arena),
                 right_on: fmt_exprs(right_on, expr_arena),
-                residual: residual
+                fused_predicate: fused_predicate
                     .as_ref()
                     .map(|r| fmt_exprs(std::slice::from_ref(r), expr_arena)),
                 nulls_equal: args.nulls_equal,

--- a/crates/polars-stream/src/physical_plan/to_description.rs
+++ b/crates/polars-stream/src/physical_plan/to_description.rs
@@ -523,7 +523,7 @@ pub fn phys_props(
                 right_on: fmt_exprs(right_on, expr_arena),
                 residual: residual
                     .as_ref()
-                    .map(|r| fmt_exprs(&[r.clone()], expr_arena)),
+                    .map(|r| fmt_exprs(std::slice::from_ref(r), expr_arena)),
                 nulls_equal: args.nulls_equal,
                 coalesce: fmt_from_static_str(args.coalesce),
                 maintain_order: fmt_from_static_str(args.maintain_order),

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1229,14 +1229,12 @@ fn to_graph_rec<'a>(
                         (right_input_key, input_right.port),
                     ],
                 ),
-                _ => {
+                EquiJoin { ref residual, .. } => {
                     // Compiled against a narrow frame of exactly the columns it reads, in
                     // the order the node gathers them.
-                    let residual = match &node.kind {
-                        EquiJoin {
-                            residual: Some(residual),
-                            ..
-                        } => {
+                    let residual = residual
+                        .as_ref()
+                        .map(|residual| {
                             let mut names =
                                 aexpr_to_leaf_names_iter(residual.node(), ctx.expr_arena)
                                     .cloned()
@@ -1246,14 +1244,12 @@ fn to_graph_rec<'a>(
 
                             let residual_schema =
                                 Arc::new(output_schema.try_project(names.iter())?);
-                            let residual = residual.clone();
-                            Some((
-                                create_stream_expr(&residual, ctx, &residual_schema)?,
+                            PolarsResult::Ok((
+                                create_stream_expr(residual, ctx, &residual_schema)?,
                                 residual_schema,
                             ))
-                        },
-                        _ => None,
-                    };
+                        })
+                        .transpose()?;
 
                     ctx.graph.add_node(
                         nodes::joins::equi_join::EquiJoinNode::new(
@@ -1275,6 +1271,7 @@ fn to_graph_rec<'a>(
                         ],
                     )
                 },
+                _ => unreachable!(),
             }
         },
 

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1153,7 +1153,7 @@ fn to_graph_rec<'a>(
             left_on,
             right_on,
             args,
-            residual: _,
+            fused_predicate: _,
         }
         | SemiAntiJoin {
             input_left,
@@ -1229,24 +1229,27 @@ fn to_graph_rec<'a>(
                         (right_input_key, input_right.port),
                     ],
                 ),
-                EquiJoin { ref residual, .. } => {
+                EquiJoin {
+                    ref fused_predicate,
+                    ..
+                } => {
                     // Compiled against a narrow frame of exactly the columns it reads, in
                     // the order the node gathers them.
-                    let residual = residual
+                    let fused_predicate = fused_predicate
                         .as_ref()
-                        .map(|residual| {
+                        .map(|fused_predicate| {
                             let mut names =
-                                aexpr_to_leaf_names_iter(residual.node(), ctx.expr_arena)
+                                aexpr_to_leaf_names_iter(fused_predicate.node(), ctx.expr_arena)
                                     .cloned()
                                     .collect::<Vec<_>>();
                             names.sort_unstable();
                             names.dedup();
 
-                            let residual_schema =
+                            let fused_predicate_schema =
                                 Arc::new(output_schema.try_project(names.iter())?);
                             PolarsResult::Ok((
-                                create_stream_expr(residual, ctx, &residual_schema)?,
-                                residual_schema,
+                                create_stream_expr(fused_predicate, ctx, &fused_predicate_schema)?,
+                                fused_predicate_schema,
                             ))
                         })
                         .transpose()?;
@@ -1261,7 +1264,7 @@ fn to_graph_rec<'a>(
                             output_schema,
                             left_key_selectors,
                             right_key_selectors,
-                            residual,
+                            fused_predicate,
                             args,
                             ctx.num_pipelines,
                         )?,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -19,6 +19,7 @@ use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::options::JoinOptionsIR;
 use polars_plan::plans::{AExpr, ArenaExprIter, IR, IRAggExpr};
 use polars_plan::prelude::FunctionFlags;
+use polars_plan::utils::aexpr_to_leaf_names_iter;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools;
@@ -1152,6 +1153,7 @@ fn to_graph_rec<'a>(
             left_on,
             right_on,
             args,
+            residual: _,
         }
         | SemiAntiJoin {
             input_left,
@@ -1227,24 +1229,52 @@ fn to_graph_rec<'a>(
                         (right_input_key, input_right.port),
                     ],
                 ),
-                _ => ctx.graph.add_node(
-                    nodes::joins::equi_join::EquiJoinNode::new(
-                        left_input_schema,
-                        right_input_schema,
-                        left_key_schema,
-                        right_key_schema,
-                        unique_key_schema,
-                        output_schema,
-                        left_key_selectors,
-                        right_key_selectors,
-                        args,
-                        ctx.num_pipelines,
-                    )?,
-                    [
-                        (left_input_key, input_left.port),
-                        (right_input_key, input_right.port),
-                    ],
-                ),
+                _ => {
+                    // Compiled against a narrow frame of exactly the columns it reads, in
+                    // the order the node gathers them.
+                    let residual = match &node.kind {
+                        EquiJoin {
+                            residual: Some(residual),
+                            ..
+                        } => {
+                            let mut names =
+                                aexpr_to_leaf_names_iter(residual.node(), ctx.expr_arena)
+                                    .cloned()
+                                    .collect::<Vec<_>>();
+                            names.sort_unstable();
+                            names.dedup();
+
+                            let residual_schema =
+                                Arc::new(output_schema.try_project(names.iter())?);
+                            let residual = residual.clone();
+                            Some((
+                                create_stream_expr(&residual, ctx, &residual_schema)?,
+                                residual_schema,
+                            ))
+                        },
+                        _ => None,
+                    };
+
+                    ctx.graph.add_node(
+                        nodes::joins::equi_join::EquiJoinNode::new(
+                            left_input_schema,
+                            right_input_schema,
+                            left_key_schema,
+                            right_key_schema,
+                            unique_key_schema,
+                            output_schema,
+                            left_key_selectors,
+                            right_key_selectors,
+                            residual,
+                            args,
+                            ctx.num_pipelines,
+                        )?,
+                        [
+                            (left_input_key, input_left.port),
+                            (right_input_key, input_right.port),
+                        ],
+                    )
+                },
             }
         },
 

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1907,3 +1907,16 @@ def test_or_factoring_skips_nondeterminism_in_eval_body() -> None:
 
     plan = query.explain()
     assert plan.count("shuffle") == 2, plan
+
+
+def test_predicate_pushdown_fallible_inside_list_eval() -> None:
+    lf = pl.LazyFrame({"k": [1, 2], "a": [["1"], ["bad"]]})
+
+    q = lf.filter(pl.col("k") == 1).filter(
+        pl.col("a").list.eval(pl.element().cast(pl.Int64)).list.first() == 1
+    )
+
+    plan = q.explain()
+    assert plan.index("list.eval") < plan.index('FILTER col("k")')
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"k": [1], "a": [["1"]]}))

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -255,7 +255,9 @@ def test_join_where_predicates(range_constraint: list[pl.Expr]) -> None:
 
     explained = q.explain()
     assert "INNER JOIN" in explained
-    assert "FILTER" in explained
+    # The equality becomes the join key; the range constraint stays a separate
+    # condition, fused into the join as its residual.
+    assert "RESIDUAL" in explained
     actual = q.collect()
 
     expected = (

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -256,8 +256,8 @@ def test_join_where_predicates(range_constraint: list[pl.Expr]) -> None:
     explained = q.explain()
     assert "INNER JOIN" in explained
     # The equality becomes the join key; the range constraint stays a separate
-    # condition, fused into the join as its residual.
-    assert "RESIDUAL" in explained
+    # condition, fused into the join as its fused predicate.
+    assert "FUSED PREDICATE" in explained
     actual = q.collect()
 
     expected = (

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1686,7 +1686,7 @@ def test_join_where_predicate_type_coercion_21009() -> None:
 
     plan = q1.explain().splitlines()
     assert plan[0].strip().startswith("INNER JOIN")
-    assert plan[1].strip().startswith("RESIDUAL")
+    assert plan[1].strip().startswith("FUSED PREDICATE")
 
     q2 = left_frame.join_where(
         right_frame,
@@ -1696,7 +1696,7 @@ def test_join_where_predicate_type_coercion_21009() -> None:
 
     plan = q2.explain().splitlines()
     assert plan[0].strip().startswith("INNER JOIN")
-    assert plan[1].strip().startswith("RESIDUAL")
+    assert plan[1].strip().startswith("FUSED PREDICATE")
 
     assert_frame_equal(q1.collect(), q2.collect())
 
@@ -2649,7 +2649,7 @@ def test_join_filter_pushdown_inner_join() -> None:
         'LEFT PLAN ON: [col("a"), col("b")]',
         'RIGHT PLAN ON: [col("a"), col("b").alias("__POLARS_JOIN_KEY_0_b")]',
     ]
-    assert "RESIDUAL" not in plan
+    assert "FUSED PREDICATE" not in plan
 
     assert_frame_equal(q.collect(), expect)
     assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expect)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1685,9 +1685,8 @@ def test_join_where_predicate_type_coercion_21009() -> None:
     )
 
     plan = q1.explain().splitlines()
-    assert plan[0].strip().startswith("FILTER")
-    assert plan[1] == "FROM"
-    assert plan[2].strip().startswith("INNER JOIN")
+    assert plan[0].strip().startswith("INNER JOIN")
+    assert plan[1].strip().startswith("RESIDUAL")
 
     q2 = left_frame.join_where(
         right_frame,
@@ -1696,9 +1695,8 @@ def test_join_where_predicate_type_coercion_21009() -> None:
     )
 
     plan = q2.explain().splitlines()
-    assert plan[0].strip().startswith("FILTER")
-    assert plan[1] == "FROM"
-    assert plan[2].strip().startswith("INNER JOIN")
+    assert plan[0].strip().startswith("INNER JOIN")
+    assert plan[1].strip().startswith("RESIDUAL")
 
     assert_frame_equal(q1.collect(), q2.collect())
 
@@ -2629,8 +2627,6 @@ def test_join_filter_pushdown_inner_join() -> None:
     assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expect)
 
     # Filters don't pass if they refer to columns from both tables
-    # TODO: In the optimizer we can add additional equalities into the join
-    # condition itself for some cases.
     q = lhs.join(rhs, on=["a"], how="inner", maintain_order="left_right").filter(
         pl.col("b") == pl.col("b_right")
     )
@@ -2647,12 +2643,13 @@ def test_join_filter_pushdown_inner_join() -> None:
 
     plan = q.explain()
 
+    # An equality spanning both sides becomes another key pair.
     extract = _extract_plan_joins_and_filters(plan)
     assert extract == [
-        'FILTER col("b") == col("b_right")',
-        'LEFT PLAN ON: [col("a")]',
-        'RIGHT PLAN ON: [col("a")]',
+        'LEFT PLAN ON: [col("a"), col("b")]',
+        'RIGHT PLAN ON: [col("a"), col("b").alias("__POLARS_JOIN_KEY_0_b")]',
     ]
+    assert "RESIDUAL" not in plan
 
     assert_frame_equal(q.collect(), expect)
     assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expect)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4511,3 +4511,28 @@ def test_empty_join_result_with_chunked_array_29093() -> None:
     result = lhs.join(rhs, on="x")
     expected = pl.DataFrame(schema={"x": pl.Int64, "y": pl.Array(pl.Int64, 3)})
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right", "full"])
+@pytest.mark.parametrize("coalesce", [True, False])
+def test_merge_join_coalesce_right_payload_name_collision(
+    how: JoinStrategy, coalesce: bool
+) -> None:
+    # The right payload `a` shares its name with the left key, which the merge join
+    # must not confuse with its own key `b`.
+    left = pl.LazyFrame({"a": [1, 2, 3], "p": [10, 20, 30]}).sort("a")
+    right = pl.LazyFrame({"b": [1, 2, 4], "a": [7, 8, 9]}).sort("b")
+    q = left.join(
+        right,
+        left_on="a",
+        right_on="b",
+        how=how,
+        coalesce=coalesce,
+        maintain_order="left_right",
+    )
+
+    assert_frame_equal(
+        q.collect(engine="streaming"),
+        q.collect(engine="in-memory"),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/operations/test_join_fused_predicate.py
+++ b/py-polars/tests/unit/operations/test_join_fused_predicate.py
@@ -1,4 +1,4 @@
-"""Tests for predicates fused into an inner join as its residual match condition."""
+"""Tests for predicates fused into an inner join as part of its match condition."""
 
 from __future__ import annotations
 
@@ -18,19 +18,19 @@ ENGINES: list[EngineType] = ["in-memory", "streaming"]
 
 
 def assert_fused(lf: pl.LazyFrame) -> None:
-    assert "RESIDUAL" in lf.explain()
+    assert "FUSED PREDICATE" in lf.explain()
 
 
 def assert_not_fused(lf: pl.LazyFrame) -> None:
-    assert "RESIDUAL" not in lf.explain()
+    assert "FUSED PREDICATE" not in lf.explain()
 
 
-def assert_residual_native(lf: pl.LazyFrame, native: bool = True) -> None:
-    """Whether the residual reached the streaming hash join or a fallback filter."""
+def assert_fused_native(lf: pl.LazyFrame, native: bool = True) -> None:
+    """Whether the predicate reached the streaming hash join or a fallback filter."""
     plan = lf.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
     assert plan is not None
     assert "equi-join" in plan
-    assert ("residual:" in plan) == native
+    assert ("fused predicate:" in plan) == native
     assert ("filter" in plan) != native
 
 
@@ -62,7 +62,7 @@ def frames() -> tuple[pl.LazyFrame, pl.LazyFrame]:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_matches_unfused_reference(
+def test_fused_matches_unfused_reference(
     frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = frames
@@ -76,12 +76,12 @@ def test_residual_matches_unfused_reference(
     )
 
 
-def test_residual_native_streaming_path(
+def test_fused_native_streaming_path(
     frames: tuple[pl.LazyFrame, pl.LazyFrame],
 ) -> None:
     left, right = frames
     q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
-    assert_residual_native(q)
+    assert_fused_native(q)
 
 
 @pytest.mark.parametrize("engine", ENGINES)
@@ -96,7 +96,7 @@ def test_residual_native_streaming_path(
         pl.col("a").cast(pl.Float64) > pl.col("b").cast(pl.Float64),
     ],
 )
-def test_residual_expressions(
+def test_fused_expressions(
     frames: tuple[pl.LazyFrame, pl.LazyFrame], predicate: pl.Expr, engine: EngineType
 ) -> None:
     left, right = frames
@@ -109,7 +109,7 @@ def test_residual_expressions(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_composite_and_duplicate_keys(engine: EngineType) -> None:
+def test_fused_composite_and_duplicate_keys(engine: EngineType) -> None:
     left = pl.LazyFrame(
         {
             "k1": [1, 1, 1, 2, 2],
@@ -135,7 +135,7 @@ def test_residual_composite_and_duplicate_keys(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_string_keys(engine: EngineType) -> None:
+def test_fused_string_keys(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": ["x", "x", "y", "z"], "a": [1, 2, 3, 4]})
     right = pl.LazyFrame({"k": ["x", "y", "y", "w"], "b": [2, 1, 9, 0]})
     q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
@@ -150,7 +150,7 @@ def test_residual_string_keys(engine: EngineType) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("nulls_equal", [True, False])
-def test_residual_null_keys_and_values(engine: EngineType, nulls_equal: bool) -> None:
+def test_fused_null_keys_and_values(engine: EngineType, nulls_equal: bool) -> None:
     left = pl.LazyFrame({"k": [1, None, 2, None], "a": [10, 20, None, 40]})
     right = pl.LazyFrame({"k": [1, None, 2], "b": [1, 5, None]})
     predicate = pl.col("b") < pl.col("a")
@@ -175,7 +175,7 @@ def test_residual_null_keys_and_values(engine: EngineType, nulls_equal: bool) ->
         ([], [], True),  # both empty
     ],
 )
-def test_residual_degenerate_inputs(
+def test_fused_degenerate_inputs(
     engine: EngineType, left_k: list[int], right_k: list[int], predicate_true: bool
 ) -> None:
     left = pl.LazyFrame(
@@ -200,7 +200,7 @@ def test_residual_degenerate_inputs(
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("suffix", ["_right", "_R"])
 @pytest.mark.parametrize("coalesce", [True, False])
-def test_residual_suffix_and_coalesce(
+def test_fused_suffix_and_coalesce(
     engine: EngineType, suffix: str, coalesce: bool
 ) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]})
@@ -217,8 +217,8 @@ def test_residual_suffix_and_coalesce(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_only_columns_dropped_by_select(engine: EngineType) -> None:
-    """`v`/`v_right` are read only by the residual, so they must survive to the join."""
+def test_fused_only_columns_dropped_by_select(engine: EngineType) -> None:
+    """`v`/`v_right` are read only by the predicate, so they must reach the join."""
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30], "keep": ["a", "b", "c"]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
     predicate = pl.col("v_right") < pl.col("v")
@@ -233,8 +233,8 @@ def test_residual_only_columns_dropped_by_select(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_suffix_dropped_when_collision_disappears(engine: EngineType) -> None:
-    """Pruning the left `v` un-suffixes the right one; the residual must follow."""
+def test_fused_suffix_dropped_when_collision_disappears(engine: EngineType) -> None:
+    """Pruning the left `v` un-suffixes the right one; the predicate must follow."""
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [99, 99, 99], "x": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
     predicate = pl.col("v_right") < pl.col("x")
@@ -249,7 +249,7 @@ def test_residual_suffix_dropped_when_collision_disappears(engine: EngineType) -
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_reads_right_key(engine: EngineType) -> None:
+def test_fused_reads_right_key(engine: EngineType) -> None:
     """The right key must survive even though nothing else projects it.
 
     Predicate pushdown may rewrite `k_right` to `k` and push it to one side, so this
@@ -271,7 +271,7 @@ def test_residual_reads_right_key(engine: EngineType) -> None:
 @pytest.mark.parametrize(
     "maintain_order", ["none", "left", "right", "left_right", "right_left"]
 )
-def test_residual_maintain_order(engine: EngineType, maintain_order: str) -> None:
+def test_fused_maintain_order(engine: EngineType, maintain_order: str) -> None:
     left = pl.LazyFrame({"k": [1, 2, 1, 3, 2], "a": [10, 20, 30, 40, 50]})
     right = pl.LazyFrame({"k": [1, 2, 2, 3], "b": [5, 15, 45, 5]})
     predicate = pl.col("b") < pl.col("a")
@@ -298,7 +298,7 @@ def test_residual_maintain_order(engine: EngineType, maintain_order: str) -> Non
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("build_side", ["force_left", "force_right"])
-def test_residual_forced_build_side(engine: EngineType, build_side: str) -> None:
+def test_fused_forced_build_side(engine: EngineType, build_side: str) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2, 3], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2, 2, 4], "b": [5, 15, 45, 0]})
     predicate = pl.col("b") < pl.col("a")
@@ -312,7 +312,7 @@ def test_residual_forced_build_side(engine: EngineType, build_side: str) -> None
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_many_morsels_and_skew(engine: EngineType) -> None:
+def test_fused_many_morsels_and_skew(engine: EngineType) -> None:
     """More rows than one morsel, plus a key whose duplicate list exceeds the limit."""
     n = 60_000
     left = pl.LazyFrame({"k": [0] * n + list(range(n)), "a": list(range(2 * n))})
@@ -329,7 +329,7 @@ def test_residual_many_morsels_and_skew(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_rejected_batch_followed_by_accepted(engine: EngineType) -> None:
+def test_fused_rejected_batch_followed_by_accepted(engine: EngineType) -> None:
     """Leading candidates are all rejected; later survivors must still be emitted."""
     n = 20_000
     left = pl.LazyFrame({"k": [1] * n + [2] * n, "a": [0] * n + [100] * n})
@@ -345,7 +345,7 @@ def test_residual_rejected_batch_followed_by_accepted(engine: EngineType) -> Non
 
 
 @pytest.mark.parametrize("how", ["left", "right", "full"])
-def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
+def test_fused_not_fused_while_join_stays_outer(how: str) -> None:
     """Keeping null-extended rows leaves the join outer, so it cannot fuse."""
     left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
@@ -362,7 +362,7 @@ def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("how", ["left", "right", "full"])
-def test_residual_outer_join_reduced_to_inner(engine: EngineType, how: str) -> None:
+def test_fused_outer_join_reduced_to_inner(engine: EngineType, how: str) -> None:
     """Rejecting null-extended rows turns the join inner, which may then fuse."""
     left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
@@ -377,7 +377,7 @@ def test_residual_outer_join_reduced_to_inner(engine: EngineType, how: str) -> N
     )
 
 
-def test_residual_not_fused_for_non_elementwise_predicates() -> None:
+def test_fused_not_fused_for_non_elementwise_predicates() -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 2], "b": [5, 15, 45]})
 
@@ -390,7 +390,7 @@ def test_residual_not_fused_for_non_elementwise_predicates() -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_slice_ordering(engine: EngineType) -> None:
+def test_fused_slice_ordering(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
     predicate = pl.col("b") < pl.col("a")
@@ -411,8 +411,8 @@ def test_residual_slice_ordering(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_validation_still_errors(engine: EngineType) -> None:
-    """Validation runs on the keys; a residual rejecting the pair does not excuse it."""
+def test_fused_validation_still_errors(engine: EngineType) -> None:
+    """Validation runs on the keys; a rejected pair does not excuse a duplicate key."""
     left = pl.LazyFrame({"k": [1, 2], "a": [10, 20]})
     right = pl.LazyFrame({"k": [1, 1, 2], "b": [99, 99, 99]})
     q = left.join(right, on="k", validate="m:1").filter(pl.col("b") < pl.col("a"))
@@ -423,7 +423,7 @@ def test_residual_validation_still_errors(engine: EngineType) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("join_order", [True, False])
-def test_residual_with_join_order(engine: EngineType, join_order: bool) -> None:
+def test_fused_with_join_order(engine: EngineType, join_order: bool) -> None:
     a = pl.LazyFrame({"k": [1, 2, 3], "x": [1, 2, 3]})
     b = pl.LazyFrame({"k": [1, 2, 3], "y": [3, 2, 1]})
     c = pl.LazyFrame({"k": [1, 2, 3], "z": [1, 1, 1]})
@@ -438,7 +438,7 @@ def test_residual_with_join_order(engine: EngineType, join_order: bool) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_shared_join_with_distinct_predicates(engine: EngineType) -> None:
+def test_fused_shared_join_with_distinct_predicates(engine: EngineType) -> None:
     """One join feeding two filters must not have either fused into the other."""
     left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 35]})
@@ -457,18 +457,18 @@ def test_residual_shared_join_with_distinct_predicates(engine: EngineType) -> No
     assert_frame_equal(q.collect(engine=engine), expected, check_row_order=False)
 
 
-def test_residual_optimization_is_idempotent() -> None:
-    """Optimizing the same plan repeatedly must not lose or duplicate the residual."""
+def test_fused_optimization_is_idempotent() -> None:
+    """Optimizing the same plan repeatedly must not lose or duplicate the predicate."""
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
     predicate = pl.col("b") < pl.col("a")
     q = left.join(right, on="k").filter(predicate)
 
-    assert q.explain().count("RESIDUAL") == 1
+    assert q.explain().count("FUSED PREDICATE") == 1
     assert q.explain() == q.explain()
 
     roundtripped = pl.LazyFrame.deserialize(q.serialize())
-    assert roundtripped.explain().count("RESIDUAL") == 1
+    assert roundtripped.explain().count("FUSED PREDICATE") == 1
     assert_frame_equal(
         roundtripped.collect(),
         reference(left, right, predicate, on="k"),
@@ -476,14 +476,14 @@ def test_residual_optimization_is_idempotent() -> None:
     )
 
 
-def test_residual_unfused_when_predicate_pushdown_disabled() -> None:
+def test_fused_unfused_when_predicate_pushdown_disabled() -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
     predicate = pl.col("b") < pl.col("a")
     q = left.join(right, on="k").filter(predicate)
 
     unfused = q.explain(optimizations=pl.QueryOptFlags(predicate_pushdown=False))
-    assert "RESIDUAL" not in unfused
+    assert "FUSED PREDICATE" not in unfused
     assert "FILTER" in unfused
 
     assert_frame_equal(
@@ -618,7 +618,7 @@ def test_float_equality_becomes_join_key(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_equality_promoted_and_rest_stays_residual(
+def test_equality_promoted_and_rest_stays_fused(
     eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = eq_frames
@@ -739,14 +739,14 @@ def test_fallible_inside_list_eval_is_not_promoted(engine: EngineType) -> None:
 
 
 @pytest.mark.parametrize("maintain_order", ["left", "right", "left_right"])
-def test_residual_not_native_when_order_is_preserved(maintain_order: str) -> None:
-    """The ordered probe would evaluate the residual a group at a time."""
+def test_fused_not_native_when_order_is_preserved(maintain_order: str) -> None:
+    """The ordered probe would evaluate the fused predicate a group at a time."""
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [1, 5, 9]})
     right = pl.LazyFrame({"k": [1, 2, 2], "b": [3, 4, 7]})
     predicate = pl.col("a") < pl.col("b")
     q = left.join(right, on="k", maintain_order=maintain_order).filter(predicate)  # type: ignore[arg-type]
 
-    assert_residual_native(q, native=False)
+    assert_fused_native(q, native=False)
     assert_frame_equal(
         q.collect(engine="streaming"),
         reference(left, right, predicate, on="k", maintain_order=maintain_order),
@@ -803,8 +803,8 @@ def test_non_strict_cast_equality_is_promoted(engine: EngineType) -> None:
     )
 
 
-def test_residual_gathers_from_a_multi_chunk_payload() -> None:
-    """A multi-chunk probe payload is rechunked before the residual gathers from it."""
+def test_fused_gathers_from_a_multi_chunk_payload() -> None:
+    """A multi-chunk probe payload is rechunked before the predicate gathers from it."""
     left = pl.concat(
         [
             pl.DataFrame({"k": [1, 2, 3], "a": [10, 20, 30]}),
@@ -817,7 +817,7 @@ def test_residual_gathers_from_a_multi_chunk_payload() -> None:
     predicate = pl.col("a") < pl.col("b")
     q = left.lazy().join(right.lazy(), on="k").filter(predicate)
 
-    assert_residual_native(q)
+    assert_fused_native(q)
     assert_frame_equal(
         q.collect(engine="streaming"),
         reference(left.lazy(), right.lazy(), predicate, on="k"),

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -798,7 +798,7 @@ def test_non_strict_cast_equality_is_promoted(engine: str) -> None:
 
 
 def test_residual_gathers_from_a_multi_chunk_payload() -> None:
-    """The probe payload is rechunked on the first gather, not up front."""
+    """A multi-chunk probe payload is rechunked before the residual gathers from it."""
     left = pl.concat(
         [
             pl.DataFrame({"k": [1, 2, 3], "a": [10, 20, 30]}),

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -799,3 +799,25 @@ def test_non_strict_cast_equality_is_promoted(engine: str) -> None:
         reference(left, right, predicate, on="k"),
         check_row_order=False,
     )
+
+
+def test_residual_gathers_from_a_multi_chunk_payload() -> None:
+    """The probe payload is rechunked on the first gather, not up front."""
+    left = pl.concat(
+        [
+            pl.DataFrame({"k": [1, 2, 3], "a": [10, 20, 30]}),
+            pl.DataFrame({"k": [1, 2, 3], "a": [11, 21, 31]}),
+        ],
+        rechunk=False,
+    )
+    assert left.n_chunks() == 2
+    right = pl.DataFrame({"k": [1, 1, 2, 3], "b": [15, 5, 25, 99]})
+    predicate = pl.col("a") < pl.col("b")
+    q = left.lazy().join(right.lazy(), on="k").filter(predicate)
+
+    assert_native_streaming(q)
+    assert_frame_equal(
+        q.collect(engine="streaming"),
+        reference(left.lazy(), right.lazy(), predicate, on="k"),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -716,3 +716,17 @@ def test_promoted_key_keeps_right_payload_in_merge_join(engine: str) -> None:
         q.collect(engine=engine),
         reference(left, right, predicate, on="k", maintain_order="left_right"),
     )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_fallible_inside_list_eval_is_not_promoted(engine: str) -> None:
+    """A key is evaluated on every row, so a nested fallible cast must block it."""
+    left = pl.LazyFrame({"k": [1, 2], "a": [["1"], ["bad"]]})
+    right = pl.LazyFrame({"k": [1], "b": [[1]]})
+    predicate = pl.col("a").list.eval(pl.element().cast(pl.Int64)) == pl.col("b")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine), reference(left, right, predicate, on="k")
+    )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -200,7 +200,9 @@ def test_residual_degenerate_inputs(
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("suffix", ["_right", "_R"])
 @pytest.mark.parametrize("coalesce", [True, False])
-def test_residual_suffix_and_coalesce(engine: EngineType, suffix: str, coalesce: bool) -> None:
+def test_residual_suffix_and_coalesce(
+    engine: EngineType, suffix: str, coalesce: bool
+) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
     predicate = pl.col(f"v{suffix}") < pl.col("v")

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,7 +11,10 @@ import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
-ENGINES = ["in-memory", "streaming"]
+if TYPE_CHECKING:
+    from polars._typing import EngineType
+
+ENGINES: list[EngineType] = ["in-memory", "streaming"]
 
 
 def assert_fused(lf: pl.LazyFrame) -> None:
@@ -59,7 +63,7 @@ def frames() -> tuple[pl.LazyFrame, pl.LazyFrame]:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_residual_matches_unfused_reference(
-    frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+    frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = frames
     q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
@@ -93,7 +97,7 @@ def test_residual_native_streaming_path(
     ],
 )
 def test_residual_expressions(
-    frames: tuple[pl.LazyFrame, pl.LazyFrame], predicate: pl.Expr, engine: str
+    frames: tuple[pl.LazyFrame, pl.LazyFrame], predicate: pl.Expr, engine: EngineType
 ) -> None:
     left, right = frames
     q = left.join(right, on="k").filter(predicate)
@@ -105,7 +109,7 @@ def test_residual_expressions(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_composite_and_duplicate_keys(engine: str) -> None:
+def test_residual_composite_and_duplicate_keys(engine: EngineType) -> None:
     left = pl.LazyFrame(
         {
             "k1": [1, 1, 1, 2, 2],
@@ -131,7 +135,7 @@ def test_residual_composite_and_duplicate_keys(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_string_keys(engine: str) -> None:
+def test_residual_string_keys(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": ["x", "x", "y", "z"], "a": [1, 2, 3, 4]})
     right = pl.LazyFrame({"k": ["x", "y", "y", "w"], "b": [2, 1, 9, 0]})
     q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
@@ -146,7 +150,7 @@ def test_residual_string_keys(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("nulls_equal", [True, False])
-def test_residual_null_keys_and_values(engine: str, nulls_equal: bool) -> None:
+def test_residual_null_keys_and_values(engine: EngineType, nulls_equal: bool) -> None:
     left = pl.LazyFrame({"k": [1, None, 2, None], "a": [10, 20, None, 40]})
     right = pl.LazyFrame({"k": [1, None, 2], "b": [1, 5, None]})
     predicate = pl.col("b") < pl.col("a")
@@ -172,7 +176,7 @@ def test_residual_null_keys_and_values(engine: str, nulls_equal: bool) -> None:
     ],
 )
 def test_residual_degenerate_inputs(
-    engine: str, left_k: list[int], right_k: list[int], predicate_true: bool
+    engine: EngineType, left_k: list[int], right_k: list[int], predicate_true: bool
 ) -> None:
     left = pl.LazyFrame(
         {"k": left_k, "a": [1] * len(left_k)}, schema={"k": pl.Int64, "a": pl.Int64}
@@ -196,7 +200,7 @@ def test_residual_degenerate_inputs(
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("suffix", ["_right", "_R"])
 @pytest.mark.parametrize("coalesce", [True, False])
-def test_residual_suffix_and_coalesce(engine: str, suffix: str, coalesce: bool) -> None:
+def test_residual_suffix_and_coalesce(engine: EngineType, suffix: str, coalesce: bool) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
     predicate = pl.col(f"v{suffix}") < pl.col("v")
@@ -211,7 +215,7 @@ def test_residual_suffix_and_coalesce(engine: str, suffix: str, coalesce: bool) 
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_only_columns_dropped_by_select(engine: str) -> None:
+def test_residual_only_columns_dropped_by_select(engine: EngineType) -> None:
     """`v`/`v_right` are read only by the residual, so they must survive to the join."""
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30], "keep": ["a", "b", "c"]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
@@ -227,7 +231,7 @@ def test_residual_only_columns_dropped_by_select(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_suffix_dropped_when_collision_disappears(engine: str) -> None:
+def test_residual_suffix_dropped_when_collision_disappears(engine: EngineType) -> None:
     """Pruning the left `v` un-suffixes the right one; the residual must follow."""
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [99, 99, 99], "x": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
@@ -243,7 +247,7 @@ def test_residual_suffix_dropped_when_collision_disappears(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_reads_right_key(engine: str) -> None:
+def test_residual_reads_right_key(engine: EngineType) -> None:
     """The right key must survive even though nothing else projects it.
 
     Predicate pushdown may rewrite `k_right` to `k` and push it to one side, so this
@@ -265,7 +269,7 @@ def test_residual_reads_right_key(engine: str) -> None:
 @pytest.mark.parametrize(
     "maintain_order", ["none", "left", "right", "left_right", "right_left"]
 )
-def test_residual_maintain_order(engine: str, maintain_order: str) -> None:
+def test_residual_maintain_order(engine: EngineType, maintain_order: str) -> None:
     left = pl.LazyFrame({"k": [1, 2, 1, 3, 2], "a": [10, 20, 30, 40, 50]})
     right = pl.LazyFrame({"k": [1, 2, 2, 3], "b": [5, 15, 45, 5]})
     predicate = pl.col("b") < pl.col("a")
@@ -292,7 +296,7 @@ def test_residual_maintain_order(engine: str, maintain_order: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("build_side", ["force_left", "force_right"])
-def test_residual_forced_build_side(engine: str, build_side: str) -> None:
+def test_residual_forced_build_side(engine: EngineType, build_side: str) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2, 3], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2, 2, 4], "b": [5, 15, 45, 0]})
     predicate = pl.col("b") < pl.col("a")
@@ -306,7 +310,7 @@ def test_residual_forced_build_side(engine: str, build_side: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_many_morsels_and_skew(engine: str) -> None:
+def test_residual_many_morsels_and_skew(engine: EngineType) -> None:
     """More rows than one morsel, plus a key whose duplicate list exceeds the limit."""
     n = 60_000
     left = pl.LazyFrame({"k": [0] * n + list(range(n)), "a": list(range(2 * n))})
@@ -323,7 +327,7 @@ def test_residual_many_morsels_and_skew(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_rejected_batch_followed_by_accepted(engine: str) -> None:
+def test_residual_rejected_batch_followed_by_accepted(engine: EngineType) -> None:
     """Leading candidates are all rejected; later survivors must still be emitted."""
     n = 20_000
     left = pl.LazyFrame({"k": [1] * n + [2] * n, "a": [0] * n + [100] * n})
@@ -356,7 +360,7 @@ def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("how", ["left", "right", "full"])
-def test_residual_outer_join_reduced_to_inner(engine: str, how: str) -> None:
+def test_residual_outer_join_reduced_to_inner(engine: EngineType, how: str) -> None:
     """Rejecting null-extended rows turns the join inner, which may then fuse."""
     left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
@@ -384,7 +388,7 @@ def test_residual_not_fused_for_non_elementwise_predicates() -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_slice_ordering(engine: str) -> None:
+def test_residual_slice_ordering(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
     predicate = pl.col("b") < pl.col("a")
@@ -405,7 +409,7 @@ def test_residual_slice_ordering(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_validation_still_errors(engine: str) -> None:
+def test_residual_validation_still_errors(engine: EngineType) -> None:
     """Validation runs on the keys; a residual rejecting the pair does not excuse it."""
     left = pl.LazyFrame({"k": [1, 2], "a": [10, 20]})
     right = pl.LazyFrame({"k": [1, 1, 2], "b": [99, 99, 99]})
@@ -417,7 +421,7 @@ def test_residual_validation_still_errors(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("join_order", [True, False])
-def test_residual_with_join_order(engine: str, join_order: bool) -> None:
+def test_residual_with_join_order(engine: EngineType, join_order: bool) -> None:
     a = pl.LazyFrame({"k": [1, 2, 3], "x": [1, 2, 3]})
     b = pl.LazyFrame({"k": [1, 2, 3], "y": [3, 2, 1]})
     c = pl.LazyFrame({"k": [1, 2, 3], "z": [1, 1, 1]})
@@ -432,7 +436,7 @@ def test_residual_with_join_order(engine: str, join_order: bool) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_residual_shared_join_with_distinct_predicates(engine: str) -> None:
+def test_residual_shared_join_with_distinct_predicates(engine: EngineType) -> None:
     """One join feeding two filters must not have either fused into the other."""
     left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 35]})
@@ -515,7 +519,7 @@ def eq_frames() -> tuple[pl.LazyFrame, pl.LazyFrame]:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_becomes_join_key(
-    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = eq_frames
     predicate = pl.col("a") == pl.col("b")
@@ -535,7 +539,7 @@ def test_equality_becomes_join_key(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_equality_key_rejects_nulls(engine: str) -> None:
+def test_equality_key_rejects_nulls(engine: EngineType) -> None:
     left = pl.LazyFrame(
         {"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64}
     )
@@ -555,7 +559,7 @@ def test_equality_key_rejects_nulls(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_not_promoted_when_join_matches_nulls(
-    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     """`==` rejects a null pair, so it cannot become a key that matches them."""
     left, right = eq_frames
@@ -572,7 +576,7 @@ def test_equality_not_promoted_when_join_matches_nulls(
 
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("nulls_equal", [False, True])
-def test_eq_missing_matches_the_join(engine: str, nulls_equal: bool) -> None:
+def test_eq_missing_matches_the_join(engine: EngineType, nulls_equal: bool) -> None:
     left = pl.LazyFrame(
         {"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64}
     )
@@ -595,7 +599,7 @@ def test_eq_missing_matches_the_join(engine: str, nulls_equal: bool) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_float_equality_becomes_join_key(engine: str) -> None:
+def test_float_equality_becomes_join_key(engine: EngineType) -> None:
     """`==` and a key pair agree on NaN, so floats promote like any other dtype."""
     nan = float("nan")
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [1.5, nan, nan]})
@@ -613,7 +617,7 @@ def test_float_equality_becomes_join_key(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_promoted_and_rest_stays_residual(
-    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = eq_frames
     predicate = (pl.col("a") == pl.col("b")) & (pl.col("a") + pl.col("b") > 40)
@@ -630,7 +634,7 @@ def test_equality_promoted_and_rest_stays_residual(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_equality_promoted_with_suffixed_column(engine: str) -> None:
+def test_equality_promoted_with_suffixed_column(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 99, 30]})
     predicate = pl.col("a") == pl.col("a_right")
@@ -646,7 +650,7 @@ def test_equality_promoted_with_suffixed_column(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_several_equalities_sharing_a_left_column(engine: str) -> None:
+def test_several_equalities_sharing_a_left_column(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 1, 2], "b": [10, 20, 30], "c": [10, 99, 30]})
     predicate = (pl.col("a") == pl.col("b")) & (pl.col("a") == pl.col("c"))
@@ -663,7 +667,7 @@ def test_several_equalities_sharing_a_left_column(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_promoted_without_coalesce(
-    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: EngineType
 ) -> None:
     left, right = eq_frames
     predicate = pl.col("a") == pl.col("b")
@@ -679,7 +683,7 @@ def test_equality_promoted_without_coalesce(
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_equality_resolves_suffixed_output_column(engine: str) -> None:
+def test_equality_resolves_suffixed_output_column(engine: EngineType) -> None:
     """An output name can belong to a different column than it shares a name with."""
     left = pl.LazyFrame({"k": [1, 1], "v": [10, 20]})
     right = pl.LazyFrame({"v_right": [1, 1], "v": [10, 20]})
@@ -705,7 +709,7 @@ def test_equality_resolves_suffixed_output_column(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_promoted_key_keeps_right_payload_in_merge_join(engine: str) -> None:
+def test_promoted_key_keeps_right_payload_in_merge_join(engine: EngineType) -> None:
     """Sorted inputs take the merge join, which coalesces by name."""
     left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]}).sort("k", "v")
     right = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 99, 30]}).sort("k", "v")
@@ -719,7 +723,7 @@ def test_promoted_key_keeps_right_payload_in_merge_join(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_fallible_inside_list_eval_is_not_promoted(engine: str) -> None:
+def test_fallible_inside_list_eval_is_not_promoted(engine: EngineType) -> None:
     """A key is evaluated on every row, so a nested fallible cast must block it."""
     left = pl.LazyFrame({"k": [1, 2], "a": [["1"], ["bad"]]})
     right = pl.LazyFrame({"k": [1], "b": [[1]]})
@@ -748,7 +752,7 @@ def test_residual_not_native_when_order_is_preserved(maintain_order: str) -> Non
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_nondeterministic_equality_is_not_promoted(engine: str) -> None:
+def test_nondeterministic_equality_is_not_promoted(engine: EngineType) -> None:
     """A key is drawn once per input row; the filter draws once per candidate pair."""
     left = pl.LazyFrame({"k": [0, 1], "a": [list(range(10)), list(range(10, 20))]})
     right = pl.LazyFrame({"k": [0] * 10 + [1] * 10, "b": range(20)})
@@ -764,7 +768,7 @@ def test_nondeterministic_equality_is_not_promoted(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_strict_regex_equality_is_not_promoted(engine: str) -> None:
+def test_strict_regex_equality_is_not_promoted(engine: EngineType) -> None:
     """An invalid pattern on an unmatched row must not be evaluated."""
     left = pl.LazyFrame({"k": [1, 2], "pat": ["x", "["]})
     right = pl.LazyFrame({"k": [1], "b": [True]})
@@ -777,7 +781,7 @@ def test_strict_regex_equality_is_not_promoted(engine: str) -> None:
 
 
 @pytest.mark.parametrize("engine", ENGINES)
-def test_non_strict_cast_equality_is_promoted(engine: str) -> None:
+def test_non_strict_cast_equality_is_promoted(engine: EngineType) -> None:
     left = pl.LazyFrame({"k": [1, 1], "a": [10, 20]})
     right = pl.LazyFrame({"k": [1, 1], "b": [10, 99]})
     predicate = pl.col("a").cast(pl.Int32, strict=False) == pl.col("b").cast(

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -1,0 +1,663 @@
+"""Tests for predicates fused into an inner join as its residual match condition."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import polars as pl
+from polars.exceptions import ComputeError
+from polars.testing import assert_frame_equal
+
+ENGINES = ["in-memory", "streaming"]
+
+
+def assert_fused(lf: pl.LazyFrame) -> None:
+    assert "RESIDUAL" in lf.explain()
+
+
+def assert_not_fused(lf: pl.LazyFrame) -> None:
+    assert "RESIDUAL" not in lf.explain()
+
+
+def assert_native_streaming(lf: pl.LazyFrame) -> None:
+    """The residual reached the streaming hash join rather than a fallback filter."""
+    plan = lf.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
+    assert plan is not None
+    assert "equi-join" in plan
+    assert "residual:" in plan
+    assert "filter" not in plan
+
+
+def reference(
+    left: pl.LazyFrame,
+    right: pl.LazyFrame,
+    predicate: pl.Expr,
+    **join_kwargs: object,
+) -> pl.DataFrame:
+    """Join and filter as two separate materialized steps, so nothing can fuse them."""
+    return left.join(right, **join_kwargs).collect().filter(predicate)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def frames() -> tuple[pl.LazyFrame, pl.LazyFrame]:
+    left = pl.LazyFrame(
+        {
+            "k": [1, 1, 2, 2, 3, 4],
+            "a": [10, 20, 30, 40, 50, 60],
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "k": [1, 2, 2, 3, 5],
+            "b": [15, 25, 45, 5, 99],
+        }
+    )
+    return left, right
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_matches_unfused_reference(
+    frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+) -> None:
+    left, right = frames
+    q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, pl.col("b") < pl.col("a"), on="k"),
+        check_row_order=False,
+    )
+
+
+def test_residual_native_streaming_path(
+    frames: tuple[pl.LazyFrame, pl.LazyFrame],
+) -> None:
+    left, right = frames
+    q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
+    assert_native_streaming(q)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        pl.col("b") < pl.col("a"),
+        pl.col("b") == pl.col("a"),
+        pl.col("b") + pl.col("a") > 40,
+        (pl.col("b") < pl.col("a")) & (pl.col("a") > 20),
+        (pl.col("b") < pl.col("a")) | (pl.col("a") > 50),
+        pl.col("a").cast(pl.Float64) > pl.col("b").cast(pl.Float64),
+    ],
+)
+def test_residual_expressions(
+    frames: tuple[pl.LazyFrame, pl.LazyFrame], predicate: pl.Expr, engine: str
+) -> None:
+    left, right = frames
+    q = left.join(right, on="k").filter(predicate)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_composite_and_duplicate_keys(engine: str) -> None:
+    left = pl.LazyFrame(
+        {
+            "k1": [1, 1, 1, 2, 2],
+            "k2": ["a", "a", "b", "a", "a"],
+            "v": [1, 2, 3, 4, 5],
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "k1": [1, 1, 2, 2],
+            "k2": ["a", "a", "a", "a"],
+            "w": [0, 5, 1, 9],
+        }
+    )
+    q = left.join(right, on=["k1", "k2"]).filter(pl.col("w") < pl.col("v"))
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, pl.col("w") < pl.col("v"), on=["k1", "k2"]),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_string_keys(engine: str) -> None:
+    left = pl.LazyFrame({"k": ["x", "x", "y", "z"], "a": [1, 2, 3, 4]})
+    right = pl.LazyFrame({"k": ["x", "y", "y", "w"], "b": [2, 1, 9, 0]})
+    q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, pl.col("b") < pl.col("a"), on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("nulls_equal", [True, False])
+def test_residual_null_keys_and_values(engine: str, nulls_equal: bool) -> None:
+    left = pl.LazyFrame({"k": [1, None, 2, None], "a": [10, 20, None, 40]})
+    right = pl.LazyFrame({"k": [1, None, 2], "b": [1, 5, None]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k", nulls_equal=nulls_equal).filter(predicate)
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", nulls_equal=nulls_equal),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize(
+    ("left_k", "right_k", "predicate_true"),
+    [
+        ([1, 2], [3, 4], True),  # no equi matches
+        ([1, 2], [1, 2], False),  # every candidate rejected
+        ([], [1, 2], True),  # empty left
+        ([1, 2], [], True),  # empty right
+        ([], [], True),  # both empty
+    ],
+)
+def test_residual_degenerate_inputs(
+    engine: str, left_k: list[int], right_k: list[int], predicate_true: bool
+) -> None:
+    left = pl.LazyFrame({"k": left_k, "a": [1] * len(left_k)}, schema={"k": pl.Int64, "a": pl.Int64})
+    right = pl.LazyFrame(
+        {"k": right_k, "b": [1] * len(right_k)}, schema={"k": pl.Int64, "b": pl.Int64}
+    )
+    predicate = pl.col("b") <= pl.col("a") if predicate_true else pl.col("b") < pl.col("a")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("suffix", ["_right", "_R"])
+@pytest.mark.parametrize("coalesce", [True, False])
+def test_residual_suffix_and_coalesce(engine: str, suffix: str, coalesce: bool) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
+    predicate = pl.col(f"v{suffix}") < pl.col("v")
+    q = left.join(right, on="k", suffix=suffix, coalesce=coalesce).filter(predicate)
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", suffix=suffix, coalesce=coalesce),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_only_columns_dropped_by_select(engine: str) -> None:
+    """`v`/`v_right` are read only by the residual, so they must survive to the join."""
+    left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30], "keep": ["a", "b", "c"]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
+    predicate = pl.col("v_right") < pl.col("v")
+    q = left.join(right, on="k").filter(predicate).select("k", "keep")
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k").select("k", "keep"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_suffix_dropped_when_collision_disappears(engine: str) -> None:
+    """Pruning the left `v` un-suffixes the right one; the residual must follow."""
+    left = pl.LazyFrame({"k": [1, 1, 2], "v": [99, 99, 99], "x": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "v": [15, 5, 99]})
+    predicate = pl.col("v_right") < pl.col("x")
+    q = left.join(right, on="k").filter(predicate).select("k", "x")
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k").select("k", "x"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_reads_right_key(engine: str) -> None:
+    """The right key must survive even though nothing else projects it.
+
+    Predicate pushdown may rewrite `k_right` to `k` and push it to one side, so this
+    does not necessarily fuse; either way the answer must hold.
+    """
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [5, 25, 35]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [1, 2, 3]})
+    predicate = pl.col("k_right") + pl.col("b") < pl.col("a")
+    q = left.join(right, on="k", coalesce=False).filter(predicate).select("a", "b")
+
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", coalesce=False).select("a", "b"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize(
+    "maintain_order", ["none", "left", "right", "left_right", "right_left"]
+)
+def test_residual_maintain_order(engine: str, maintain_order: str) -> None:
+    left = pl.LazyFrame({"k": [1, 2, 1, 3, 2], "a": [10, 20, 30, 40, 50]})
+    right = pl.LazyFrame({"k": [1, 2, 2, 3], "b": [5, 15, 45, 5]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k", maintain_order=maintain_order).filter(predicate)  # type: ignore[arg-type]
+
+    expected = (
+        left.join(right, on="k", maintain_order=maintain_order)  # type: ignore[arg-type]
+        .collect()
+        .filter(predicate)
+    )
+    result = q.collect(engine=engine)
+
+    # `left`/`right` only pin the order of that side, so compare the side that is
+    # actually specified; the two-sided modes pin the whole row order.
+    if maintain_order in ("left_right", "right_left"):
+        assert_frame_equal(result, expected)
+    else:
+        assert_frame_equal(result, expected, check_row_order=False)
+        if maintain_order == "left":
+            assert result["a"].to_list() == expected["a"].to_list()
+        elif maintain_order == "right":
+            assert result["b"].to_list() == expected["b"].to_list()
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("build_side", ["force_left", "force_right"])
+def test_residual_forced_build_side(engine: str, build_side: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2, 3], "a": [10, 20, 30, 40]})
+    right = pl.LazyFrame({"k": [1, 2, 2, 4], "b": [5, 15, 45, 0]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k", build_side=build_side).filter(predicate)  # type: ignore[arg-type]
+
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_many_morsels_and_skew(engine: str) -> None:
+    """More rows than one morsel, plus a key whose duplicate list exceeds the limit."""
+    n = 60_000
+    left = pl.LazyFrame({"k": [0] * n + list(range(n)), "a": list(range(2 * n))})
+    right = pl.LazyFrame({"k": [0] * 32 + list(range(n)), "b": list(range(32 + n))})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_rejected_batch_followed_by_accepted(engine: str) -> None:
+    """Leading candidates are all rejected; survivors after them must still be emitted."""
+    n = 20_000
+    left = pl.LazyFrame({"k": [1] * n + [2] * n, "a": [0] * n + [100] * n})
+    right = pl.LazyFrame({"k": [1, 2], "b": [50, 50]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k").filter(predicate)
+
+    result = q.collect(engine=engine)
+    assert result.height == n
+    assert_frame_equal(
+        result, reference(left, right, predicate, on="k"), check_row_order=False
+    )
+
+
+@pytest.mark.parametrize("how", ["left", "right", "full"])
+def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
+    """A predicate that keeps null-extended rows leaves the join outer, so it cannot fuse."""
+    left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
+    predicate = pl.col("b").is_null() | (pl.col("b") < pl.col("a"))
+
+    q = left.join(right, on="k", how=how).filter(predicate)  # type: ignore[arg-type]
+    assert_not_fused(q)
+    assert_frame_equal(
+        q.collect(),
+        reference(left, right, predicate, on="k", how=how),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("how", ["left", "right", "full"])
+def test_residual_outer_join_reduced_to_inner(engine: str, how: str) -> None:
+    """A predicate rejecting null-extended rows turns the join inner, which may then fuse."""
+    left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
+    predicate = pl.col("b") < pl.col("a")
+
+    q = left.join(right, on="k", how=how).filter(predicate)  # type: ignore[arg-type]
+    assert "INNER JOIN" in q.explain()
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", how=how),
+        check_row_order=False,
+    )
+
+
+def test_residual_not_fused_for_non_elementwise_predicates() -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [5, 15, 45]})
+
+    # An aggregate is not decidable per candidate pair.
+    assert_not_fused(left.join(right, on="k").filter(pl.col("b") < pl.col("a").max()))
+    # Neither is a window function.
+    assert_not_fused(
+        left.join(right, on="k").filter(pl.col("b") < pl.col("a").sum().over("k"))
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_slice_ordering(engine: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
+    right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
+    predicate = pl.col("b") < pl.col("a")
+
+    # filter-then-slice: the slice must stay above the join.
+    q = left.join(right, on="k", maintain_order="left_right").filter(predicate).head(1)
+    assert q.collect(engine=engine).height == 1
+
+    # slice-then-filter: the slice must not be absorbed past the filter.
+    q = left.join(right, on="k", maintain_order="left_right").head(2).filter(predicate)
+    expected = (
+        left.join(right, on="k", maintain_order="left_right")
+        .collect()
+        .head(2)
+        .filter(predicate)
+    )
+    assert_frame_equal(q.collect(engine=engine), expected)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_validation_still_errors(engine: str) -> None:
+    """Validation runs on the keys, so a residual rejecting the pair does not excuse it."""
+    left = pl.LazyFrame({"k": [1, 2], "a": [10, 20]})
+    right = pl.LazyFrame({"k": [1, 1, 2], "b": [99, 99, 99]})
+    q = left.join(right, on="k", validate="m:1").filter(pl.col("b") < pl.col("a"))
+
+    with pytest.raises(ComputeError):
+        q.collect(engine=engine)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("join_order", [True, False])
+def test_residual_with_join_order(engine: str, join_order: bool) -> None:
+    a = pl.LazyFrame({"k": [1, 2, 3], "x": [1, 2, 3]})
+    b = pl.LazyFrame({"k": [1, 2, 3], "y": [3, 2, 1]})
+    c = pl.LazyFrame({"k": [1, 2, 3], "z": [1, 1, 1]})
+    predicate = pl.col("y") > pl.col("x")
+
+    q = a.join(b, on="k").join(c, on="k").filter(predicate)
+    result = q.collect(engine=engine, optimizations=pl.QueryOptFlags(join_order=join_order))
+    expected = a.join(b, on="k").join(c, on="k").collect().filter(predicate)
+    assert_frame_equal(result, expected, check_row_order=False)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_residual_shared_join_with_distinct_predicates(engine: str) -> None:
+    """One join feeding two different filters must not have either fused into the other."""
+    left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
+    right = pl.LazyFrame({"k": [1, 2], "b": [15, 35]})
+    joined = left.join(right, on="k")
+
+    lo = joined.filter(pl.col("b") < pl.col("a"))
+    hi = joined.filter(pl.col("b") > pl.col("a"))
+    q = pl.concat([lo, hi])
+
+    expected = pl.concat(
+        [
+            reference(left, right, pl.col("b") < pl.col("a"), on="k"),
+            reference(left, right, pl.col("b") > pl.col("a"), on="k"),
+        ]
+    )
+    assert_frame_equal(q.collect(engine=engine), expected, check_row_order=False)
+
+
+def test_residual_optimization_is_idempotent() -> None:
+    """Optimizing the same plan repeatedly must not lose or duplicate the residual."""
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert q.explain().count("RESIDUAL") == 1
+    assert q.explain() == q.explain()
+
+    roundtripped = pl.LazyFrame.deserialize(q.serialize())
+    assert roundtripped.explain().count("RESIDUAL") == 1
+    assert_frame_equal(
+        roundtripped.collect(),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+def test_residual_unfused_when_predicate_pushdown_disabled() -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 2], "b": [15, 5]})
+    predicate = pl.col("b") < pl.col("a")
+    q = left.join(right, on="k").filter(predicate)
+
+    unfused = q.explain(optimizations=pl.QueryOptFlags(predicate_pushdown=False))
+    assert "RESIDUAL" not in unfused
+    assert "FILTER" in unfused
+
+    assert_frame_equal(
+        q.collect(optimizations=pl.QueryOptFlags(predicate_pushdown=False)),
+        q.collect(),
+        check_row_order=False,
+    )
+
+
+def join_keys(lf: pl.LazyFrame) -> tuple[str, str]:
+    plan = lf.explain()
+    left = re.search(r"LEFT PLAN ON: \[(.*)\]", plan)
+    right = re.search(r"RIGHT PLAN ON: \[(.*)\]", plan)
+    assert left is not None and right is not None
+    return left.group(1), right.group(1)
+
+
+@pytest.fixture
+def eq_frames() -> tuple[pl.LazyFrame, pl.LazyFrame]:
+    left = pl.LazyFrame(
+        {
+            "k": [1, 1, 2, 2, 3],
+            "a": [10, 20, 30, 40, 50],
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "k": [1, 1, 2, 3, 3],
+            "b": [10, 99, 40, 50, 60],
+        }
+    )
+    return left, right
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_becomes_join_key(
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+) -> None:
+    left, right = eq_frames
+    predicate = pl.col("a") == pl.col("b")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    left_keys, right_keys = join_keys(q)
+    assert 'col("a")' in left_keys
+    assert 'col("b")' in right_keys
+
+    assert q.collect_schema().names() == ["k", "a", "b"]
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_key_rejects_nulls(engine: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64})
+    predicate = pl.col("a") == pl.col("b")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_not_promoted_when_join_matches_nulls(
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+) -> None:
+    """`==` rejects a null pair, so it cannot become a key that matches them."""
+    left, right = eq_frames
+    predicate = pl.col("a") == pl.col("b")
+    q = left.join(right, on="k", nulls_equal=True).filter(predicate)
+
+    assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", nulls_equal=True),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("nulls_equal", [False, True])
+def test_eq_missing_matches_the_join(engine: str, nulls_equal: bool) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64})
+    predicate = pl.col("a").eq_missing(pl.col("b"))
+    q = left.join(right, on="k", nulls_equal=nulls_equal).filter(predicate)
+
+    # `eq_missing` accepts a null pair, which only a null-matching join key reproduces.
+    if nulls_equal:
+        assert_not_fused(q)
+    else:
+        assert_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", nulls_equal=nulls_equal),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_float_equality_becomes_join_key(engine: str) -> None:
+    """`==` and a key pair agree on NaN, so floats promote like any other dtype."""
+    nan = float("nan")
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [1.5, nan, nan]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [1.5, nan, 2.5]})
+    predicate = pl.col("a") == pl.col("b")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_promoted_and_rest_stays_residual(
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+) -> None:
+    left, right = eq_frames
+    predicate = (pl.col("a") == pl.col("b")) & (pl.col("a") + pl.col("b") > 40)
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_fused(q)
+    left_keys, _ = join_keys(q)
+    assert 'col("a")' in left_keys
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_promoted_with_suffixed_column(engine: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 99, 30]})
+    predicate = pl.col("a") == pl.col("a_right")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    assert q.collect_schema().names() == ["k", "a", "a_right"]
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_several_equalities_sharing_a_left_column(engine: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [10, 20, 30]})
+    right = pl.LazyFrame({"k": [1, 1, 2], "b": [10, 20, 30], "c": [10, 99, 30]})
+    predicate = (pl.col("a") == pl.col("b")) & (pl.col("a") == pl.col("c"))
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    assert q.collect_schema().names() == ["k", "a", "b", "c"]
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_promoted_without_coalesce(
+    eq_frames: tuple[pl.LazyFrame, pl.LazyFrame], engine: str
+) -> None:
+    left, right = eq_frames
+    predicate = pl.col("a") == pl.col("b")
+    q = left.join(right, on="k", coalesce=False).filter(predicate)
+
+    assert_not_fused(q)
+    assert q.collect_schema().names() == ["k", "a", "k_right", "b"]
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", coalesce=False),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -661,3 +661,29 @@ def test_equality_promoted_without_coalesce(
         reference(left, right, predicate, on="k", coalesce=False),
         check_row_order=False,
     )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_equality_resolves_suffixed_output_column(engine: str) -> None:
+    """An output name can belong to a different input column than it shares a name with."""
+    left = pl.LazyFrame({"k": [1, 1], "v": [10, 20]})
+    right = pl.LazyFrame({"v_right": [1, 1], "v": [10, 20]})
+    predicate = pl.col("v") == pl.col("v_right")
+    q = left.join(right, left_on="k", right_on="v_right").filter(predicate)
+
+    assert_not_fused(q)
+    assert q.collect_schema().names() == ["k", "v", "v_right"]
+
+    # This shape trips a projection pushdown bug that has nothing to do with the join
+    # condition, so the reference is taken without that pass.
+    no_pushdown = pl.QueryOptFlags(projection_pushdown=False)
+    expected = (
+        left.join(right, left_on="k", right_on="v_right")
+        .collect(optimizations=no_pushdown)
+        .filter(predicate)
+    )
+    assert_frame_equal(
+        q.collect(engine=engine, optimizations=no_pushdown),
+        expected,
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -174,11 +174,15 @@ def test_residual_null_keys_and_values(engine: str, nulls_equal: bool) -> None:
 def test_residual_degenerate_inputs(
     engine: str, left_k: list[int], right_k: list[int], predicate_true: bool
 ) -> None:
-    left = pl.LazyFrame({"k": left_k, "a": [1] * len(left_k)}, schema={"k": pl.Int64, "a": pl.Int64})
+    left = pl.LazyFrame(
+        {"k": left_k, "a": [1] * len(left_k)}, schema={"k": pl.Int64, "a": pl.Int64}
+    )
     right = pl.LazyFrame(
         {"k": right_k, "b": [1] * len(right_k)}, schema={"k": pl.Int64, "b": pl.Int64}
     )
-    predicate = pl.col("b") <= pl.col("a") if predicate_true else pl.col("b") < pl.col("a")
+    predicate = (
+        pl.col("b") <= pl.col("a") if predicate_true else pl.col("b") < pl.col("a")
+    )
     q = left.join(right, on="k").filter(predicate)
 
     assert_fused(q)
@@ -320,7 +324,7 @@ def test_residual_many_morsels_and_skew(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_residual_rejected_batch_followed_by_accepted(engine: str) -> None:
-    """Leading candidates are all rejected; survivors after them must still be emitted."""
+    """Leading candidates are all rejected; later survivors must still be emitted."""
     n = 20_000
     left = pl.LazyFrame({"k": [1] * n + [2] * n, "a": [0] * n + [100] * n})
     right = pl.LazyFrame({"k": [1, 2], "b": [50, 50]})
@@ -336,7 +340,7 @@ def test_residual_rejected_batch_followed_by_accepted(engine: str) -> None:
 
 @pytest.mark.parametrize("how", ["left", "right", "full"])
 def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
-    """A predicate that keeps null-extended rows leaves the join outer, so it cannot fuse."""
+    """Keeping null-extended rows leaves the join outer, so it cannot fuse."""
     left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
     predicate = pl.col("b").is_null() | (pl.col("b") < pl.col("a"))
@@ -353,7 +357,7 @@ def test_residual_not_fused_while_join_stays_outer(how: str) -> None:
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("how", ["left", "right", "full"])
 def test_residual_outer_join_reduced_to_inner(engine: str, how: str) -> None:
-    """A predicate rejecting null-extended rows turns the join inner, which may then fuse."""
+    """Rejecting null-extended rows turns the join inner, which may then fuse."""
     left = pl.LazyFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
     right = pl.LazyFrame({"k": [1, 2, 4], "b": [5, 25, 0]})
     predicate = pl.col("b") < pl.col("a")
@@ -402,7 +406,7 @@ def test_residual_slice_ordering(engine: str) -> None:
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_residual_validation_still_errors(engine: str) -> None:
-    """Validation runs on the keys, so a residual rejecting the pair does not excuse it."""
+    """Validation runs on the keys; a residual rejecting the pair does not excuse it."""
     left = pl.LazyFrame({"k": [1, 2], "a": [10, 20]})
     right = pl.LazyFrame({"k": [1, 1, 2], "b": [99, 99, 99]})
     q = left.join(right, on="k", validate="m:1").filter(pl.col("b") < pl.col("a"))
@@ -420,14 +424,16 @@ def test_residual_with_join_order(engine: str, join_order: bool) -> None:
     predicate = pl.col("y") > pl.col("x")
 
     q = a.join(b, on="k").join(c, on="k").filter(predicate)
-    result = q.collect(engine=engine, optimizations=pl.QueryOptFlags(join_order=join_order))
+    result = q.collect(
+        engine=engine, optimizations=pl.QueryOptFlags(join_order=join_order)
+    )
     expected = a.join(b, on="k").join(c, on="k").collect().filter(predicate)
     assert_frame_equal(result, expected, check_row_order=False)
 
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_residual_shared_join_with_distinct_predicates(engine: str) -> None:
-    """One join feeding two different filters must not have either fused into the other."""
+    """One join feeding two filters must not have either fused into the other."""
     left = pl.LazyFrame({"k": [1, 1, 2, 2], "a": [10, 20, 30, 40]})
     right = pl.LazyFrame({"k": [1, 2], "b": [15, 35]})
     joined = left.join(right, on="k")
@@ -485,7 +491,8 @@ def join_keys(lf: pl.LazyFrame) -> tuple[str, str]:
     plan = lf.explain()
     left = re.search(r"LEFT PLAN ON: \[(.*)\]", plan)
     right = re.search(r"RIGHT PLAN ON: \[(.*)\]", plan)
-    assert left is not None and right is not None
+    assert left is not None
+    assert right is not None
     return left.group(1), right.group(1)
 
 
@@ -529,8 +536,12 @@ def test_equality_becomes_join_key(
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_key_rejects_nulls(engine: str) -> None:
-    left = pl.LazyFrame({"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64})
-    right = pl.LazyFrame({"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64})
+    left = pl.LazyFrame(
+        {"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64}
+    )
+    right = pl.LazyFrame(
+        {"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64}
+    )
     predicate = pl.col("a") == pl.col("b")
     q = left.join(right, on="k").filter(predicate)
 
@@ -562,8 +573,12 @@ def test_equality_not_promoted_when_join_matches_nulls(
 @pytest.mark.parametrize("engine", ENGINES)
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_eq_missing_matches_the_join(engine: str, nulls_equal: bool) -> None:
-    left = pl.LazyFrame({"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64})
-    right = pl.LazyFrame({"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64})
+    left = pl.LazyFrame(
+        {"k": [1, 1, 2], "a": [None, 5, None]}, schema_overrides={"a": pl.Int64}
+    )
+    right = pl.LazyFrame(
+        {"k": [1, 2, 2], "b": [None, None, 5]}, schema_overrides={"b": pl.Int64}
+    )
     predicate = pl.col("a").eq_missing(pl.col("b"))
     q = left.join(right, on="k", nulls_equal=nulls_equal).filter(predicate)
 
@@ -665,7 +680,7 @@ def test_equality_promoted_without_coalesce(
 
 @pytest.mark.parametrize("engine", ENGINES)
 def test_equality_resolves_suffixed_output_column(engine: str) -> None:
-    """An output name can belong to a different input column than it shares a name with."""
+    """An output name can belong to a different column than it shares a name with."""
     left = pl.LazyFrame({"k": [1, 1], "v": [10, 20]})
     right = pl.LazyFrame({"v_right": [1, 1], "v": [10, 20]})
     predicate = pl.col("v") == pl.col("v_right")
@@ -686,4 +701,18 @@ def test_equality_resolves_suffixed_output_column(engine: str) -> None:
         q.collect(engine=engine, optimizations=no_pushdown),
         expected,
         check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_promoted_key_keeps_right_payload_in_merge_join(engine: str) -> None:
+    """Sorted inputs take the merge join, which coalesces by name."""
+    left = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 20, 30]}).sort("k", "v")
+    right = pl.LazyFrame({"k": [1, 1, 2], "v": [10, 99, 30]}).sort("k", "v")
+    predicate = pl.col("v") == pl.col("v_right")
+    q = left.join(right, on="k", maintain_order="left_right").filter(predicate)
+
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k", maintain_order="left_right"),
     )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -749,3 +749,53 @@ def test_residual_not_native_when_order_is_preserved(maintain_order: str) -> Non
         q.collect(engine="streaming"),
         reference(left, right, predicate, on="k", maintain_order=maintain_order),
     )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_nondeterministic_equality_is_not_promoted(engine: str) -> None:
+    """A key is drawn once per input row; the filter draws once per candidate pair."""
+    left = pl.LazyFrame({"k": [0, 1], "a": [list(range(10)), list(range(10, 20))]})
+    right = pl.LazyFrame({"k": [0] * 10 + [1] * 10, "b": range(20)})
+    predicate = pl.col("a").list.sample(n=1).list.first() == pl.col("b")
+    q = left.join(right, on="k", maintain_order="left_right").filter(predicate)
+
+    assert_fused(q)
+    left_keys, _ = join_keys(q)
+    assert "sample" not in left_keys
+
+    # Promotion pins the height at one row per key; per-pair sampling does not.
+    assert len({q.collect(engine=engine).height for _ in range(30)}) > 1
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_strict_regex_equality_is_not_promoted(engine: str) -> None:
+    """An invalid pattern on an unmatched row must not be evaluated."""
+    left = pl.LazyFrame({"k": [1, 2], "pat": ["x", "["]})
+    right = pl.LazyFrame({"k": [1], "b": [True]})
+    predicate = pl.lit("x").str.contains(pl.col("pat")) == pl.col("b")
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_frame_equal(
+        q.collect(engine=engine), reference(left, right, predicate, on="k")
+    )
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_non_strict_cast_equality_is_promoted(engine: str) -> None:
+    left = pl.LazyFrame({"k": [1, 1], "a": [10, 20]})
+    right = pl.LazyFrame({"k": [1, 1], "b": [10, 99]})
+    predicate = pl.col("a").cast(pl.Int32, strict=False) == pl.col("b").cast(
+        pl.Int32, strict=False
+    )
+    q = left.join(right, on="k").filter(predicate)
+
+    assert_not_fused(q)
+    left_keys, right_keys = join_keys(q)
+    assert "cast" in left_keys
+    assert "cast" in right_keys
+
+    assert_frame_equal(
+        q.collect(engine=engine),
+        reference(left, right, predicate, on="k"),
+        check_row_order=False,
+    )

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -21,13 +21,13 @@ def assert_not_fused(lf: pl.LazyFrame) -> None:
     assert "RESIDUAL" not in lf.explain()
 
 
-def assert_native_streaming(lf: pl.LazyFrame) -> None:
-    """The residual reached the streaming hash join rather than a fallback filter."""
+def assert_residual_native(lf: pl.LazyFrame, native: bool = True) -> None:
+    """Whether the residual reached the streaming hash join or a fallback filter."""
     plan = lf.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
     assert plan is not None
     assert "equi-join" in plan
-    assert "residual:" in plan
-    assert "filter" not in plan
+    assert ("residual:" in plan) == native
+    assert ("filter" in plan) != native
 
 
 def reference(
@@ -77,7 +77,7 @@ def test_residual_native_streaming_path(
 ) -> None:
     left, right = frames
     q = left.join(right, on="k").filter(pl.col("b") < pl.col("a"))
-    assert_native_streaming(q)
+    assert_residual_native(q)
 
 
 @pytest.mark.parametrize("engine", ENGINES)
@@ -740,11 +740,7 @@ def test_residual_not_native_when_order_is_preserved(maintain_order: str) -> Non
     predicate = pl.col("a") < pl.col("b")
     q = left.join(right, on="k", maintain_order=maintain_order).filter(predicate)  # type: ignore[arg-type]
 
-    plan = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
-    assert plan is not None
-    assert "residual:" not in plan
-    assert "filter" in plan
-
+    assert_residual_native(q, native=False)
     assert_frame_equal(
         q.collect(engine="streaming"),
         reference(left, right, predicate, on="k", maintain_order=maintain_order),
@@ -815,7 +811,7 @@ def test_residual_gathers_from_a_multi_chunk_payload() -> None:
     predicate = pl.col("a") < pl.col("b")
     q = left.lazy().join(right.lazy(), on="k").filter(predicate)
 
-    assert_native_streaming(q)
+    assert_residual_native(q)
     assert_frame_equal(
         q.collect(engine="streaming"),
         reference(left.lazy(), right.lazy(), predicate, on="k"),

--- a/py-polars/tests/unit/operations/test_join_residual.py
+++ b/py-polars/tests/unit/operations/test_join_residual.py
@@ -730,3 +730,22 @@ def test_fallible_inside_list_eval_is_not_promoted(engine: str) -> None:
     assert_frame_equal(
         q.collect(engine=engine), reference(left, right, predicate, on="k")
     )
+
+
+@pytest.mark.parametrize("maintain_order", ["left", "right", "left_right"])
+def test_residual_not_native_when_order_is_preserved(maintain_order: str) -> None:
+    """The ordered probe would evaluate the residual a group at a time."""
+    left = pl.LazyFrame({"k": [1, 1, 2], "a": [1, 5, 9]})
+    right = pl.LazyFrame({"k": [1, 2, 2], "b": [3, 4, 7]})
+    predicate = pl.col("a") < pl.col("b")
+    q = left.join(right, on="k", maintain_order=maintain_order).filter(predicate)  # type: ignore[arg-type]
+
+    plan = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
+    assert plan is not None
+    assert "residual:" not in plan
+    assert "filter" in plan
+
+    assert_frame_equal(
+        q.collect(engine="streaming"),
+        reference(left, right, predicate, on="k", maintain_order=maintain_order),
+    )


### PR DESCRIPTION
This prevents materializing the payload and then filtering it again afterwards.

All code reviewed by me.