### PR TITLE
feat(python): Add `explain_properties()` to Python `FileReaderBuilder`

### DIFF
--- a/crates/polars-error/src/python.rs
+++ b/crates/polars-error/src/python.rs
@@ -19,6 +19,12 @@ impl<'a, 'py> From<PyClassGuardError<'a, 'py>> for PolarsError {
     }
 }
 
+impl<'a, 'py> From<pyo3::CastError<'a, 'py>> for PolarsError {
+    fn from(err: pyo3::CastError) -> Self {
+        PolarsError::from(PyErr::from(err))
+    }
+}
+
 impl Clone for PyErrWrap {
     fn clone(&self) -> Self {
         Python::attach(|py| Self(self.0.clone_ref(py)))

--- a/crates/polars-io/src/external_reader/mod.rs
+++ b/crates/polars-io/src/external_reader/mod.rs
@@ -1,3 +1,6 @@
+use polars_error::PolarsResult;
+use polars_utils::aliases::PlIndexMap;
+
 #[cfg(feature = "python")]
 pub mod python;
 
@@ -10,4 +13,14 @@ pub enum ExternalReaderBuilder {
     /// Unimplemented. Placeholder to avoid empty enum when Python feature is
     /// disabled.
     Rust(()),
+}
+
+impl ExternalReaderBuilder {
+    pub fn explain_properties(&self) -> PolarsResult<PlIndexMap<String, String>> {
+        match self {
+            #[cfg(feature = "python")]
+            ExternalReaderBuilder::Python(x) => x.explain_properties(),
+            ExternalReaderBuilder::Rust(()) => unimplemented!(),
+        }
+    }
 }

--- a/crates/polars-io/src/external_reader/python.rs
+++ b/crates/polars-io/src/external_reader/python.rs
@@ -1,8 +1,12 @@
 use std::sync::Arc;
 
+use polars_error::PolarsResult;
+use polars_utils::aliases::PlIndexMap;
 use polars_utils::python_function::PythonObject;
+use pyo3::types::{PyAnyMethods, PyDict};
 use pyo3::{
     Borrowed, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyResult,
+    Python, intern,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -21,6 +25,31 @@ impl PythonFileReaderBuilder {
 
     pub fn builder(&self) -> &Arc<PythonObject> {
         &self.builder
+    }
+
+    pub fn explain_properties(&self) -> PolarsResult<PlIndexMap<String, String>> {
+        Python::attach(|py| {
+            let properties: Py<PyDict> = self
+                .builder
+                .call_method0(py, intern!(py, "explain_properties"))?
+                .extract(py)?;
+
+            let properties = properties.bind(py);
+
+            let mut ret = PlIndexMap::default();
+
+            for (k, v) in properties
+                .try_iter()?
+                .zip(properties.call_method0(intern!(py, "values"))?.try_iter()?)
+            {
+                let k: String = k?.extract()?;
+                let v: String = v?.extract()?;
+
+                ret.insert(k, v);
+            }
+
+            Ok(ret)
+        })
     }
 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -196,7 +196,11 @@ pub(super) async fn dsl_to_ir(
                 .unwrap();
         }
 
-        let ir = if sources.is_empty() && !matches!(&(*scan_type), FileScanDsl::Anonymous { .. }) {
+        let ir = if sources.is_empty()
+            && !matches!(
+                &(*scan_type),
+                FileScanDsl::Anonymous { .. } | FileScanDsl::ExternalReaderBuilder { .. }
+            ) {
             IR::DataFrameScan {
                 df: Arc::new(DataFrame::empty_with_schema(&file_info.schema)),
                 schema: file_info.schema,

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter, Write};
 use polars_core::frame::DataFrame;
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
-use polars_utils::aliases::{InitHashMaps as _, PlIndexSet};
+use polars_utils::aliases::{InitHashMaps as _, PlIndexMap, PlIndexSet};
 use polars_utils::format_list_truncated;
 use polars_utils::slice_enum::Slice;
 use polars_utils::unique_id::UniqueId;
@@ -70,6 +70,7 @@ impl AsExpr for ExprIR {
 fn write_scan(
     f: &mut dyn fmt::Write,
     name: &str,
+    scan_type: Option<&FileScanIR>,
     sources: &ScanSources,
     indent: usize,
     n_columns: usize,
@@ -86,6 +87,23 @@ fn write_scan(
         "",
         ScanSourcesDisplay(sources),
     )?;
+
+    if let Some(FileScanIR::ExternalReaderBuilder { external }) = scan_type {
+        let props = match external.explain_properties() {
+            Ok(x) => x,
+            Err(e) => PlIndexMap::from_iter([(
+                "Error:".into(),
+                format!("failed explain_properties(): {e:?}"),
+            )]),
+        };
+
+        let indent = indent + INDENT_INCREMENT;
+
+        for (k, v) in props {
+            write!(f, "\n")?;
+            write!(EscapeLabel(f), "{:indent$}{k}: {v}", "")?;
+        }
+    }
 
     let total_columns = total_columns - usize::from(row_index.is_some());
     if n_columns != usize::MAX {
@@ -840,6 +858,7 @@ pub fn write_ir_non_recursive(
             write_scan(
                 f,
                 &header_name,
+                None,
                 &ScanSources::default(),
                 indent,
                 n_columns,
@@ -898,6 +917,7 @@ pub fn write_ir_non_recursive(
             write_scan(
                 f,
                 (&**scan_type).into(),
+                Some(&**scan_type),
                 sources,
                 indent,
                 n_columns,

--- a/crates/polars-stream/src/nodes/io_sources/external_python/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/external_python/mod.rs
@@ -93,6 +93,12 @@ impl FileReaderBuilder for PythonFileReaderBuilder {
         })
     }
 
+    fn downcast_as_external_python_reader(
+        &self,
+    ) -> Option<&polars_io::external_reader::python::PythonFileReaderBuilder> {
+        Some(&self.builder)
+    }
+
     fn is_external_python_reader(&self) -> bool {
         true
     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/builder.rs
@@ -23,6 +23,13 @@ pub trait FileReaderBuilder: Debug + Send + Sync + 'static {
 
     fn set_io_metrics(&self, _io_metrics: Arc<IOMetrics>) {}
 
+    #[cfg(feature = "python")]
+    fn downcast_as_external_python_reader(
+        &self,
+    ) -> Option<&polars_io::external_reader::python::PythonFileReaderBuilder> {
+        None
+    }
+
     fn is_external_python_reader(&self) -> bool {
         false
     }

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -557,6 +557,21 @@ fn visualize_plan_rec(
             let mut out = format!("multi-scan[{reader_name}]");
             let mut f = EscapeLabel(&mut out);
 
+            #[cfg(feature = "python")]
+            if let Some(builder) = file_reader_builder.downcast_as_external_python_reader() {
+                let props = match builder.explain_properties() {
+                    Ok(x) => x,
+                    Err(e) => polars_utils::aliases::PlIndexMap::from_iter([(
+                        "Error:".into(),
+                        format!("failed explain_properties(): {e:?}"),
+                    )]),
+                };
+
+                for (k, v) in props {
+                    write!(f, "\n{k}: {v}").unwrap();
+                }
+            }
+
             write!(f, "\n{} source", scan_sources.len()).unwrap();
 
             if scan_sources.len() != 1 {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -662,7 +662,10 @@ pub fn lower_ir(
             };
 
             if (scan_sources.is_empty()
-                && !matches!(scan_type.as_ref(), FileScanIR::Anonymous { .. }))
+                && !matches!(
+                    scan_type.as_ref(),
+                    FileScanIR::Anonymous { .. } | FileScanIR::ExternalReaderBuilder { .. }
+                ))
                 || unified_scan_args
                     .pre_slice
                     .as_ref()

--- a/py-polars/src/polars/io/external_reader/_external_reader.py
+++ b/py-polars/src/polars/io/external_reader/_external_reader.py
@@ -31,6 +31,10 @@ class FileReaderBuilder(abc.ABC):
     def build_file_reader(self, source: str | bytes) -> FileReader:
         """Build a file reader for the given source."""
 
+    def explain_properties(self) -> dict[str, str]:
+        """Properties to display in IR explain."""
+        return {}
+
 
 class FileReader(abc.ABC):
     """

--- a/py-polars/tests/unit/io/test_external_reader.py
+++ b/py-polars/tests/unit/io/test_external_reader.py
@@ -556,3 +556,31 @@ def test_external_reader_with_resolver_use_case() -> None:
     assert_frame_equal(
         q.collect(), pl.DataFrame({"x": [3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]})
     )
+
+
+def test_external_reader_explain() -> None:
+    class ReaderBuilder(FileReaderBuilder):
+        def build_file_reader(self, source: str | bytes) -> FileReader:
+            msg = "unreachable"
+            raise NotImplementedError(msg)
+
+        def explain_properties(self) -> dict[str, str]:
+            return {
+                "explain_property_key": "explain_property_value",
+            }
+
+    q = pl.scan_external_reader(ReaderBuilder(), sources=[], schema={})
+    plan = q.explain()
+
+    assert (
+        plan
+        == """\
+ExternalReaderBuilder SCAN []
+  explain_property_key: explain_property_value
+PROJECT */0 COLUMNS"""
+    )
+
+    phys_graph = q.show_graph(raw_output=True)
+    assert "explain_property_key: explain_property_value" in phys_graph
+
+    assert q.collect().shape == (0, 0)


### PR DESCRIPTION
Allows users to add properties to the explain() output. E.g. -

```python
class ReaderBuilder(FileReaderBuilder):
    def build_file_reader(self, source: str | bytes) -> FileReader:
        msg = "unreachable"
        raise NotImplementedError(msg)

    def explain_properties(self) -> dict[str, str]:
        return {
            "explain_property_key": "explain_property_value",
        }

q = pl.scan_external_reader(ReaderBuilder(), sources=[], schema={})
plan = q.explain()

assert (
    plan
    == """\
ExternalReaderBuilder SCAN []
   explain_property_key: explain_property_value
PROJECT */0 COLUMNS"""
)
```
