### PR TITLE
fix(rust): Fix panic when converting a NaiveDate[Time] to a Polars literal

### DIFF
--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -562,25 +562,12 @@ impl Literal for Null {
 #[cfg(feature = "dtype-datetime")]
 impl Literal for NaiveDateTime {
     fn lit(self) -> Expr {
-        if polars_time::in_nanoseconds_window(&self) {
-            Expr::Literal(
-                Scalar::new_datetime(
-                    self.and_utc().timestamp_nanos_opt().unwrap(),
-                    TimeUnit::Nanoseconds,
-                    None,
-                )
-                .into(),
-            )
-        } else {
-            Expr::Literal(
-                Scalar::new_datetime(
-                    self.and_utc().timestamp_micros(),
-                    TimeUnit::Microseconds,
-                    None,
-                )
-                .into(),
-            )
-        }
+        let z = self.and_utc();
+        let (value, time_unit) = match z.timestamp_nanos_opt() {
+            None => (z.timestamp_micros(), TimeUnit::Microseconds),
+            Some(value) => (value, TimeUnit::Nanoseconds),
+        };
+        Expr::Literal(Scalar::new_datetime(value, time_unit, None).into())
     }
 }
 

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -6,11 +6,6 @@ use polars_core::series::IsSorted;
 
 use crate::prelude::*;
 
-pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
-    // ~584 year around 1970
-    !(ndt.year() > 2554 || ndt.year() < 1386)
-}
-
 /// Create a [`DatetimeChunked`] from a given `start` and `end` date and a given `interval`.
 pub fn date_range(
     name: PlSmallStr,

--- a/crates/polars/tests/it/time/date.rs
+++ b/crates/polars/tests/it/time/date.rs
@@ -95,3 +95,28 @@ fn test_out_of_range_date_year_11991() {
     let is_leap = s.is_leap_year().unwrap();
     assert_eq!(is_leap.get(0), None);
 }
+
+#[test]
+#[cfg(feature = "dtype-date")]
+fn test_naivedate_to_literal_29229() {
+    use chrono::NaiveDate;
+
+    fn compare(value: i64, time_unit: TimeUnit, year: i32, month: u32, day: u32) {
+        let expr = Expr::Literal(Scalar::new_datetime(value, time_unit, None).into());
+        let lit = NaiveDate::from_ymd_opt(year, month, day).unwrap().lit();
+        assert_eq!(lit, expr);
+    }
+
+    // NaiveDate[Time] values outside of the nanosecond resolution range should not panic
+    // on conversion to a literal.
+    compare(-9_223_286_400_000_000_000, TimeUnit::Nanoseconds, 1677, 9, 22);
+    compare(-9_223_372_800_000_000, TimeUnit::Microseconds, 1677, 9, 21);
+    compare(-18_429_206_400_000_000, TimeUnit::Microseconds, 1386, 1, 1);
+
+    compare(9_223_286_400_000_000_000, TimeUnit::Nanoseconds, 2262, 4, 11);
+    compare(9_223_372_800_000_000, TimeUnit::Microseconds, 2262, 4, 12);
+    compare(18_460_742_400_000_000, TimeUnit::Microseconds, 2554, 12, 31);
+
+    compare(-8_334_601_228_800_000_000, TimeUnit::Microseconds, -262143, 1, 1);
+    compare(8_210_266_790_400_000_000, TimeUnit::Microseconds, 262142, 12, 31);
+}


### PR DESCRIPTION
Fixes #29229.
