### PR TITLE
perf: Inline hot small functions

### DIFF
--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -255,6 +255,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         )
     }
 
+    #[inline]
     pub fn data_buffers(&self) -> &Buffer<Buffer<u8>> {
         &self.buffers
     }
@@ -439,6 +440,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     }
 
     /// Returns an iterator of `&[u8]` over every element of this array, ignoring the validity
+    #[inline]
     pub fn values_iter(&self) -> BinaryViewValueIter<'_, T> {
         BinaryViewValueIter::new(self)
     }
@@ -679,6 +681,7 @@ impl Utf8ViewArray {
 }
 
 impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -702,6 +705,7 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
         &mut self.dtype
     }
 
+    #[inline]
     fn validity(&self) -> Option<&Bitmap> {
         self.validity.as_ref()
     }

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -398,6 +398,7 @@ unsafe impl Zeroable for View {}
 unsafe impl Pod for View {}
 
 impl PartialEq for View {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.as_u128() == other.as_u128()
     }
@@ -412,6 +413,7 @@ impl TotalOrd for View {
 }
 
 impl TotalEq for View {
+    #[inline(always)]
     fn tot_eq(&self, other: &Self) -> bool {
         self.eq(other)
     }

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -396,6 +396,7 @@ impl BooleanArray {
 impl Array for BooleanArray {
     impl_common_array!();
 
+    #[inline]
     fn validity(&self) -> Option<&Bitmap> {
         self.validity.as_ref()
     }

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -86,6 +86,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     fn len(&self) -> usize;
 
     /// whether the array is empty
+    #[inline]
     fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -504,6 +504,7 @@ impl<T: NativeType> PrimitiveArray<T> {
 impl<T: NativeType> Array for PrimitiveArray<T> {
     impl_common_array!();
 
+    #[inline(always)]
     fn validity(&self) -> Option<&Bitmap> {
         self.validity.as_ref()
     }

--- a/crates/polars-arrow/src/array/static_array_collect.rs
+++ b/crates/polars-arrow/src/array/static_array_collect.rs
@@ -344,7 +344,7 @@ trait IntoBytes {
 trait TrivialIntoBytes: AsRef<[u8]> {}
 impl<T: TrivialIntoBytes> IntoBytes for T {
     type AsRefT = Self;
-    
+
     #[inline(always)]
     fn into_bytes(self) -> Self {
         self
@@ -357,7 +357,7 @@ impl TrivialIntoBytes for String {}
 impl TrivialIntoBytes for &str {}
 impl<'a> IntoBytes for Cow<'a, str> {
     type AsRefT = Cow<'a, [u8]>;
-    
+
     #[inline]
     fn into_bytes(self) -> Cow<'a, [u8]> {
         match self {

--- a/crates/polars-arrow/src/array/static_array_collect.rs
+++ b/crates/polars-arrow/src/array/static_array_collect.rs
@@ -344,6 +344,8 @@ trait IntoBytes {
 trait TrivialIntoBytes: AsRef<[u8]> {}
 impl<T: TrivialIntoBytes> IntoBytes for T {
     type AsRefT = Self;
+    
+    #[inline(always)]
     fn into_bytes(self) -> Self {
         self
     }
@@ -355,6 +357,8 @@ impl TrivialIntoBytes for String {}
 impl TrivialIntoBytes for &str {}
 impl<'a> IntoBytes for Cow<'a, str> {
     type AsRefT = Cow<'a, [u8]>;
+    
+    #[inline]
     fn into_bytes(self) -> Cow<'a, [u8]> {
         match self {
             Cow::Borrowed(a) => Cow::Borrowed(a.as_bytes()),

--- a/crates/polars-arrow/src/bitmap/bitmask.rs
+++ b/crates/polars-arrow/src/bitmap/bitmask.rs
@@ -226,10 +226,12 @@ impl<'a> BitMask<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn unset_bits(&self) -> usize {
         count_zeros(self.bytes, self.offset, self.len)
     }
 
+    #[inline(always)]
     pub fn set_bits(&self) -> usize {
         self.len - self.unset_bits()
     }

--- a/crates/polars-arrow/src/bitmap/builder.rs
+++ b/crates/polars-arrow/src/bitmap/builder.rs
@@ -18,6 +18,7 @@ pub struct BitmapBuilder {
 }
 
 impl BitmapBuilder {
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -459,6 +459,7 @@ impl ArrowDataType {
         matches!(self, ArrowDataType::Utf8View | ArrowDataType::BinaryView)
     }
 
+    #[inline]
     pub fn is_numeric(&self) -> bool {
         use ArrowDataType as D;
         matches!(

--- a/crates/polars-async/src/executor/mod.rs
+++ b/crates/polars-async/src/executor/mod.rs
@@ -127,6 +127,7 @@ impl<T> JoinHandle<T> {
 impl<T> Future for JoinHandle<T> {
     type Output = T;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.poll_join(ctx)
     }

--- a/crates/polars-async/src/executor/park_group.rs
+++ b/crates/polars-async/src/executor/park_group.rs
@@ -38,10 +38,12 @@ const ACTIVE_RECRUITER_BIT: u64 = 1 << 32;
 const PREPARING_TO_PARK_BIT: u64 = 1 << 33;
 const VERSION_UNIT: u64 = 1 << 34;
 
+#[inline(always)]
 fn state_num_idle(state: u64) -> u32 {
     state as u32
 }
 
+#[inline(always)]
 fn state_version(state: u64) -> u32 {
     (state >> 34) as u32
 }
@@ -85,6 +87,7 @@ impl ParkGroup {
     /// Also cancels in-progress park attempts.
     ///
     /// Returns whether there was at least one idle worker.
+    #[inline]
     pub fn unpark_one(&self) -> bool {
         self.inner.unpark_one()
     }

--- a/crates/polars-async/src/executor/task.rs
+++ b/crates/polars-async/src/executor/task.rs
@@ -161,6 +161,7 @@ where
     S: Fn(Arc<dyn Runnable<M>>) + Send + Sync + Copy + 'static,
     M: Send + Sync + 'static,
 {
+    #[inline]
     fn metadata(&self) -> &M {
         &self.metadata
     }
@@ -340,6 +341,7 @@ mod std_shim {
         }
 
         // Decrement the reference count of the Arc on drop
+        #[inline]
         unsafe fn drop_waker<W: Wake + Send + Sync>(waker: *const ()) {
             unsafe { Arc::decrement_strong_count(waker as *const W) };
         }

--- a/crates/polars-buffer/src/buffer.rs
+++ b/crates/polars-buffer/src/buffer.rs
@@ -48,6 +48,7 @@ pub struct Buffer<T> {
 }
 
 impl<T> Clone for Buffer<T> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),

--- a/crates/polars-buffer/src/storage.rs
+++ b/crates/polars-buffer/src/storage.rs
@@ -29,6 +29,7 @@ impl VecVTable {
         }
     }
 
+    #[inline]
     fn new_static<T>() -> &'static Self {
         const { &Self::new::<T>() }
     }
@@ -118,6 +119,7 @@ unsafe impl<T: Sync + Send> Send for SharedStorage<T> {}
 unsafe impl<T: Sync + Send> Sync for SharedStorage<T> {}
 
 impl<T> Default for SharedStorage<T> {
+    #[inline]
     fn default() -> Self {
         Self::empty()
     }

--- a/crates/polars-compute/src/float_sum.rs
+++ b/crates/polars-compute/src/float_sum.rs
@@ -23,6 +23,7 @@ macro_rules! impl_cast_custom {
     ($_type:ty) => {
         #[cfg(feature = "simd")]
         impl<const N: usize> SimdCastGeneric<N> for Simd<$_type, N> {
+            #[inline]
             fn cast_generic<U: SimdCast>(self) -> Simd<U, N> {
                 self.cast::<U>()
             }

--- a/crates/polars-core/src/chunked_array/flags.rs
+++ b/crates/polars-core/src/chunked_array/flags.rs
@@ -53,26 +53,34 @@ impl From<StatisticsFlags> for StatisticsFlagsIM {
 }
 
 impl StatisticsFlagsIM {
+    #[inline]
     pub fn new(value: StatisticsFlags) -> Self {
         Self {
             inner: RelaxedCell::from(value.bits()),
         }
     }
 
+    #[inline]
     pub fn empty() -> Self {
         Self::new(StatisticsFlags::empty())
     }
 
+    #[inline]
     pub fn get_mut(&mut self) -> StatisticsFlags {
         StatisticsFlags::from_bits(*self.inner.get_mut()).unwrap()
     }
+
+    #[inline]
     pub fn set_mut(&mut self, value: StatisticsFlags) {
         *self.inner.get_mut() = value.bits();
     }
 
+    #[inline]
     pub fn get(&self) -> StatisticsFlags {
         StatisticsFlags::from_bits(self.inner.load()).unwrap()
     }
+
+    #[inline]
     pub fn set(&self, value: StatisticsFlags) {
         self.inner.store(value.bits());
     }
@@ -104,6 +112,7 @@ impl StatisticsFlags {
         self.insert(is_sorted);
     }
 
+    #[inline]
     pub fn is_sorted_any(&self) -> bool {
         self.contains(Self::IS_SORTED_ASC) | self.contains(Self::IS_SORTED_DSC)
     }

--- a/crates/polars-core/src/chunked_array/logical/date.rs
+++ b/crates/polars-core/src/chunked_array/logical/date.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 pub type DateChunked = Logical<DateType, Int32Type>;
 
 impl Int32Chunked {
+    #[inline]
     pub fn into_date(self) -> DateChunked {
         // SAFETY: no invalid states.
         unsafe { DateChunked::new_logical(self, DataType::Date) }
@@ -10,6 +11,7 @@ impl Int32Chunked {
 }
 
 impl LogicalType for DateChunked {
+    #[inline]
     fn dtype(&self) -> &DataType {
         &DataType::Date
     }

--- a/crates/polars-core/src/chunked_array/logical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/mod.rs
@@ -57,6 +57,7 @@ impl<K: PolarsDataType, T: PolarsDataType> Clone for Logical<K, T> {
 impl<K: PolarsDataType, T: PolarsDataType> Logical<K, T> {
     /// # Safety
     /// You must uphold the logical types' invariants.
+    #[inline]
     pub unsafe fn new_logical(phys: ChunkedArray<T>, dtype: DataType) -> Logical<K, T> {
         Logical {
             phys,

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -501,6 +501,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     /// Get data type of [`ChunkedArray`].
+    #[inline(always)]
     pub fn dtype(&self) -> &DataType {
         self.field.dtype()
     }
@@ -515,6 +516,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     /// Get a reference to the field.
+    #[inline(always)]
     pub fn ref_field(&self) -> &Field {
         &self.field
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -239,6 +239,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.get_flags().can_fast_explode_list()
     }
 
+    #[inline]
     pub fn get_flags(&self) -> StatisticsFlags {
         self.flags.get()
     }
@@ -511,6 +512,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     /// Name of the [`ChunkedArray`].
+    #[inline]
     pub fn name(&self) -> &PlSmallStr {
         self.field.name()
     }

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -133,6 +133,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     /// Check if ChunkedArray is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/crates/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -16,12 +16,14 @@ use crate::series::implementations::null::NullChunked;
 pub struct NonNull<T>(pub T);
 
 impl<T: TotalEq> TotalEq for NonNull<T> {
+    #[inline]
     fn tot_eq(&self, other: &Self) -> bool {
         self.0.tot_eq(&other.0)
     }
 }
 
 impl<T: TotalOrd> TotalOrd for NonNull<T> {
+    #[inline]
     fn tot_cmp(&self, other: &Self) -> Ordering {
         self.0.tot_cmp(&other.0)
     }
@@ -31,9 +33,12 @@ impl<T> IsNull for NonNull<T> {
     const HAS_NULLS: bool = false;
     type Inner = T;
 
+    #[inline(always)]
     fn is_null(&self) -> bool {
         false
     }
+
+    #[inline(always)]
     fn unwrap_inner(self) -> Self::Inner {
         self.0
     }
@@ -46,6 +51,8 @@ pub trait GetInner {
 
 impl<'a, T: PolarsDataType> GetInner for &'a ChunkedArray<T> {
     type Item = Option<T::Physical<'a>>;
+
+    #[inline(always)]
     unsafe fn get_unchecked(&self, idx: usize) -> Self::Item {
         ChunkedArray::get_unchecked(self, idx)
     }
@@ -53,6 +60,8 @@ impl<'a, T: PolarsDataType> GetInner for &'a ChunkedArray<T> {
 
 impl<'a, T: StaticArray> GetInner for &'a T {
     type Item = Option<T::ValueT<'a>>;
+
+    #[inline(always)]
     unsafe fn get_unchecked(&self, idx: usize) -> Self::Item {
         <T as StaticArray>::get_unchecked(self, idx)
     }
@@ -60,6 +69,8 @@ impl<'a, T: StaticArray> GetInner for &'a T {
 
 impl<'a, T: PolarsDataType> GetInner for NonNull<&'a ChunkedArray<T>> {
     type Item = NonNull<T::Physical<'a>>;
+
+    #[inline(always)]
     unsafe fn get_unchecked(&self, idx: usize) -> Self::Item {
         NonNull(self.0.value_unchecked(idx))
     }
@@ -67,6 +78,8 @@ impl<'a, T: PolarsDataType> GetInner for NonNull<&'a ChunkedArray<T>> {
 
 impl<'a, T: StaticArray> GetInner for NonNull<&'a T> {
     type Item = NonNull<T::ValueT<'a>>;
+
+    #[inline(always)]
     unsafe fn get_unchecked(&self, idx: usize) -> Self::Item {
         NonNull(self.0.value_unchecked(idx))
     }

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -10,18 +10,21 @@ struct CompareRow<'a> {
 }
 
 impl PartialEq for CompareRow<'_> {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         self.bytes == other.bytes
     }
 }
 
 impl Ord for CompareRow<'_> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.bytes.cmp(other.bytes)
     }
 }
 
 impl PartialOrd for CompareRow<'_> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -355,6 +355,7 @@ impl DataType {
     }
 
     /// Get the inner data type of a nested type.
+    #[inline]
     pub fn inner_dtype(&self) -> Option<&DataType> {
         match self {
             DataType::List(inner) => Some(inner),
@@ -634,6 +635,7 @@ impl DataType {
     }
 
     /// Check if this [`DataType`] is a boolean.
+    #[inline]
     pub fn is_bool(&self) -> bool {
         matches!(self, DataType::Boolean)
     }
@@ -895,6 +897,7 @@ impl DataType {
 
     /// Check if this [`DataType`] is a basic floating point type (excludes Decimal).
     /// Note, this also includes `Unknown(UnknownKind::Float)`.
+    #[inline]
     pub fn is_float(&self) -> bool {
         matches!(
             self,
@@ -906,6 +909,7 @@ impl DataType {
     }
 
     /// Check if this [`DataType`] is an integer. Note, this also includes `Unknown(UnknownKind::Int)`.
+    #[inline]
     pub fn is_integer(&self) -> bool {
         matches!(
             self,
@@ -1734,6 +1738,7 @@ pub fn unpack_dtypes(dtype: &DataType, include_compound_types: bool) -> PlHashSe
 pub struct CompatLevel(pub(crate) u16);
 
 impl CompatLevel {
+    #[inline]
     pub const fn newest() -> CompatLevel {
         CompatLevel(1)
     }

--- a/crates/polars-core/src/frame/column/scalar.rs
+++ b/crates/polars-core/src/frame/column/scalar.rs
@@ -65,6 +65,7 @@ impl ScalarColumn {
         self.scalar.dtype()
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-core/src/frame/column/series.rs
+++ b/crates/polars-core/src/frame/column/series.rs
@@ -46,6 +46,7 @@ impl SeriesColumn {
         None
     }
 
+    #[inline]
     pub fn take(self) -> Series {
         self.inner
     }

--- a/crates/polars-core/src/frame/column/series.rs
+++ b/crates/polars-core/src/frame/column/series.rs
@@ -62,12 +62,14 @@ impl From<Series> for SeriesColumn {
 impl Deref for SeriesColumn {
     type Target = Series;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl DerefMut for SeriesColumn {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -46,6 +46,7 @@ use crate::series::IsSorted;
 use crate::series::implementations::SeriesWrap;
 use crate::utils::{Container, NoNull};
 
+#[inline]
 fn idx2usize(idx: &[IdxSize]) -> impl ExactSizeIterator<Item = usize> + '_ {
     idx.iter().map(|i| *i as usize)
 }

--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -143,18 +143,22 @@ impl GroupsIdx {
         self.into_iter()
     }
 
+    #[inline(always)]
     pub fn all(&self) -> &[IdxVec] {
         &self.all
     }
 
+    #[inline(always)]
     pub fn first(&self) -> &[IdxSize] {
         &self.first
     }
 
+    #[inline(always)]
     pub(crate) fn len(&self) -> usize {
         self.first.len()
     }
 
+    #[inline(always)]
     pub(crate) unsafe fn get_unchecked(&self, index: usize) -> BorrowIdxItem<'_> {
         let first = *self.first.get_unchecked(index);
         let all = self.all.get_unchecked(index);

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -1113,6 +1113,7 @@ unsafe impl IntoSeries for Series {
         true
     }
 
+    #[inline]
     fn into_series(self) -> Series {
         self
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -196,6 +196,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.deposit(validity).into_series()
     }
 
+    #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -25,6 +25,7 @@ impl private::PrivateSeries for SeriesWrap<DateChunked> {
         Cow::Owned(self.0.field())
     }
 
+    #[inline]
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
@@ -166,6 +167,7 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
         self.0.physical().chunk_lengths()
     }
 
+    #[inline]
     fn name(&self) -> &PlSmallStr {
         self.0.name()
     }
@@ -275,6 +277,7 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
             .into_series()
     }
 
+    #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -13,6 +13,7 @@ macro_rules! impl_dyn_series {
             fn _field(&self) -> Cow<'_, Field> {
                 Cow::Borrowed(self.0.ref_field())
             }
+            #[inline]
             fn _dtype(&self) -> &DataType {
                 self.0.ref_field().dtype()
             }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -59,6 +59,7 @@ impl<T: PolarsDataType> Deref for SeriesWrap<ChunkedArray<T>> {
 }
 
 unsafe impl<T: PolarsPhysicalType> IntoSeries for ChunkedArray<T> {
+    #[inline]
     fn into_series(self) -> Series {
         T::ca_into_series(self)
     }
@@ -75,6 +76,7 @@ macro_rules! impl_dyn_series {
                 Cow::Borrowed(self.0.ref_field())
             }
 
+            #[inline]
             fn _dtype(&self) -> &DataType {
                 self.0.ref_field().dtype()
             }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -307,6 +307,7 @@ macro_rules! impl_dyn_series {
                 self.0.deposit(validity).into_series()
             }
 
+            #[inline(always)]
             fn len(&self) -> usize {
                 self.0.len()
             }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -8,6 +8,7 @@ impl private::PrivateSeries for SeriesWrap<StringChunked> {
     fn _field(&self) -> Cow<'_, Field> {
         Cow::Borrowed(self.0.ref_field())
     }
+    #[inline]
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().dtype()
     }
@@ -107,6 +108,7 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
     fn chunk_lengths(&self) -> ChunkLenIter<'_> {
         self.0.chunk_lengths()
     }
+    #[inline]
     fn name(&self) -> &PlSmallStr {
         self.0.name()
     }
@@ -174,6 +176,7 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         self.0.deposit(validity).into_series()
     }
 
+    #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1124,6 +1124,7 @@ impl Default for Series {
 impl Deref for Series {
     type Target = dyn SeriesTrait;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -227,6 +227,7 @@ pub trait SeriesTrait:
     }
 
     /// Get datatype of series.
+    #[inline(always)]
     fn dtype(&self) -> &DataType {
         self._dtype()
     }

--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -110,6 +110,7 @@ bitflags! {
 }
 
 impl Default for SuperTypeFlags {
+    #[inline]
     fn default() -> Self {
         SuperTypeFlags::from_bits_truncate(0) | SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING
     }

--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -71,6 +71,7 @@ impl Grouper for RowEncodedHashGrouper {
         self.idx_map.reserve(additional);
     }
 
+    #[inline]
     fn num_groups(&self) -> IdxSize {
         self.idx_map.len()
     }

--- a/crates/polars-expr/src/lib.rs
+++ b/crates/polars-expr/src/lib.rs
@@ -39,6 +39,7 @@ impl EvictIdx {
         (self.0 >> (IdxSize::BITS - 1)) != 0
     }
 
+    #[inline]
     pub fn cast_slice(idxs: &[IdxSize]) -> &[EvictIdx] {
         // SAFETY: same size and align, repr(transparent).
         unsafe { std::slice::from_raw_parts(idxs.as_ptr() as *const EvictIdx, idxs.len()) }

--- a/crates/polars-ooc/src/spill_frame.rs
+++ b/crates/polars-ooc/src/spill_frame.rs
@@ -125,6 +125,7 @@ impl SpillFrame {
     }
 
     /// The height of the contained DataFrame. Does not need to unspill DataFrame.
+    #[inline]
     pub fn height(&self) -> usize {
         self.height
     }

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -4,6 +4,7 @@ use polars_core::prelude::{ChunkFullNull, Int64Chunked, StringChunked, UInt64Chu
 use polars_core::series::IsSorted;
 use polars_error::{PolarsResult, polars_ensure};
 
+#[inline(always)]
 fn is_utf8_codepoint_start(b: u8) -> bool {
     // The top two bits of a continuation byte are 10. Any other value is a
     // starting byte. We can use signed comparison to test for this in one
@@ -54,6 +55,7 @@ pub fn char_to_byte_idx_or_cp_count(s: &str, char_idx: usize) -> Result<usize, u
 /// equivalent offset in bytes.
 ///
 /// If `char_idx` would be out-of-bounds s.len() is returned.
+#[inline]
 pub fn char_to_byte_idx(s: &str, char_idx: usize) -> usize {
     if char_idx >= s.len() {
         // No need to even count.

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
@@ -25,7 +25,7 @@ pub trait IndexMapping {
         self.len() == 0
     }
     fn len(&self) -> usize;
-    
+
     #[inline(always)]
     fn get(&self, idx: u32) -> Option<Self::Output> {
         ((idx as usize) < self.len()).then(|| unsafe { self.get_unchecked(idx) })

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
@@ -25,9 +25,12 @@ pub trait IndexMapping {
         self.len() == 0
     }
     fn len(&self) -> usize;
+    
+    #[inline(always)]
     fn get(&self, idx: u32) -> Option<Self::Output> {
         ((idx as usize) < self.len()).then(|| unsafe { self.get_unchecked(idx) })
     }
+
     unsafe fn get_unchecked(&self, idx: u32) -> Self::Output;
 }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
@@ -108,6 +108,7 @@ where
 }
 
 impl<T: NativeType> utils::Decoded for (Vec<T>, BitmapBuilder) {
+    #[inline]
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
@@ -25,6 +25,7 @@ impl<'a, B: AlignedBytes> ArrayChunks<'a, B> {
         Some(Self { bytes })
     }
 
+    #[inline(always)]
     pub(crate) unsafe fn get_unchecked(&self, at: usize) -> B {
         B::from_unaligned(*unsafe { self.bytes.get_unchecked(at) })
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
@@ -39,6 +39,7 @@ impl Filter {
         }
     }
 
+    #[inline]
     pub fn max_offset(&self, total_num_rows: usize) -> usize {
         match self {
             Self::Range(range) => range.end,

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -89,6 +89,7 @@ impl<'a, D: Decoder> State<'a, D> {
         })
     }
 
+    #[inline]
     pub fn decode(
         self,
         decoder: &mut D,

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
@@ -192,10 +192,12 @@ impl<T: Unpackable> ChunkedDecoder<'_, '_, T> {
 }
 
 impl<'a, T: Unpackable> Decoder<'a, T> {
+    #[inline(always)]
     pub fn chunked<'b>(&'b mut self) -> ChunkedDecoder<'a, 'b, T> {
         ChunkedDecoder { decoder: self }
     }
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -65,10 +65,12 @@ impl<'a> HybridRleDecoder<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.num_values
     }
 
+    #[inline(always)]
     pub fn num_bits(&self) -> usize {
         self.num_bits
     }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -57,6 +57,7 @@ impl HybridRleChunk<'_> {
 
 impl<'a> HybridRleDecoder<'a> {
     /// Returns a new [`HybridRleDecoder`]
+    #[inline]
     pub fn new(data: &'a [u8], num_bits: u32, num_values: usize) -> Self {
         Self {
             data,
@@ -184,6 +185,7 @@ impl<'a> HybridRleDecoder<'a> {
         }))
     }
 
+    #[inline]
     pub fn limit_to(&mut self, length: usize) {
         self.num_values = self.num_values.min(length);
     }

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
@@ -458,6 +458,7 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
     }
 
     /// Read an `i32`.
+    #[inline]
     fn read_i32(&mut self) -> ThriftProtocolResult<i32> {
         Ok(self.read_zig_zag()? as _)
     }

--- a/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
@@ -48,6 +48,7 @@ impl ColumnChunkMetadata {
 
     /// The [`ColumnDescriptor`] for this column. This descriptor contains
     /// the physical and logical type of the pages.
+    #[inline]
     pub fn descriptor(&self) -> &ColumnDescriptor {
         &self.column_descr
     }
@@ -78,6 +79,7 @@ impl ColumnChunkMetadata {
     /// Total number of values in this column chunk. Note that this is not
     /// necessarily the number of rows. E.g. the (nested) array `[[1, 2], [3]]`
     /// has 2 rows and 3 values.
+    #[inline]
     pub fn num_values(&self) -> i64 {
         self.compact_metadata().num_values
     }
@@ -103,6 +105,7 @@ impl ColumnChunkMetadata {
     }
 
     /// Returns the total uncompressed data size of this column chunk.
+    #[inline]
     pub fn uncompressed_size(&self) -> i64 {
         self.compact_metadata().total_uncompressed_size
     }
@@ -165,6 +168,7 @@ impl ColumnChunkMetadata {
     /// Build from a [`CompactColumnChunk`] + descriptor handle.
     /// Infallible: the decoder rejects malformed chunks (missing
     /// `meta_data`) up front, so by here the invariant is type-enforced.
+    #[inline]
     pub(crate) fn from_compact(
         column_descr: ColumnDescriptorRef,
         column_chunk: CompactColumnChunk,

--- a/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
@@ -101,6 +101,7 @@ pub(crate) struct ColumnDescriptorRef {
 }
 
 impl ColumnDescriptorRef {
+    #[inline]
     pub(crate) fn new(descrs: Arc<Vec<ColumnDescriptor>>, idx: usize) -> Self {
         Self { descrs, idx }
     }

--- a/crates/polars-parquet/src/parquet/metadata/row_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/row_metadata.rs
@@ -64,16 +64,19 @@ impl RowGroupMetadata {
         self.column_lookup.get(root_name).map(|x| x.as_slice())
     }
 
+    #[inline]
     pub fn parquet_columns(&self) -> &[ColumnChunkMetadata] {
         &self.columns
     }
 
     /// Number of rows in this row group.
+    #[inline]
     pub fn num_rows(&self) -> usize {
         self.num_rows
     }
 
     /// Total byte size of all uncompressed column data in this row group.
+    #[inline]
     pub fn total_byte_size(&self) -> usize {
         self.total_byte_size
     }

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -48,6 +48,7 @@ impl CompressedDataPage {
     }
 
     /// Returns a new [`CompressedDataPage`].
+    #[inline]
     pub(crate) fn new_read(
         header: DataPageHeader,
         buffer: CowBuffer,
@@ -65,14 +66,17 @@ impl CompressedDataPage {
         }
     }
 
+    #[inline]
     pub fn header(&self) -> &DataPageHeader {
         &self.header
     }
 
+    #[inline]
     pub fn uncompressed_size(&self) -> usize {
         self.uncompressed_page_size
     }
 
+    #[inline]
     pub fn compressed_size(&self) -> usize {
         self.buffer.len()
     }
@@ -80,10 +84,12 @@ impl CompressedDataPage {
     /// The compression of the data in this page.
     /// Note that what is compressed in a page depends on its version:
     /// in V1, the whole data (`[repetition levels][definition levels][values]`) is compressed; in V2 only the values are compressed.
+    #[inline]
     pub fn compression(&self) -> Compression {
         self.compression
     }
 
+    #[inline]
     pub fn num_values(&self) -> usize {
         self.header.num_values()
     }
@@ -122,6 +128,7 @@ pub enum DataPageHeader {
 }
 
 impl DataPageHeader {
+    #[inline]
     pub fn num_values(&self) -> usize {
         match &self {
             DataPageHeader::V1(d) => d.num_values as usize,
@@ -129,6 +136,7 @@ impl DataPageHeader {
         }
     }
 
+    #[inline]
     pub fn null_count(&self) -> Option<usize> {
         match &self {
             DataPageHeader::V1(_) => None,
@@ -173,6 +181,7 @@ impl DataPage {
         }
     }
 
+    #[inline]
     pub(crate) fn new_read(
         header: DataPageHeader,
         buffer: CowBuffer,
@@ -186,10 +195,12 @@ impl DataPage {
         }
     }
 
+    #[inline]
     pub fn header(&self) -> &DataPageHeader {
         &self.header
     }
 
+    #[inline]
     pub fn buffer(&self) -> &[u8] {
         &self.buffer
     }
@@ -200,10 +211,12 @@ impl DataPage {
         self.buffer.to_mut()
     }
 
+    #[inline]
     pub fn num_values(&self) -> usize {
         self.header.num_values()
     }
 
+    #[inline]
     pub fn null_count(&self) -> Option<usize> {
         self.header.null_count()
     }
@@ -353,6 +366,7 @@ impl CompressedDictPage {
     }
 
     /// The compression of the data in this page.
+    #[inline]
     pub fn compression(&self) -> Compression {
         self.compression
     }

--- a/crates/polars-parquet/src/parquet/read/compression.rs
+++ b/crates/polars-parquet/src/parquet/read/compression.rs
@@ -8,6 +8,7 @@ use crate::parquet::page::{
     CompressedDataPage, CompressedPage, DataPage, DataPageHeader, DictPage, Page,
 };
 
+#[inline]
 fn decompress_v1(
     compressed: &[u8],
     compression: Compression,
@@ -221,6 +222,7 @@ pub struct DataPageItem {
 }
 
 impl DataPageItem {
+    #[inline]
     pub fn num_values(&self) -> usize {
         self.page.num_values()
     }

--- a/crates/polars-plan/src/plans/aexpr/projection_height.rs
+++ b/crates/polars-plan/src/plans/aexpr/projection_height.rs
@@ -71,6 +71,7 @@ impl<'a> NodeVisitor for ExprHeightVisitor<'a> {
     type Storage = &'a Arena<AExpr>;
     type BreakValue = ();
 
+    #[inline]
     fn default_edge(
         &mut self,
         _key: Self::Key,

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -317,6 +317,7 @@ impl LiteralValue {
         }
     }
 
+    #[inline]
     pub fn is_scalar(&self) -> bool {
         !matches!(self, LiteralValue::Series(_) | LiteralValue::Range { .. })
     }

--- a/crates/polars-plan/src/traversal/tree_traversal.rs
+++ b/crates/polars-plan/src/traversal/tree_traversal.rs
@@ -288,6 +288,7 @@ impl<'provider, Edge> NodeEdgesProvider<Edge> for SliceEdgeProvider<'provider, E
 struct Inputs<T>(T);
 
 impl<'a, Edge> Collection<Edge> for Inputs<SliceEdgeProvider<'a, Edge>> {
+    #[inline]
     fn len(&self) -> usize {
         self.0.input_range.len()
     }
@@ -305,6 +306,7 @@ impl<'a, Edge> Collection<Edge> for Inputs<SliceEdgeProvider<'a, Edge>> {
 struct Outputs<T>(T);
 
 impl<'a, Edge> Collection<Edge> for Outputs<SliceEdgeProvider<'a, Edge>> {
+    #[inline]
     fn len(&self) -> usize {
         self.0.output_idxs.len()
     }

--- a/crates/polars-plan/src/traversal/visitor.rs
+++ b/crates/polars-plan/src/traversal/visitor.rs
@@ -36,6 +36,7 @@ pub trait NodeVisitor {
     /// to that node, that node will not be visited.
     ///
     /// Called before pre_visit of each node.
+    #[inline]
     fn is_deleted_edge(&mut self, _edge: &Self::Edge) -> Option<bool> {
         None
     }

--- a/crates/polars-row/src/fixed/numeric.rs
+++ b/crates/polars-row/src/fixed/numeric.rs
@@ -48,10 +48,12 @@ macro_rules! encode_unsigned {
         impl FixedLengthEncoding for $t {
             type Encoded = [u8; $n];
 
+            #[inline(always)]
             fn encode(self) -> [u8; $n] {
                 self.to_be_bytes()
             }
 
+            #[inline(always)]
             fn decode(encoded: Self::Encoded) -> Self {
                 Self::from_be_bytes(encoded)
             }
@@ -71,6 +73,7 @@ macro_rules! encode_signed {
         impl FixedLengthEncoding for $t {
             type Encoded = [u8; $n];
 
+            #[inline(always)]
             fn encode(self) -> [u8; $n] {
                 #[cfg(target_endian = "big")]
                 {
@@ -83,6 +86,7 @@ macro_rules! encode_signed {
                 b
             }
 
+            #[inline(always)]
             fn decode(mut encoded: Self::Encoded) -> Self {
                 // Toggle top "sign" bit
                 encoded[0] ^= 0x80;
@@ -117,6 +121,7 @@ impl FixedLengthEncoding for pf16 {
 impl FixedLengthEncoding for f32 {
     type Encoded = [u8; 4];
 
+    #[inline]
     fn encode(self) -> [u8; 4] {
         // https://github.com/rust-lang/rust/blob/9c20b2a8cc7588decb6de25ac6a7912dcef24d65/library/core/src/num/f32.rs#L1176-L1260
         let s = canonical_f32(self).to_bits() as i32;
@@ -124,6 +129,7 @@ impl FixedLengthEncoding for f32 {
         val.encode()
     }
 
+    #[inline]
     fn decode(encoded: Self::Encoded) -> Self {
         let bits = i32::decode(encoded);
         let val = bits ^ (((bits >> 31) as u32) >> 1) as i32;
@@ -134,6 +140,7 @@ impl FixedLengthEncoding for f32 {
 impl FixedLengthEncoding for f64 {
     type Encoded = [u8; 8];
 
+    #[inline]
     fn encode(self) -> [u8; 8] {
         // https://github.com/rust-lang/rust/blob/9c20b2a8cc7588decb6de25ac6a7912dcef24d65/library/core/src/num/f32.rs#L1176-L1260
         let s = canonical_f64(self).to_bits() as i64;
@@ -141,6 +148,7 @@ impl FixedLengthEncoding for f64 {
         val.encode()
     }
 
+    #[inline]
     fn decode(encoded: Self::Encoded) -> Self {
         let bits = i64::decode(encoded);
         let val = bits ^ (((bits >> 63) as u64) >> 1) as i64;

--- a/crates/polars-row/src/variable/no_order.rs
+++ b/crates/polars-row/src/variable/no_order.rs
@@ -16,6 +16,7 @@ use polars_utils::slice::Slice2Uninit;
 
 use crate::row::RowEncodingOptions;
 
+#[inline(always)]
 pub fn len_from_item(value: Option<usize>, opt: RowEncodingOptions) -> usize {
     debug_assert!(opt.contains(RowEncodingOptions::NO_ORDER));
 

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -154,6 +154,7 @@ impl<Field, Metadata> Schema<Field, Metadata> {
     }
 
     /// Get a reference to the dtype of the field named `name`, or `None` if the field doesn't exist.
+    #[inline]
     pub fn get(&self, name: &str) -> Option<&Field> {
         self.fields.get(name)
     }
@@ -179,6 +180,7 @@ impl<Field, Metadata> Schema<Field, Metadata> {
     /// Return all data about the field named `name`: its index in the schema, its name, and its dtype.
     ///
     /// Returns `Some((index, &name, &dtype))` if the field exists, `None` if it doesn't.
+    #[inline]
     pub fn get_full(&self, name: &str) -> Option<(usize, &PlSmallStr, &Field)> {
         self.fields.get_full(name)
     }
@@ -372,6 +374,7 @@ impl<Field, Metadata> Schema<Field, Metadata> {
         self.fields.iter_mut().map(|(_name, dtype)| dtype)
     }
 
+    #[inline]
     pub fn index_of(&self, name: &str) -> Option<usize> {
         self.fields.get_index_of(name)
     }

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -163,6 +163,7 @@ impl Morsel {
         self.sf.get_mut_blocking()
     }
 
+    #[inline]
     pub fn seq(&self) -> MorselSeq {
         self.seq
     }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/projection.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/projection.rs
@@ -71,6 +71,7 @@ pub enum ArrowFieldProjection {
 }
 
 impl ArrowFieldProjection {
+    #[inline]
     pub fn arrow_field(&self) -> &ArrowField {
         match self {
             Self::Plain(field) => field,

--- a/crates/polars-utils/src/aliases.rs
+++ b/crates/polars-utils/src/aliases.rs
@@ -79,10 +79,12 @@ pub trait InitHashMaps {
 impl<K, V> InitHashMaps for PlHashMap<K, V> {
     type HashMap = Self;
 
+    #[inline]
     fn new() -> Self::HashMap {
         Self::with_capacity_and_hasher(0, Default::default())
     }
 
+    #[inline]
     fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity_and_hasher(capacity, Default::default())
     }
@@ -90,10 +92,12 @@ impl<K, V> InitHashMaps for PlHashMap<K, V> {
 impl<K> InitHashMaps for PlHashSet<K> {
     type HashMap = Self;
 
+    #[inline]
     fn new() -> Self::HashMap {
         Self::with_capacity_and_hasher(0, Default::default())
     }
 
+    #[inline]
     fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity_and_hasher(capacity, Default::default())
     }
@@ -102,10 +106,12 @@ impl<K> InitHashMaps for PlHashSet<K> {
 impl<K> InitHashMaps for PlIndexSet<K> {
     type HashMap = Self;
 
+    #[inline]
     fn new() -> Self::HashMap {
         Self::with_capacity_and_hasher(0, Default::default())
     }
 
+    #[inline]
     fn with_capacity(capacity: usize) -> Self::HashMap {
         Self::with_capacity_and_hasher(capacity, Default::default())
     }
@@ -114,10 +120,12 @@ impl<K> InitHashMaps for PlIndexSet<K> {
 impl<K, V> InitHashMaps for PlIndexMap<K, V> {
     type HashMap = Self;
 
+    #[inline]
     fn new() -> Self::HashMap {
         Self::with_capacity_and_hasher(0, Default::default())
     }
 
+    #[inline]
     fn with_capacity(capacity: usize) -> Self::HashMap {
         Self::with_capacity_and_hasher(capacity, Default::default())
     }

--- a/crates/polars-utils/src/cardinality_sketch.rs
+++ b/crates/polars-utils/src/cardinality_sketch.rs
@@ -35,6 +35,7 @@ impl CardinalitySketch {
     }
 
     /// Add a new hash to the sketch.
+    #[inline]
     pub fn insert(&mut self, mut h: u64) {
         const ARBITRARY_ODD: u64 = 0x902813a5785dc787;
         // We multiply by this arbitrarily chosen odd number and then take the

--- a/crates/polars-utils/src/chunks.rs
+++ b/crates/polars-utils/src/chunks.rs
@@ -8,6 +8,7 @@ pub struct Chunks<'a, T> {
 impl<'a, T> Iterator for Chunks<'a, T> {
     type Item = &'a [T];
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.slice.is_empty() {
             return None;
@@ -44,14 +45,17 @@ impl<T> DoubleEndedIterator for Chunks<'_, T> {
 impl<T> ExactSizeIterator for Chunks<'_, T> {}
 
 impl<'a, T> Chunks<'a, T> {
+    #[inline(always)]
     pub const fn new(slice: &'a [T], chunk_size: usize) -> Self {
         Self { slice, chunk_size }
     }
 
+    #[inline(always)]
     pub const fn as_slice(&self) -> &'a [T] {
         self.slice
     }
 
+    #[inline(always)]
     pub const fn chunk_size(&self) -> usize {
         self.chunk_size
     }

--- a/crates/polars-utils/src/clmul.rs
+++ b/crates/polars-utils/src/clmul.rs
@@ -1,4 +1,5 @@
 #[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
+#[inline]
 fn intel_clmul64(x: u64, y: u64) -> u64 {
     use core::arch::x86_64::*;
     unsafe {
@@ -16,6 +17,7 @@ fn intel_clmul64(x: u64, y: u64) -> u64 {
     target_feature = "neon",
     target_feature = "aes"
 ))]
+#[inline]
 fn arm_clmul64(x: u64, y: u64) -> u64 {
     unsafe {
         // SAFETY: we have the target feature.

--- a/crates/polars-utils/src/collection.rs
+++ b/crates/polars-utils/src/collection.rs
@@ -18,6 +18,7 @@ pub struct CollectionWrap<T: ?Sized, C: Collection<T>> {
 }
 
 impl<T: ?Sized, C: Collection<T>> CollectionWrap<T, C> {
+    #[inline(always)]
     pub fn new(inner: C) -> Self {
         Self {
             inner,

--- a/crates/polars-utils/src/collection.rs
+++ b/crates/polars-utils/src/collection.rs
@@ -56,12 +56,14 @@ impl<T: ?Sized, C: Collection<T>> CollectionWrap<T, C> {
 impl<T: ?Sized, C: Collection<T>> Deref for CollectionWrap<T, C> {
     type Target = C;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl<T: ?Sized, C: Collection<T>> DerefMut for CollectionWrap<T, C> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -94,6 +96,7 @@ impl<T: Clone, C: Collection<T>, const N: usize> TryFrom<CollectionWrap<T, C>> f
 }
 
 impl<T: ?Sized, C: Collection<T>> From<C> for CollectionWrap<T, C> {
+    #[inline]
     fn from(value: C) -> Self {
         Self {
             inner: value,
@@ -103,14 +106,17 @@ impl<T: ?Sized, C: Collection<T>> From<C> for CollectionWrap<T, C> {
 }
 
 impl<T: ?Sized> Collection<T> for &mut dyn Collection<T> {
+    #[inline]
     fn len(&self) -> usize {
         (**self).len()
     }
 
+    #[inline]
     fn get(&self, idx: usize) -> Option<&T> {
         (**self).get(idx)
     }
 
+    #[inline]
     fn get_mut(&mut self, idx: usize) -> Option<&mut T> {
         (**self).get_mut(idx)
     }

--- a/crates/polars-utils/src/hashing.rs
+++ b/crates/polars-utils/src/hashing.rs
@@ -46,6 +46,7 @@ impl<'a> IsNull for BytesHash<'a> {
 }
 
 impl Hash for BytesHash<'_> {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_u64(self.hash)
     }
@@ -134,6 +135,7 @@ const RANDOM_ODD: u64 = 0x55fbfd6bfc5458e9;
 macro_rules! impl_hash_partition_as_u64 {
     ($T: ty) => {
         impl DirtyHash for $T {
+            #[inline(always)]
             fn dirty_hash(&self) -> u64 {
                 (*self as u64).wrapping_mul(RANDOM_ODD)
             }
@@ -151,6 +153,7 @@ impl_hash_partition_as_u64!(i32);
 impl_hash_partition_as_u64!(i64);
 
 impl DirtyHash for u128 {
+    #[inline(always)]
     fn dirty_hash(&self) -> u64 {
         (*self as u64)
             .wrapping_mul(RANDOM_ODD)
@@ -159,6 +162,7 @@ impl DirtyHash for u128 {
 }
 
 impl DirtyHash for i128 {
+    #[inline(always)]
     fn dirty_hash(&self) -> u64 {
         (*self as u64)
             .wrapping_mul(RANDOM_ODD)
@@ -167,12 +171,14 @@ impl DirtyHash for i128 {
 }
 
 impl DirtyHash for BytesHash<'_> {
+    #[inline(always)]
     fn dirty_hash(&self) -> u64 {
         self.hash
     }
 }
 
 impl<T: DirtyHash + ?Sized> DirtyHash for &T {
+    #[inline(always)]
     fn dirty_hash(&self) -> u64 {
         (*self).dirty_hash()
     }
@@ -181,6 +187,7 @@ impl<T: DirtyHash + ?Sized> DirtyHash for &T {
 // TODO: we should probably encourage explicit null handling, but for now we'll
 // allow directly getting a partition from a nullable value.
 impl<T: DirtyHash> DirtyHash for Option<T> {
+    #[inline(always)]
     fn dirty_hash(&self) -> u64 {
         self.as_ref().map(|s| s.dirty_hash()).unwrap_or(0)
     }

--- a/crates/polars-utils/src/idx_map/bytes_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/bytes_idx_map.rs
@@ -14,6 +14,7 @@ struct Key {
 }
 
 impl Key {
+    #[inline]
     unsafe fn get<'k>(&self, key_data: &'k [Vec<u8>]) -> &'k [u8] {
         let buf = unsafe { key_data.get_unchecked(self.key_buffer as usize) };
         unsafe { buf.get_unchecked(self.key_offset..self.key_offset + self.key_length as usize) }

--- a/crates/polars-utils/src/idx_map/bytes_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/bytes_idx_map.rs
@@ -56,10 +56,12 @@ impl<V> BytesIndexMap<V> {
         self.tuples.reserve(additional);
     }
 
+    #[inline]
     pub fn len(&self) -> IdxSize {
         self.tuples.len() as IdxSize
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.tuples.is_empty()
     }

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -56,6 +56,7 @@ impl<T> UnitVec<T> {
         }
     }
 
+    #[inline(always)]
     pub fn is_inline(&self) -> bool {
         self.capacity.get() == 1
     }
@@ -265,24 +266,28 @@ impl<T> Default for UnitVec<T> {
 impl<T> Deref for UnitVec<T> {
     type Target = [T];
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         self.as_slice()
     }
 }
 
 impl<T> DerefMut for UnitVec<T> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_slice()
     }
 }
 
 impl<T> AsRef<[T]> for UnitVec<T> {
+    #[inline(always)]
     fn as_ref(&self) -> &[T] {
         unsafe { std::slice::from_raw_parts(self.data_ptr(), self.len as usize) }
     }
 }
 
 impl<T> AsMut<[T]> for UnitVec<T> {
+    #[inline(always)]
     fn as_mut(&mut self) -> &mut [T] {
         unsafe { std::slice::from_raw_parts_mut(self.data_ptr_mut(), self.len as usize) }
     }

--- a/crates/polars-utils/src/kahan_sum.rs
+++ b/crates/polars-utils/src/kahan_sum.rs
@@ -11,6 +11,7 @@ pub struct KahanSum<T> {
 }
 
 impl<T: IsFloat + Num + Copy> KahanSum<T> {
+    #[inline]
     pub fn new(v: T) -> Self {
         KahanSum {
             sum: v,
@@ -18,12 +19,14 @@ impl<T: IsFloat + Num + Copy> KahanSum<T> {
         }
     }
 
+    #[inline(always)]
     pub fn sum(&self) -> T {
         self.sum
     }
 }
 
 impl<T: Num> Default for KahanSum<T> {
+    #[inline]
     fn default() -> Self {
         KahanSum {
             sum: T::zero(),
@@ -33,6 +36,7 @@ impl<T: Num> Default for KahanSum<T> {
 }
 
 impl<T: IsFloat + Num + AddAssign + Copy> AddAssign<T> for KahanSum<T> {
+    #[inline]
     fn add_assign(&mut self, rhs: T) {
         let y = rhs - self.err;
         let new_sum = self.sum + y;
@@ -48,6 +52,7 @@ impl<T: IsFloat + Num + AddAssign + Copy> AddAssign<T> for KahanSum<T> {
 impl<T: IsFloat + Num + AddAssign + Copy> Add<T> for KahanSum<T> {
     type Output = Self;
 
+    #[inline]
     fn add(self, rhs: T) -> Self::Output {
         let mut rv = self;
         rv += rhs;

--- a/crates/polars-utils/src/mem.rs
+++ b/crates/polars-utils/src/mem.rs
@@ -17,6 +17,7 @@ pub mod prefetch {
     /// # Safety
     ///
     /// This should only be called with pointers to valid memory.
+    #[inline]
     unsafe fn prefetch_l2_impl(ptr: *const u8) {
         _ = ptr; // Silence unused - not always used on all platforms.
 

--- a/crates/polars-utils/src/priority.rs
+++ b/crates/polars-utils/src/priority.rs
@@ -5,18 +5,21 @@ use std::cmp::Ordering;
 pub struct Priority<P, T>(pub P, pub T);
 
 impl<P: Ord + Eq, T> Ord for Priority<P, T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 }
 
 impl<P: Ord + Eq, T> PartialOrd for Priority<P, T> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl<P: Eq, T> PartialEq for Priority<P, T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }

--- a/crates/polars-utils/src/select.rs
+++ b/crates/polars-utils/src/select.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "nightly")]
+#[inline(always)]
 pub fn select_unpredictable<T>(cond: bool, true_val: T, false_val: T) -> T {
     core::hint::select_unpredictable(cond, true_val, false_val)
 }
 
 #[cfg(not(feature = "nightly"))]
+#[inline(always)]
 pub fn select_unpredictable<T>(cond: bool, true_val: T, false_val: T) -> T {
     if cond { true_val } else { false_val }
 }

--- a/crates/polars-utils/src/with_drop.rs
+++ b/crates/polars-utils/src/with_drop.rs
@@ -17,6 +17,7 @@ where
     F: FnOnce(T),
 {
     #[must_use]
+    #[inline]
     pub const fn new(inner: T, f: F) -> Self {
         Self {
             inner: ManuallyDrop::new(inner),
@@ -51,6 +52,7 @@ where
 {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &T {
         &self.inner
     }
@@ -60,6 +62,7 @@ impl<T, F> DerefMut for WithDrop<T, F>
 where
     F: FnOnce(T),
 {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         &mut self.inner
     }


### PR DESCRIPTION
I made a custom build of Polars that logs every single function call **not already marked with `#[inline]`** using AI, and ran it on PDS-H SF=1, logging how much each function is called. For the curious, here are the results: https://gist.github.com/orlp/41d4f0c94e76d7ce14786563d0ceaf21.

I went over the ones that were called 100,000+ times manually and decided whether or not to inline them, in the first commit. I let AI handle those who were called < 100,000 and >= 10,000, only inlining those functions it would consider trivial in the second commit. I had to still do a manual pass over this second commit to remove some silly ones.