### PR TITLE
fix(rust): Function is_valid for RollingAggWindowNulls only checked last value

### DIFF
--- a/crates/polars-compute/src/rolling/nulls/rank.rs
+++ b/crates/polars-compute/src/rolling/nulls/rank.rs
@@ -86,11 +86,15 @@ where
         if !(self.start..self.end).contains(&idx) {
             panic!("index out of bounds");
         }
+        // Null cannot have a rank, so explicitly fail.
+        if !self.validity.get(idx).unwrap() {
+            return None;
+        }
         self.policy.rank(&self.ost, &self.slice[idx])
     }
 
     fn is_valid(&self, min_periods: usize) -> bool {
-        self.validity.get(self.end - 1).unwrap() && self.ost.len() >= min_periods
+        self.ost.len() >= min_periods
     }
 
     fn slice_len(&self) -> usize {

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/shared.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/shared.rs
@@ -171,8 +171,10 @@ where
             // SAFETY:
             // we are in bound
             unsafe { agg_window.update(start as usize, end as usize) };
+            // idx is the position of the current element in the window,
+            // because the values were sorted by 'by' before.
             let res = if agg_window.is_valid(min_periods) {
-                agg_window.get_agg(*out_idx as usize)
+                agg_window.get_agg(idx)
             } else {
                 None
             };

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -2351,6 +2351,32 @@ def test_rolling_rank_closed_left_26147() -> None:
     assert_frame_equal(actual, expected)
 
 
+def test_rolling_rank_by_null_in_shared_window() -> None:
+    # All `by` values are equal, so every row is ranked against the same
+    # window. A null in that window must only null out its own row.
+    df = pl.DataFrame(
+        {"index": [0, 0, 0, 0], "x": [1, 2, None, 4], "y": [1, 2, 4, None]}
+    )
+    actual = df.with_columns(
+        x_ranked=pl.col("x").rolling_rank_by("index", window_size="4i"),
+        y_ranked=pl.col("y").rolling_rank_by("index", window_size="4i"),
+    )
+    expected = df.with_columns(
+        x_ranked=pl.Series([1.0, 2.0, None, 3.0]),
+        y_ranked=pl.Series([1.0, 2.0, 3.0, None]),
+    )
+    assert_frame_equal(actual, expected)
+
+
+def test_rolling_rank_by_unsorted_by() -> None:
+    df = pl.DataFrame({"index": [3, 1, 2], "x": [30, None, 20]})
+    actual = df.with_columns(
+        x_ranked=pl.col("x").rolling_rank_by("index", window_size="3i"),
+    )
+    expected = df.with_columns(x_ranked=pl.Series([2.0, None, 1.0]))
+    assert_frame_equal(actual, expected)
+
+
 def test_rolling_cov_no_panic_26741() -> None:
     result = (
         pl.DataFrame({"x": [1.0, 2.0, 3.0], "y": [1, 2, 3]})


### PR DESCRIPTION
Fixes #29044

The `is_valid` function for `RollingAggWindowNulls` previously checked only on the validity of its row at the window end.
This caused it to return invalidity for all items in the window, even if it was only the last value that was None.
Fix is having the rows individually checking their validity, rather than doing it for the entire window.
This is done inside of `get_agg`, which defers them to the validity buffer further back up.