### PR TITLE
perf: Rechunk before selecting in group-by pre-select

### DIFF
--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -10,14 +10,21 @@ pub struct SelectNode {
     selectors: Vec<StreamExpr>,
     schema: Arc<Schema>,
     extend_original: bool,
+    rechunk_input: bool,
 }
 
 impl SelectNode {
-    pub fn new(selectors: Vec<StreamExpr>, schema: Arc<Schema>, extend_original: bool) -> Self {
+    pub fn new(
+        selectors: Vec<StreamExpr>,
+        schema: Arc<Schema>,
+        extend_original: bool,
+        rechunk_input: bool,
+    ) -> Self {
         Self {
             selectors,
             schema,
             extend_original,
+            rechunk_input,
         }
     }
 }
@@ -59,7 +66,11 @@ impl ComputeNode for SelectNode {
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 while let Ok(morsel) = recv.recv().await {
                     let (sf, seq, source_token, consume_token) = morsel.into_inner();
-                    let df = sf.into_df().await;
+                    let mut df = sf.into_df().await;
+                    if slf.rechunk_input {
+                        df.rechunk_mut();
+                    }
+
                     let mut selected = Vec::new();
                     for selector in slf.selectors.iter() {
                         let s = selector.evaluate(&df, &state.in_memory_exec_state).await?;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -213,6 +213,7 @@ fn visualize_plan_rec(
             input,
             selectors,
             extend_original,
+            rechunk_input: _,
         } => {
             let label = if *extend_original {
                 "with-columns"

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -619,6 +619,7 @@ fn lower_exprs_with_ctx(
                     input: trans_input,
                     selectors: vec![explode_expr.clone()],
                     extend_original: false,
+                    rechunk_input: false,
                 };
                 let node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, node_kind));
                 input_streams.insert(PhysStream::first(node_key));
@@ -1650,6 +1651,7 @@ fn lower_exprs_with_ctx(
                     input: trans_input,
                     selectors: vec![func_expr.clone()],
                     extend_original: false,
+                    rechunk_input: false,
                 };
                 let node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, node_kind));
                 input_streams.insert(PhysStream::first(node_key));
@@ -2789,6 +2791,7 @@ fn build_select_stream_with_ctx(
         input: transformed_input,
         selectors: trans_expr_irs,
         extend_original: false,
+        rechunk_input: false,
     };
     let node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, node_kind));
     Ok(PhysStream::first(node_key))
@@ -2879,6 +2882,7 @@ pub fn build_hstack_stream(
             input,
             selectors,
             extend_original: true,
+            rechunk_input: false,
         };
         let node_key = phys_sm.insert(PhysNode::new(output_schema, kind));
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -963,6 +963,9 @@ pub fn build_physical_plan(
     insert_multiplexers(vec![phys_root.node], phys_sm);
     split_multiplexers(vec![phys_root.node], phys_sm);
     fuse_drops(vec![phys_root.node], phys_sm);
+    
+    // TODO: remove this after fusing pre-select into group-by node.
     rechunk_group_by_inputs(vec![phys_root.node], phys_sm);
+
     Ok(phys_root.node)
 }

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -963,7 +963,7 @@ pub fn build_physical_plan(
     insert_multiplexers(vec![phys_root.node], phys_sm);
     split_multiplexers(vec![phys_root.node], phys_sm);
     fuse_drops(vec![phys_root.node], phys_sm);
-    
+
     // TODO: remove this after fusing pre-select into group-by node.
     rechunk_group_by_inputs(vec![phys_root.node], phys_sm);
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -170,6 +170,7 @@ pub enum PhysNodeKind {
         input: PhysStream,
         selectors: Vec<ExprIR>,
         extend_original: bool,
+        rechunk_input: bool,
     },
 
     InputIndependentSelect {
@@ -919,6 +920,25 @@ fn fuse_drops(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey, PhysNo
     });
 }
 
+/// Sets `rechunk_input` on any `Select` node directly feeding into a `GroupBy`.
+///
+/// The group-by consumes the selected key/aggregation columns in bulk, so it is
+/// worth paying for a rechunk of the select's output to get contiguous inputs.
+fn rechunk_group_by_inputs(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>) {
+    visit_nodes_mut(roots, phys_sm, |key, phys_sm| {
+        let PhysNodeKind::GroupBy { inputs, .. } = phys_sm[key].kind() else {
+            return;
+        };
+
+        let input_nodes: Vec<PhysNodeKey> = inputs.iter().map(|i| i.node).collect();
+        for input_node in input_nodes {
+            if let PhysNodeKind::Select { rechunk_input, .. } = phys_sm[input_node].kind_mut() {
+                *rechunk_input = true;
+            }
+        }
+    });
+}
+
 pub fn build_physical_plan(
     root: Node,
     ir_arena: &mut Arena<IR>,
@@ -943,5 +963,6 @@ pub fn build_physical_plan(
     insert_multiplexers(vec![phys_root.node], phys_sm);
     split_multiplexers(vec![phys_root.node], phys_sm);
     fuse_drops(vec![phys_root.node], phys_sm);
+    rechunk_group_by_inputs(vec![phys_root.node], phys_sm);
     Ok(phys_root.node)
 }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -227,6 +227,7 @@ fn to_graph_rec<'a>(
             selectors,
             input,
             extend_original,
+            rechunk_input,
         } => {
             let input_schema = input.output_schema(ctx.phys_sm);
             let phys_selectors = selectors
@@ -239,6 +240,7 @@ fn to_graph_rec<'a>(
                     phys_selectors,
                     node.output_schema(0).clone(),
                     *extend_original,
+                    *rechunk_input,
                 ),
                 [(input_key, input.port)],
             )


### PR DESCRIPTION
This is a bit of a hack, and should be removed once we properly fuse the pre-select into the group-by post-partition.

But essentially, if you have a lot of group-by expressions it's better to rechunk the input to them once instead of rechunking all the intermediate outputs.