### PR TITLE
chore: Update analytics endpoint config

### DIFF
--- a/docs/source/_build/js/posthog-init.js
+++ b/docs/source/_build/js/posthog-init.js
@@ -1,32 +1,57 @@
-!function (t, e) {
-    var o, n, p, r;
-    e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) {
-        function g(t, e) {
-            var o = e.split(".");
-            2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () {
-                t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-            };
-        }
-
-        (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
-        var u = e;
-        for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) {
-            var e = "posthog";
-            return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e;
-        }, u.people.toString = function () {
-            return u.toString(1) + ".people (stub)";
-        }, o = "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
-        e._i.push([i, s, a]);
-    }, e.__SV = 1);
-}(document, window.posthog || []);
+// biome-ignore-all lint: vendor snippet
+!(function (e, t) {
+	var r, o, s, i;
+	t.__SV ||
+		((window.posthog = t),
+		(t._i = []),
+		(t.init = function (n, p, a) {
+			function g(e, t) {
+				var r = t.split(".");
+				2 == r.length && ((e = e[r[0]]), (t = r[1])),
+					(e[t] = function () {
+						e.push([t].concat(Array.prototype.slice.call(arguments, 0)));
+					});
+			}
+			((s = e.createElement("script")).type = "text/javascript"),
+				(s.crossOrigin = "anonymous"),
+				(s.async = !0),
+				(s.src =
+					p.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") +
+					"/static/array.js"),
+				(i = e.getElementsByTagName("script")[0]).parentNode.insertBefore(s, i);
+			var u = t;
+			for (
+				void 0 !== a ? (u = t[a] = []) : (a = "posthog"),
+					u.people = u.people || [],
+					u.toString = function (e) {
+						var t = "posthog";
+						return "posthog" !== a && (t += "." + a), e || (t += " (stub)"), t;
+					},
+					u.people.toString = function () {
+						return u.toString(1) + ".people (stub)";
+					},
+					r =
+						"init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(
+							" ",
+						),
+					o = 0;
+				o < r.length;
+				o++
+			)
+				g(u, r[o]);
+			t._i.push([n, p, a]);
+		}),
+		(t.__SV = 1));
+})(document, window.posthog || []);
 
 var POSTHOG_ALLOWED_HOSTS = ["docs.pola.rs"];
 
 if (POSTHOG_ALLOWED_HOSTS.includes(location.hostname)) {
-    posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
-        api_host: "https://eu.i.posthog.com",
-        defaults: "2026-05-30",
-        cookieless_mode: "always",
-        person_profiles: "never",
-    });
+	posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
+		api_host: "https://iji.pola.rs",
+		ui_host: "https://eu.posthog.com",
+		defaults: "2026-05-30",
+		cookieless_mode: "always",
+		person_profiles: "never",
+	});
 }

--- a/docs/source/_build/js/posthog-init.js
+++ b/docs/source/_build/js/posthog-init.js
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: vendor snippet
 !(function (e, t) {
 	var r, o, s, i;
 	t.__SV ||

--- a/py-polars/docs/source/_static/js/posthog-init.js
+++ b/py-polars/docs/source/_static/js/posthog-init.js
@@ -1,32 +1,56 @@
-!function (t, e) {
-    var o, n, p, r;
-    e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) {
-        function g(t, e) {
-            var o = e.split(".");
-            2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () {
-                t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-            };
-        }
-
-        (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
-        var u = e;
-        for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) {
-            var e = "posthog";
-            return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e;
-        }, u.people.toString = function () {
-            return u.toString(1) + ".people (stub)";
-        }, o = "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
-        e._i.push([i, s, a]);
-    }, e.__SV = 1);
-}(document, window.posthog || []);
+// biome-ignore-all lint: vendor snippet
+!(function (e, t) {
+	var r, o, s, i;
+	t.__SV ||
+		((window.posthog = t),
+		(t._i = []),
+		(t.init = function (n, p, a) {
+			function g(e, t) {
+				var r = t.split(".");
+				2 == r.length && ((e = e[r[0]]), (t = r[1])),
+					(e[t] = function () {
+						e.push([t].concat(Array.prototype.slice.call(arguments, 0)));
+					});
+			}
+			((s = e.createElement("script")).type = "text/javascript"),
+				(s.crossOrigin = "anonymous"),
+				(s.async = !0),
+				(s.src =
+					p.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") +
+					"/static/array.js"),
+				(i = e.getElementsByTagName("script")[0]).parentNode.insertBefore(s, i);
+			var u = t;
+			for (
+				void 0 !== a ? (u = t[a] = []) : (a = "posthog"),
+					u.people = u.people || [],
+					u.toString = function (e) {
+						var t = "posthog";
+						return "posthog" !== a && (t += "." + a), e || (t += " (stub)"), t;
+					},
+					u.people.toString = function () {
+						return u.toString(1) + ".people (stub)";
+					},
+					r =
+						"init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(
+							" ",
+						),
+					o = 0;
+				o < r.length;
+				o++
+			)
+				g(u, r[o]);
+			t._i.push([n, p, a]);
+		}),
+		(t.__SV = 1));
+})(document, window.posthog || []);
 
 var POSTHOG_ALLOWED_HOSTS = ["docs.pola.rs"];
-
 if (POSTHOG_ALLOWED_HOSTS.includes(location.hostname)) {
-    posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
-        api_host: "https://eu.i.posthog.com",
-        defaults: "2026-05-30",
-        cookieless_mode: "always",
-        person_profiles: "never",
-    });
+	posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
+		api_host: "https://iji.pola.rs",
+		ui_host: "https://eu.posthog.com",
+		defaults: "2026-05-30",
+		cookieless_mode: "always",
+		person_profiles: "never",
+	});
 }

--- a/py-polars/docs/source/_static/js/posthog-init.js
+++ b/py-polars/docs/source/_static/js/posthog-init.js
@@ -1,4 +1,3 @@
-// biome-ignore-all lint: vendor snippet
 !(function (e, t) {
 	var r, o, s, i;
 	t.__SV ||


### PR DESCRIPTION
Updates the docs analytics config to use our own proxy endpoint, and syncs the API reference copy of the snippet with the user guide one.

Privacy settings are unchanged when browsing the documtation (`cookieless_mode: "always"`, `person_profiles: "never"`).