### PR TITLE
fix: Reject non-numeric input and preserve `Decimal` scale in `entropy`

### DIFF
--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -682,12 +682,12 @@ pub(super) fn entropy(s: &Column, base: f64, normalize: bool) -> PolarsResult<Co
     use polars_ops::series::LogSeries;
 
     let out = s.as_materialized_series().entropy(base, normalize)?;
-    if matches!(s.dtype(), DataType::Float32) {
-        let out = out as f32;
-        Ok(Column::new(s.name().clone(), [out]))
+    let out_dtype = if s.dtype().is_float() {
+        s.dtype().clone()
     } else {
-        Ok(Column::new(s.name().clone(), [out]))
-    }
+        DataType::Float64
+    };
+    Column::new(s.name().clone(), [out]).cast(&out_dtype)
 }
 
 #[cfg(feature = "log")]

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -23,11 +23,9 @@ pub trait LogSeries: SeriesSealed {
 
         match (s.dtype(), base.dtype()) {
             (dt1, dt2) if dt1 == dt2 && dt1.is_float() => {
-                let s = s.to_physical_repr();
-                let base = base.to_physical_repr();
                 with_match_physical_float_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    let base_ca: &ChunkedArray<$T> = base.as_ref().as_ref().as_ref();
+                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref();
+                    let base_ca: &ChunkedArray<$T> = base.as_ref().as_ref();
                     let out: ChunkedArray<$T> = broadcast_binary_elementwise_values(ca, base_ca,
                         |x, base| x.log(base)
                     );
@@ -44,12 +42,6 @@ pub trait LogSeries: SeriesSealed {
     fn log1p(&self) -> PolarsResult<Series> {
         let s = self.as_series();
         polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'log1p'");
-        if s.dtype().is_decimal() {
-            return s.cast(&DataType::Float64).unwrap().log1p();
-        }
-
-        let s = s.to_physical_repr();
-        let s = s.as_ref();
 
         use DataType::*;
         match s.dtype() {
@@ -71,12 +63,6 @@ pub trait LogSeries: SeriesSealed {
     fn exp(&self) -> PolarsResult<Series> {
         let s = self.as_series();
         polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'exp'");
-        if s.dtype().is_decimal() {
-            return s.cast(&DataType::Float64).unwrap().exp();
-        }
-
-        let s = s.to_physical_repr();
-        let s = s.as_ref();
 
         use DataType::*;
         match s.dtype() {
@@ -97,16 +83,16 @@ pub trait LogSeries: SeriesSealed {
     /// Compute the entropy as `-sum(pk * log(pk))`.
     /// where `pk` are discrete probabilities.
     fn entropy(&self, base: f64, normalize: bool) -> PolarsResult<f64> {
-        let s = self.as_series().to_physical_repr();
-        polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "expected numerical input for 'entropy'");
-        // if there is only one value in the series, return 0.0 to prevent the
-        // function from returning -0.0
+        let s = self.as_series();
+        polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'entropy'");
+
+        // If there is only one value in the series, return 0.0 to prevent the function from returning -0.0.
         if s.len() == 1 {
             return Ok(0.0);
         }
         match s.dtype() {
             DataType::Float16 | DataType::Float32 | DataType::Float64 => {
-                let pk = s.as_ref();
+                let pk = s;
 
                 let pk = if normalize {
                     let sum = pk.sum_reduce().unwrap().into_series(PlSmallStr::EMPTY);

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -47,7 +47,7 @@ pub trait LogSeries: SeriesSealed {
         match s.dtype() {
             dt if dt.is_integer() => {
                 with_match_physical_integer_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref();
                     Ok(log1p(ca).into_series())
                 })
             },
@@ -68,7 +68,7 @@ pub trait LogSeries: SeriesSealed {
         match s.dtype() {
             dt if dt.is_integer() => {
                 with_match_physical_integer_polars_type!(s.dtype(), |$T| {
-                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                    let ca: &ChunkedArray<$T> = s.as_ref().as_ref();
                     Ok(exp(ca).into_series())
                 })
             },

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -285,7 +285,9 @@ impl IRFunctionExpr {
             #[cfg(feature = "interpolate_by")]
             InterpolateBy => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "log")]
-            Entropy { .. } => mapper.map_to_float_dtype(),
+            Entropy { .. } => mapper
+                .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "entropy")?
+                .map_to_float_dtype(),
             #[cfg(feature = "log")]
             Log1p => mapper
                 .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "log1p")?

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -155,7 +155,8 @@ def test_entropy_dtypes(
     result = lf.select(pl.col("a").entropy(normalize=normalize))
     assert result.collect_schema() == pl.Schema({"a": dtype_out})
     assert result.collect_schema() == result.collect().schema
-    assert result.collect().item() == pytest.approx(expected, rel=1e-3)
+    rel = 1e-2 if dtype_in == pl.Float16 else 1e-6
+    assert result.collect().item() == pytest.approx(expected, rel=rel)
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from itertools import permutations
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
@@ -130,20 +130,56 @@ def test_unique_stable() -> None:
     assert_series_equal(s.unique(maintain_order=True), expected)
 
 
-def test_entropy() -> None:
-    df = pl.DataFrame(
-        {
-            "group": ["A", "A", "A", "B", "B", "B", "B", "C"],
-            "id": [1, 2, 1, 4, 5, 4, 6, 7],
-        }
-    )
-    result = df.group_by("group", maintain_order=True).agg(
-        pl.col("id").entropy(normalize=True)
-    )
-    expected = pl.DataFrame(
-        {"group": ["A", "B", "C"], "id": [1.0397207708399179, 1.371381017771811, 0.0]}
-    )
-    assert_frame_equal(result, expected)
+@pytest.mark.parametrize(
+    ("dtype_in", "dtype_out"),
+    [
+        (pl.Int32, pl.Float64),
+        (pl.Float16, pl.Float16),
+        (pl.Float32, pl.Float32),
+        (pl.Float64, pl.Float64),
+        (pl.Decimal(10, 2), pl.Float64),
+    ],
+)
+@pytest.mark.parametrize("normalize", [True, False])
+def test_entropy_dtypes(
+    dtype_in: PolarsDataType, dtype_out: PolarsDataType, normalize: bool
+) -> None:
+    a = pl.Series("a", [1, 3, 9, 4, 10], dtype=dtype_in)
+    lf = pl.LazyFrame([a])
+
+    a_np = a.cast(pl.Float64).to_numpy()
+    if normalize:
+        a_np = a_np / a_np.sum()
+    expected = -np.sum(a_np * np.log(a_np))
+
+    result = lf.select(pl.col("a").entropy(normalize=normalize))
+    assert result.collect_schema() == pl.Schema({"a": dtype_out})
+    assert result.collect_schema() == result.collect().schema
+    assert result.collect().item() == pytest.approx(expected, rel=1e-3)
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        pl.Series("a", [date(2020, 1, 1), date(2021, 1, 1)]),
+        pl.Series("a", [datetime(2020, 1, 1), datetime(2021, 1, 1)]),
+        pl.Series("a", [timedelta(days=1), timedelta(days=2)]),
+        pl.Series("a", [time(1, 0), time(2, 0)]),
+        pl.Series("a", ["x", "y"], dtype=pl.Categorical),
+        pl.Series("a", ["x", "y"]),
+    ],
+)
+def test_entropy_invalid_dtype(s: pl.Series) -> None:
+    lf = pl.LazyFrame([s])
+    q = lf.select(pl.col("a").entropy())
+
+    # planner: schema resolution must reject the input dtype
+    with pytest.raises(InvalidOperationError):
+        q.collect_schema()
+
+    # engine: execution must error rather than compute on the physical repr
+    with pytest.raises(InvalidOperationError):
+        q.collect()
 
 
 @pytest.mark.parametrize(
@@ -232,21 +268,23 @@ def test_log(
         (pl.Float16, pl.Float16),
         (pl.Float32, pl.Float32),
         (pl.Float64, pl.Float64),
+        (pl.Decimal(10, 2), pl.Float64),
     ],
 )
 def test_exp_log1p(dtype_in: PolarsDataType, dtype_out: PolarsDataType) -> None:
     a = pl.Series("a", [1, 3, 9, 4, 10], dtype=dtype_in)
     lf = pl.LazyFrame([a])
+    a_np = a.cast(pl.Float64).to_numpy()
 
     # exp
     result = lf.select(pl.col("a").exp())
-    expected = pl.Series("a", np.exp(a.to_numpy())).cast(dtype_out).to_frame()
+    expected = pl.Series("a", np.exp(a_np)).cast(dtype_out).to_frame()
     assert_frame_equal(result.collect(), expected)
     assert result.collect_schema() == expected.schema
 
     # log1p
     result = lf.select(pl.col("a").log1p())
-    expected = pl.Series("a", np.log1p(a.to_numpy())).cast(dtype_out).to_frame()
+    expected = pl.Series("a", np.log1p(a_np)).cast(dtype_out).to_frame()
     assert_frame_equal(result.collect(), expected)
     assert result.collect_schema() == expected.schema
 


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/29438. I noticed this when looking into https://github.com/pola-rs/polars/pull/29112.

`log`, `log1p`, and `exp` all ensure that the input is numeric or Boolean BEFORE casting to the physical representation. However, `entropy` did it AFTER casting to the physical representation, meaning that some logical types that have numeric physical types underneath would work, such as dates. This doesn't really make sense since `entropy` is calculated on probability distributions. Additionally, `entropy` did not allow Boolean dtypes through, while the others do.

The fix was to give `entropy` the same treatment as `log`, `log1p`, and `exp` in both the engine (`log.rs`) and planner (`schema.rs`), meaning it now only allows the calculation on numeric and Boolean dtypes; for Boolean dtypes it did not work before, but I made it match `log`, `log1p`, and `exp` to be consistent.

As a note, I also removed now redundant `to_physical_repr()` calls from each of the functions. Now that we ensure that the input is numeric, for floats, ints, and booleans `to_physical_repr()` is a no-op, so the call is redundant. For the `Decimal` dtype, it will go into the `match` statement and eventually hit the `_` catch-all arm, which will properly cast it to a `Float64` and then recurse. 

As a final note, prior to this fix `entropy` called `to_physical_repr()` before casting to `Float64`. For a `Decimal` that strips the scale and leaves the raw unscaled `Int128` (e.g. `1.2345` at scale `4` becomes `12345`), so the subsequent `Int128` -> `Float64` cast produced values `10^scale` too large. With `normalize=True` the factor cancels in the normalisation, which is why this went unnoticed; with `normalize=False` the result was wrong. Casting the logical `Decimal` to `Float64` directly applies the scale correctly.

Lastly, I updated the tests to be more robust.

🤖 Claude Fable 5.1 for navigating code, asking questions + rubber ducking 🦆 , helping with the tests, and finding the incorrect calculation with `Decimal` in `entropy`. 