### PR TITLE
fix(rust): Don't silently drop extra struct fields under a strict Expr::cast

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -146,7 +146,7 @@ impl OptimizationRule for TypeCoercionRule {
                             null_upcast: true,
                             categorical_to_string: true,
                             missing_struct_fields: MissingColumnsPolicy::Insert,
-                            extra_struct_fields: ExtraColumnsPolicy::Ignore,
+                            extra_struct_fields: ExtraColumnsPolicy::Raise,
                         }
                         .should_cast_column("", cast_to, &cast_from);
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1343,6 +1343,30 @@ def test_cast_to_struct_needs_field_14083() -> None:
         pl.Series([1], dtype=pl.Int32).cast(pl.Struct({"a": pl.UInt8, "b": pl.UInt8}))
 
 
+@pytest.mark.parametrize(
+    "cast_fn",
+    [
+        lambda lf: lf.select(
+            pl.col("s").cast(pl.Struct({"x": pl.Int64, "y": pl.Int64}))
+        ),
+        lambda lf: lf.cast({"s": pl.Struct({"x": pl.Int64, "y": pl.Int64})}),
+    ],
+)
+def test_struct_cast_strict_field_mismatch_28587(
+    cast_fn: Callable[[pl.LazyFrame], pl.LazyFrame],
+) -> None:
+    lf = pl.LazyFrame({"s": [{"a": 1, "b": 2}]})
+
+    with pytest.raises(InvalidOperationError, match="field name mismatch"):
+        cast_fn(lf).collect()
+
+    # non-strict is unaffected, still fills unmatched fields with null
+    result = lf.select(
+        pl.col("s").cast(pl.Struct({"x": pl.Int64, "y": pl.Int64}), strict=False)
+    )
+    assert result.collect().to_series().to_list() == [{"x": None, "y": None}]
+
+
 @pytest.mark.filterwarnings("ignore:Comparisons with None always result in null.")
 def test_zip_outer_validity_infinite_recursion_21267() -> None:
     s = pl.Series("x", [None, None], pl.Struct({"f": pl.Null}))


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

## Summary

```python
df = pl.DataFrame({"s": [{"a": 1, "b": 2}]})
df.select(pl.col("s").cast(pl.Struct({"x": pl.Int64, "y": pl.Int64}), strict=True))
# {null, null}   <- no error, all data silently gone
```

Struct casts map fields by name and fill unmatched target fields with null. `strict=True` doesn't raise even when zero fields overlap between source and target, silently replacing the whole column with nulls.

Closes #28587.

Note: the bare `s.cast(...)` (`Series`-level, eager) reproduction from the original issue report already raises correctly on current `main`, from unrelated prior work. This PR is about the lazy expression path (`select`/`with_columns`/`DataFrame.cast`/`LazyFrame.cast`), which is by far the more common way this method gets called and still has the bug.

## Root cause

For any `Strict`-cast expression with column inputs, `TypeCoercionRule::optimize_expr` (`crates/polars-plan/src/plans/conversion/type_coercion/mod.rs`) checks a `CastColumnsPolicy` (normally used for reconciling schemas across multi-file scans) to decide whether the cast is a known-safe widening, like integer/float/datetime coercions, that it can relax from `Strict` to `NonStrict` so that internally auto-inserted `Strict` casts (e.g. `when/then/otherwise` branch supertype unification, which always constructs `AExpr::Cast { options: Strict, .. }` nodes directly) don't fail on differences that are actually fine.

For structs, the policy this pass constructs sets **both** `missing_struct_fields` and `extra_struct_fields` to their lenient variants (`Insert`/`Ignore`), instead of the crate's own sensible `CastColumnsPolicy::ERROR_ON_MISMATCH` default (`Raise`/`Raise`). Since `should_cast_column` then never reports a mismatch for a struct with completely different fields, the cast is unconditionally downgraded away from `Strict`, regardless of whether it came from that internal ternary/supertype machinery or from the user's own explicit `strict=True`. I traced this through both original issues the mechanism was built for (#22668, #22849, from the PR that introduced it, #22850): both are purely about numeric/datetime predicate-pushdown casts, neither mentions structs, so this looks like the two struct-specific policy fields were filled in as a byproduct of reusing the whole `CastColumnsPolicy` type, not a deliberate choice about struct semantics.

## Fix

`missing_struct_fields: Insert` is genuinely load-bearing and left untouched: ternary/supertype unification casts each branch into a target that is by construction a *superset* of that branch's own fields (the union of both branches), so "insert null for target fields this branch doesn't have" is exactly the intended, safe operation there.

`extra_struct_fields` has no equivalent justification: it only fires when the *source* has a field absent from the target, i.e. the source doesn't fit the target shape at all. That can never happen in the ternary/supertype case, since a branch's fields are always a subset of the unified target by construction, so changing `extra_struct_fields: Ignore` to `Raise` is free with respect to that behavior, and is exactly what's needed to correctly surface both the reported case (source and target share zero fields) and the related case of a single field being silently dropped under `strict=True`.

One line changed in `crates/polars-plan/src/plans/conversion/type_coercion/mod.rs`.

## Test plan

- [x] Reproduced the bug via `select`/`with_columns` and via `DataFrame.cast`/`LazyFrame.cast`, both silently nulling data under `strict=True` on an unpatched build; confirmed both now raise `InvalidOperationError` after the fix.
- [x] Confirmed `strict=False` is unaffected and still fills unmatched fields with null (the correct, documented behavior for non-strict).
- [x] Confirmed a genuinely lossless struct cast (same field names) still succeeds.
- [x] Confirmed the related "one extra field silently dropped" case (not the exact reported repro, but the same underlying gap) also now correctly raises under `strict=True`.
- [x] Specifically verified `when/then/otherwise` struct-branch supertype unification is unaffected: `pl.when(...).then(pl.struct(a=..., b=...)).otherwise(pl.struct(x=..., y=...))` still merges into a 4-field struct exactly as before, since it never triggers the `extra_struct_fields` check by construction.
- [x] Added `test_struct_cast_strict_field_mismatch_28587` (`py-polars/tests/unit/datatypes/test_struct.py`), parametrized over the `select`-cast and `DataFrame.cast` call surfaces, asserting the strict raise and the non-strict null-fill baseline.
- [x] Ran `test_struct.py` + `test_cast.py` (1228 passed) and `test_when_then.py` (293 passed, including existing struct-merge tests like `test_when_then_else_struct_18961`) — no regressions.
- [x] `make test` — 19259 passed, 244 skipped, 8 xfailed.
- [x] `cargo clippy -p polars-plan --all-features --all-targets` — zero warnings from the changed file.
- [x] `cargo fmt -p polars-plan --check` — clean.
- [x] ruff, ruff format, mypy on the test file — clean.

