### PR TITLE
fix: Ensure ignored columns are excluded from dtype `Wildcard` selector

### DIFF
--- a/crates/polars-plan/src/dsl/selector.rs
+++ b/crates/polars-plan/src/dsl/selector.rs
@@ -443,7 +443,7 @@ impl DataTypeSelector {
             },
             Self::Wildcard => schema
                 .iter_names()
-                .filter(|n| ignored_columns.contains(*n))
+                .filter(|n| !ignored_columns.contains(*n))
                 .cloned()
                 .collect(),
             Self::Empty => Default::default(),


### PR DESCRIPTION
Fixed dtype `Wildcard` expansion so it properly excludes ignored columns.
(Was missing a leading `!`, oops 😅)