### PR TITLE
fix(rust): Include rolling index columns in expression metadata

### DIFF
--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -86,7 +86,14 @@ macro_rules! push_expr {
             Function { input, .. } => input.$iter().rev().for_each(|e| $push_owned($c, e)),
             Explode { input, .. } => $push($c, input),
             #[cfg(feature = "dynamic_group_by")]
-            Rolling { function, .. } => $push($c, function),
+            Rolling {
+                function,
+                index_column,
+                ..
+            } => {
+                $push($c, index_column);
+                $push($c, function);
+            },
             Over {
                 function,
                 partition_by,

--- a/py-polars/tests/unit/operations/namespaces/test_meta.py
+++ b/py-polars/tests/unit/operations/namespaces/test_meta.py
@@ -48,6 +48,48 @@ def test_root_and_output_names() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("index_column", "expected_root_names", "is_regex"),
+    [
+        pytest.param("b", ["c", "c", "b"], False, id="column-name"),
+        pytest.param(pl.col("b"), ["c", "c", "b"], False, id="column-expression"),
+        pytest.param(
+            pl.col("b") + pl.col("offset"),
+            ["c", "c", "b", "offset"],
+            False,
+            id="computed-index",
+        ),
+        pytest.param(
+            (pl.col("b") + pl.col("offset")).alias("index"),
+            ["c", "c", "b", "offset"],
+            False,
+            id="aliased-index",
+        ),
+        pytest.param(pl.lit(1), ["c", "c"], False, id="literal-index"),
+        pytest.param(pl.col("^b.*$"), ["c", "c"], True, id="regex-index"),
+    ],
+)
+def test_rolling_index_metadata(
+    index_column: str | pl.Expr, expected_root_names: list[str], is_regex: bool
+) -> None:
+    calculation = pl.col("c").last() - pl.col("c").first()
+    expr = calculation.rolling(index_column=index_column, period="2i")
+    expected_index = (
+        pl.col(index_column) if isinstance(index_column, str) else index_column
+    )
+
+    assert expr.meta.root_names() == expected_root_names
+    assert expr.meta.output_name() == "c"
+    assert expr.alias("result").meta.output_name() == "result"
+    assert expr.meta.has_multiple_outputs() is is_regex
+    assert expr.meta.is_regex_projection() is is_regex
+
+    popped_index, popped_calculation = expr.meta.pop()
+
+    assert popped_index.meta.eq(expected_index)
+    assert popped_calculation.meta.eq(calculation)
+
+
 def test_undo_aliases() -> None:
     e = pl.col("foo").alias("bar")
     assert e.meta.undo_aliases().meta == pl.col("foo")

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars._typing import ClosedInterval, PolarsIntegerType
+    from polars._typing import ClosedInterval, EngineType, PolarsIntegerType
     from tests.conftest import PlMonkeyPatch
 
 
@@ -762,6 +762,20 @@ def test_rolling_on_expressions() -> None:
     )
 
     assert_series_equal(df["df_ri"], df["in_ri"], check_names=False)
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_rolling_index_regex(engine: EngineType) -> None:
+    df = pl.DataFrame({"b": [0, 1, 2, 4], "c": [10, 13, 21, 34]}).set_sorted("b")
+
+    result = (
+        df.lazy()
+        .select(pl.col("c").sum().rolling(index_column=pl.col("^b$"), period="2i"))
+        .collect(engine=engine)
+    )
+
+    expected = pl.DataFrame({"c": [10, 23, 34, 34]})
+    assert_frame_equal(result, expected)
 
 
 def test_rolling_in_group_by() -> None:


### PR DESCRIPTION
Fixes #27557

Previously, planner ignores `rolling.index_columns` when traversing `Expr` tree, therefore when looking at `expr.meta.root_names()`, `rolling.index_columns` will be missing from there. 

This adds the expression leaf into the traverse path when planning. 

Caveat: this change modifies the output of `expr.meta` therefore any code uses `expr.meta.pop()` or `expr.mata.root_names()` will expect the result change.   

About AI: 
- The solution is generated with Codex + Astra with my guidance. 
- I have reviewed all changes, which makes sense to me.

I have tried to follow the contributing guideline as close as possible, please let me know if there's something more I can do. :)

<img width="2560" height="1440" alt="screenshot 1" src="https://github.com/user-attachments/assets/d31cd7e5-f4ff-467c-bf8d-fa643276d108" />

<img width="2560" height="1440" alt="screenshot 2" src="https://github.com/user-attachments/assets/15aac2ee-bbba-4be6-a71c-ae6584005e8f" />

