### PR TITLE
chore: More obvious `MapChunked` storage handling

### DIFF
--- a/crates/polars-compute/src/find_validity_mismatch.rs
+++ b/crates/polars-compute/src/find_validity_mismatch.rs
@@ -1,10 +1,34 @@
 use arrow::array::{Array, FixedSizeListArray, ListArray, StructArray};
+use arrow::bitmap::Bitmap;
 use arrow::datatypes::ArrowDataType;
 use arrow::types::Offset;
 use polars_utils::IdxSize;
 use polars_utils::itertools::Itertools;
 
 use crate::cast::CastOptionsImpl;
+
+/// Find the indices where two validities disagree, without recursing into children.
+pub fn find_validity_mismatch_shallow(
+    left: Option<&Bitmap>,
+    right: Option<&Bitmap>,
+    idxs: &mut Vec<IdxSize>,
+) {
+    match (left, right) {
+        (None, None) => {},
+        (Some(l), Some(r)) => {
+            if l != r {
+                let mismatches = arrow::bitmap::xor(l, r);
+                idxs.extend(mismatches.true_idx_iter().map(|i| i as IdxSize));
+            }
+        },
+        (Some(v), _) | (_, Some(v)) => {
+            if v.unset_bits() > 0 {
+                let mismatches = !v;
+                idxs.extend(mismatches.true_idx_iter().map(|i| i as IdxSize));
+            }
+        },
+    }
+}
 
 /// Find the indices of the values where the validity mismatches.
 ///
@@ -24,21 +48,7 @@ pub fn find_validity_mismatch(left: &dyn Array, right: &dyn Array, idxs: &mut Ve
     // NOTE: This is done always, even if left and right have different nestings. This is
     // intentional and needed.
     let original_idxs_length = idxs.len();
-    match (left.validity(), right.validity()) {
-        (None, None) => {},
-        (Some(l), Some(r)) => {
-            if l != r {
-                let mismatches = arrow::bitmap::xor(l, r);
-                idxs.extend(mismatches.true_idx_iter().map(|i| i as IdxSize));
-            }
-        },
-        (Some(v), _) | (_, Some(v)) => {
-            if v.unset_bits() > 0 {
-                let mismatches = !v;
-                idxs.extend(mismatches.true_idx_iter().map(|i| i as IdxSize));
-            }
-        },
-    }
+    find_validity_mismatch_shallow(left.validity(), right.validity(), idxs);
 
     let left = left.as_any();
     let right = right.as_any();

--- a/crates/polars-compute/src/propagate_nulls.rs
+++ b/crates/polars-compute/src/propagate_nulls.rs
@@ -23,22 +23,7 @@ pub fn propagate_nulls(arr: &dyn Array) -> Option<Box<dyn Array>> {
 }
 
 pub fn propagate_nulls_list<O: Offset>(arr: &ListArray<O>) -> Option<ListArray<O>> {
-    propagate_nulls_list_impl(arr, true)
-}
-
-/// Propagate nulls one level down.
-///
-/// Full recursion would null the entries under null Map rows, which the Map storage
-/// contract forbids. Callers handle the deeper levels, emptying Map children instead.
-pub fn propagate_nulls_list_shallow<O: Offset>(arr: &ListArray<O>) -> Option<ListArray<O>> {
-    propagate_nulls_list_impl(arr, false)
-}
-
-fn propagate_nulls_list_impl<O: Offset>(arr: &ListArray<O>, recurse: bool) -> Option<ListArray<O>> {
     let Some(validity) = arr.validity() else {
-        if !recurse {
-            return None;
-        }
         return propagate_nulls(arr.values().as_ref()).map(|values| {
             ListArray::new(arr.dtype().clone(), arr.offsets().clone(), values, None)
         });
@@ -100,7 +85,11 @@ fn propagate_nulls_list_impl<O: Offset>(arr: &ListArray<O>, recurse: bool) -> Op
         new_values = Some(arr.values().with_validity(Some(new_child_validity)));
     }
 
-    let Some(values) = descend(new_values, recurse) else {
+    let Some(values) = new_values
+        .as_ref()
+        .and_then(|v| propagate_nulls(v.as_ref()))
+        .or(new_values)
+    else {
         // Nothing was changed. Return the original array.
         return None;
     };
@@ -113,30 +102,8 @@ fn propagate_nulls_list_impl<O: Offset>(arr: &ListArray<O>, recurse: bool) -> Op
     ))
 }
 
-fn descend(values: Option<Box<dyn Array>>, recurse: bool) -> Option<Box<dyn Array>> {
-    if !recurse {
-        return values;
-    }
-    values
-        .as_ref()
-        .and_then(|v| propagate_nulls(v.as_ref()))
-        .or(values)
-}
-
 pub fn propagate_nulls_fsl(arr: &FixedSizeListArray) -> Option<FixedSizeListArray> {
-    propagate_nulls_fsl_impl(arr, true)
-}
-
-/// See [`propagate_nulls_list_shallow`].
-pub fn propagate_nulls_fsl_shallow(arr: &FixedSizeListArray) -> Option<FixedSizeListArray> {
-    propagate_nulls_fsl_impl(arr, false)
-}
-
-fn propagate_nulls_fsl_impl(arr: &FixedSizeListArray, recurse: bool) -> Option<FixedSizeListArray> {
     let Some(validity) = arr.validity() else {
-        if !recurse {
-            return None;
-        }
         return propagate_nulls(arr.values().as_ref())
             .map(|values| FixedSizeListArray::new(arr.dtype().clone(), arr.len(), values, None));
     };
@@ -203,7 +170,11 @@ fn propagate_nulls_fsl_impl(arr: &FixedSizeListArray, recurse: bool) -> Option<F
         new_values = Some(arr.values().with_validity(Some(new_child_validity)));
     }
 
-    let Some(values) = descend(new_values, recurse) else {
+    let Some(values) = new_values
+        .as_ref()
+        .and_then(|v| propagate_nulls(v.as_ref()))
+        .or(new_values)
+    else {
         // Nothing was changed. Return the original array.
         return None;
     };
@@ -218,19 +189,7 @@ fn propagate_nulls_fsl_impl(arr: &FixedSizeListArray, recurse: bool) -> Option<F
 }
 
 pub fn propagate_nulls_struct(arr: &StructArray) -> Option<StructArray> {
-    propagate_nulls_struct_impl(arr, true)
-}
-
-/// See [`propagate_nulls_list_shallow`].
-pub fn propagate_nulls_struct_shallow(arr: &StructArray) -> Option<StructArray> {
-    propagate_nulls_struct_impl(arr, false)
-}
-
-fn propagate_nulls_struct_impl(arr: &StructArray, recurse: bool) -> Option<StructArray> {
     let Some(validity) = arr.validity() else {
-        if !recurse {
-            return None;
-        }
         let mut new_values = Vec::new();
         for (i, field_array) in arr.values().iter().enumerate() {
             if let Some(field_array) = propagate_nulls(field_array.as_ref()) {
@@ -267,7 +226,11 @@ fn propagate_nulls_struct_impl(arr: &StructArray, recurse: bool) -> Option<Struc
             Some(v) => Some(field_array.with_validity(Some(v & validity))),
         };
 
-        let Some(new_field_array) = descend(new_field_array, recurse) else {
+        let Some(new_field_array) = new_field_array
+            .as_ref()
+            .and_then(|v| propagate_nulls(v.as_ref()))
+            .or(new_field_array)
+        else {
             // Nothing was changed. Return the original array.
             continue;
         };
@@ -289,7 +252,11 @@ fn propagate_nulls_struct_impl(arr: &StructArray, recurse: bool) -> Option<Struc
             Some(v) => Some(field_array.with_validity(Some(v & validity))),
         };
 
-        descend(new_field_array, recurse).unwrap_or_else(|| field_array.clone())
+        new_field_array
+            .as_ref()
+            .and_then(|v| propagate_nulls(v.as_ref()))
+            .or(new_field_array)
+            .unwrap_or_else(|| field_array.clone())
     }));
 
     Some(StructArray::new(

--- a/crates/polars-compute/src/propagate_nulls.rs
+++ b/crates/polars-compute/src/propagate_nulls.rs
@@ -28,7 +28,8 @@ pub fn propagate_nulls_list<O: Offset>(arr: &ListArray<O>) -> Option<ListArray<O
 
 /// Propagate nulls one level down.
 ///
-/// Callers handle deeper levels to preserve logical invariants, such as Map entries.
+/// Full recursion would null the entries under null Map rows, which the Map storage
+/// contract forbids. Callers handle the deeper levels, emptying Map children instead.
 pub fn propagate_nulls_list_shallow<O: Offset>(arr: &ListArray<O>) -> Option<ListArray<O>> {
     propagate_nulls_list_impl(arr, false)
 }

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -41,8 +41,7 @@ impl ListChunked {
     /// # Safety
     /// Physical representations must match, and the values must be safe to read as
     /// `inner_dtype`: categorical codes in range for every non-null slot, and nested Maps
-    /// satisfying the `MapChunked` storage safety contract. Dtype-blind null propagation may
-    /// violate the Map contract.
+    /// satisfying the `MapChunked` storage safety contract.
     pub unsafe fn to_logical(&mut self, inner_dtype: DataType) {
         debug_assert_eq!(inner_dtype.to_physical(), self.inner_dtype().to_physical());
         let fld = Arc::make_mut(&mut self.field);

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -419,26 +419,6 @@ fn windowed_entries_array(arr: &LargeListArray) -> ArrayRef {
     }
 }
 
-/// Count entries under null rows using an allocation-free scan of validity runs.
-pub(crate) fn hidden_entry_count(arr: &LargeListArray) -> usize {
-    let Some(validity) = arr.validity().filter(|v| v.unset_bits() > 0) else {
-        return 0;
-    };
-    let offsets = arr.offsets();
-
-    let mut validity = validity.iter();
-    let mut hidden = 0;
-    let mut row = 0;
-    while validity.num_remaining() > 0 {
-        row += validity.take_leading_ones();
-        let end = row + validity.take_leading_zeros();
-        hidden += (offsets[end] - offsets[row]) as usize;
-        row = end;
-    }
-
-    hidden
-}
-
 /// Mask the windowed entries by row validity; `None` if no null row spans an entry.
 ///
 /// Scans validity runs once, allocating only once a null row is found to span entries.
@@ -757,9 +737,9 @@ fn canonical_map_indices(
         return None;
     }
 
-    let n_live_entries = offsets.range() as usize - hidden_entry_count(arr);
-    let mut key_idx = Vec::with_capacity(n_live_entries);
-    let mut value_idx = Vec::with_capacity(n_live_entries);
+    let capacity = offsets.range() as usize;
+    let mut key_idx = Vec::with_capacity(capacity);
+    let mut value_idx = Vec::with_capacity(capacity);
     let mut new_offsets = Vec::with_capacity(offsets.len());
     new_offsets.push(0i64);
 

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -266,6 +266,27 @@ impl MapChunked {
         }
     }
 
+    /// Set row validity, emptying the rows that turn from null to valid.
+    ///
+    /// A null row's entries are unconstrained, so revealing them as they stand could expose a
+    /// null entry or key. Rows that stay null keep their entries where they were.
+    pub(crate) fn with_row_validity(&self, validity: Option<Bitmap>) -> Self {
+        let revives_rows = match self.storage.rechunk_validity() {
+            None => false,
+            Some(old) => match &validity {
+                None => old.unset_bits() > 0,
+                Some(new) => arrow::bitmap::and_not(new, &old).set_bits() > 0,
+            },
+        };
+        let storage = if revives_rows {
+            Cow::Owned(self.live_storage().into_owned().into_series())
+        } else {
+            Cow::Borrowed(&self.storage)
+        };
+        // SAFETY: only row validity changes, and no revived row owns an entry.
+        unsafe { self.with_storage_unchecked(storage.with_validity(validity)) }
+    }
+
     pub fn cast_with_options(
         &self,
         dtype: &DataType,
@@ -1124,6 +1145,60 @@ mod test {
         // The same null in a live row must be rejected.
         let corrupt = storage(&entries, &[0, 1, 2], None);
         assert!(unsafe { corrupt.from_physical_unchecked(&dtype) }.is_err());
+    }
+
+    /// Row 0 null over a nulled entry and key, row 1 `{b: 2}`.
+    fn map_with_nulled_entries_under_a_null_row() -> MapChunked {
+        let keys = str_keys(&[None, Some("b")]);
+        let values = i64_values(&[None, Some(2)]);
+        let entries =
+            pack_map_entries(&keys, &values).with_validity(Some(Bitmap::from([false, true])));
+        let storage = storage(&entries, &[0, 1, 2], Some(&[false, true]));
+        let dtype = map_dtype(DataType::String, DataType::Int64);
+        unsafe { storage.from_physical_unchecked(&dtype) }
+            .unwrap()
+            .map()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn with_validity_empties_a_revived_row() {
+        let map = map_with_nulled_entries_under_a_null_row();
+        let revived = map.into_series().with_validity(None);
+        let revived = revived.map().unwrap();
+
+        assert_eq!(revived.null_count(), 0);
+        assert_no_live_null_entries_or_keys(revived);
+        assert_eq!(list_offsets(revived.storage()), [0, 0, 1]);
+        assert_eq!(str_values(&revived.keys()), [Some("b".to_owned())]);
+        // The revived row reads as an empty map, not as a null.
+        let AnyValue::Map(row) = revived.get_any_value(0).unwrap() else {
+            panic!("revived row is not a map");
+        };
+        assert_eq!(row.len(), 0);
+
+        // Arrow export checks the non-nullable MAP key field.
+        let exported = revived
+            .clone()
+            .into_series()
+            .rechunk()
+            .to_arrow(0, CompatLevel::newest());
+        assert_eq!(exported.len(), 2);
+    }
+
+    #[test]
+    fn with_validity_that_only_adds_nulls_keeps_the_entries() {
+        let map = map_with_nulled_entries_under_a_null_row();
+        let offsets = list_offsets(map.storage());
+        let nulled = map
+            .into_series()
+            .with_validity(Some(Bitmap::from([false, false])));
+        let nulled = nulled.map().unwrap();
+
+        assert_eq!(nulled.null_count(), 2);
+        assert_eq!(list_offsets(nulled.storage()), offsets);
+        assert_eq!(child_len(nulled.storage()), 2);
     }
 
     /// Simulate a live Arrow row with a null entry/key; PyArrow aborts on this input.

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -21,7 +21,7 @@ use crate::prelude::*;
 /// 1. The storage dtype is the [`DataType::map_storage_dtype`] of a Map dtype that passes
 ///    [`DataType::ensure_valid_map_dtype`].
 /// 2. Child arrays are valid over their entire extent, including outside the list offsets:
-///    categorical codes in range, no `Object`.
+///    categorical codes in range for every non-null slot, no `Object`.
 /// 3. Entries and keys are non-null within the offset window of every non-null row of every
 ///    chunk.
 ///
@@ -221,16 +221,17 @@ impl MapChunked {
         );
         dtype.ensure_valid_map_dtype()?;
 
-        let storage = self.live_storage();
-        let keys = unpack_map_entries(&windowed_entries(&storage)).0;
-        polars_ensure!(
-            values.len() == keys.len(),
-            ShapeMismatch:
-            "Map values must have one element per entry: expected {}, got {}",
-            keys.len(),
-            values.len(),
-        );
-        let storage = repack_map_storage(&storage, &keys, values).into_series();
+        let storage = try_apply_map_entries(&self.live_storage(), |keys, _| {
+            polars_ensure!(
+                values.len() == keys.len(),
+                ShapeMismatch:
+                "Map values must have one element per entry: expected {}, got {}",
+                keys.len(),
+                values.len(),
+            );
+            Ok((keys.clone(), values.clone()))
+        })?
+        .into_series();
 
         // SAFETY: live keys and row assignments are preserved; replacements have a valid
         // Map value dtype. Only entries no live row owns are dropped.
@@ -543,25 +544,28 @@ fn windowed_entries(storage: &ListChunked) -> Series {
     }
 }
 
-/// Rebuild Map storage from flat fields with one element per windowed entry.
+/// Transform the flat entry fields and rebuild the original Map storage.
 ///
-/// Preserves entry and list validity. Only the outer rows are rebuilt: entries nested inside
-/// the new fields keep their own offsets.
-fn repack_map_storage(storage: &ListChunked, keys: &Series, values: &Series) -> ListChunked {
+/// Also accepts `List(Struct {key, value})` that is not Map storage yet, whose entries and
+/// keys may be null. Preserves entry and list validity and row lengths. Only the outer rows
+/// are rebuilt: entries nested inside the new fields keep their own offsets. The transform
+/// must preserve the windowed entry count; its returned fields determine the output dtype.
+pub(crate) fn try_apply_map_entries(
+    storage: &ListChunked,
+    f: impl FnOnce(&Series, &Series) -> PolarsResult<(Series, Series)>,
+) -> PolarsResult<ListChunked> {
     let entries = windowed_entries(storage);
-    assert_eq!(
-        keys.len(),
-        entries.len(),
-        "map keys must have one element per entry"
-    );
-    assert_eq!(
-        values.len(),
-        entries.len(),
-        "map values must have one element per entry"
+    let (key, value) = try_unpack_map_entries(&entries)?;
+
+    let entries_len = entries.len();
+    let (key, value) = f(&key, &value)?;
+    polars_ensure!(
+        key.len() == entries_len && value.len() == entries_len,
+        ShapeMismatch: "Map entry transform changed the entry count from {entries_len} to ({}, {})",
+        key.len(), value.len(),
     );
 
-    let packed = pack_map_entries(keys, values);
-    let mut packed = packed.struct_().unwrap().clone();
+    let mut packed = pack_map_entries(&key, &value).struct_().unwrap().clone();
     packed.zip_outer_validity(entries.struct_().expect("map entries are a struct"));
     let packed = packed.into_series();
 
@@ -582,36 +586,13 @@ fn repack_map_storage(storage: &ListChunked, keys: &Series, values: &Series) -> 
         .collect();
 
     // SAFETY: the list dtype is derived from the packed entries.
-    unsafe {
+    Ok(unsafe {
         ListChunked::from_chunks_and_dtype_unchecked(
             storage.name().clone(),
             chunks,
             DataType::List(Box::new(entries_dtype)),
         )
-    }
-}
-
-/// Transform the flat entry fields and rebuild the original Map storage.
-///
-/// Also accepts `List(Struct {key, value})` that is not Map storage yet, whose entries and
-/// keys may be null. Preserves validity and row lengths. The transform must preserve the
-/// windowed entry count; its returned fields determine the output dtype.
-pub(crate) fn try_apply_map_entries(
-    storage: &ListChunked,
-    f: impl FnOnce(&Series, &Series) -> PolarsResult<(Series, Series)>,
-) -> PolarsResult<ListChunked> {
-    let entries = windowed_entries(storage);
-    let (key, value) = try_unpack_map_entries(&entries)?;
-
-    let entries_len = entries.len();
-    let (key, value) = f(&key, &value)?;
-    polars_ensure!(
-        key.len() == entries_len && value.len() == entries_len,
-        ShapeMismatch: "Map entry transform changed the entry count from {entries_len} to ({}, {})",
-        key.len(), value.len(),
-    );
-
-    Ok(repack_map_storage(storage, &key, &value))
+    })
 }
 
 fn map_av(av: AnyValue<'_>) -> AnyValue<'_> {

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::offset::{Offsets, OffsetsBuffer};
 use polars_compute::filter::filter_with_bitmap;
@@ -20,12 +22,13 @@ use crate::prelude::*;
 ///    [`DataType::ensure_valid_map_dtype`].
 /// 2. Child arrays are valid over their entire extent, including outside the list offsets:
 ///    categorical codes in range, no `Object`.
-/// 3. Entries and keys have no nulls anywhere in the child arrays.
-/// 4. Null rows span no entries: `offsets[i] == offsets[i + 1]` for every null row.
+/// 3. Entries and keys are non-null within the offset window of every non-null row of every
+///    chunk.
 ///
-/// Map values are nullable. Null rows own no entries, so flat accessors can read the whole
-/// offset window. Repairs drop offending entries rather than clearing their validity, which
-/// would expose arbitrary payloads.
+/// Map values are nullable. Everything a live row does not own -- entries under null rows or
+/// outside the offsets -- is unconstrained, as for any [`ListChunked`]. Flat accessors mask
+/// those entries and Arrow export drops them; repairs never clear entry or key validity,
+/// which would expose arbitrary payloads.
 ///
 /// # Canonical semantics
 ///
@@ -51,17 +54,13 @@ impl MapChunked {
             dtype.ensure_valid_map_dtype().is_ok(),
             "invalid Map dtype: {dtype}"
         );
-        debug_assert!(
-            null_rows_are_empty(&storage),
-            "Map null rows must span no entries"
-        );
         Self { dtype, storage }
     }
 
     /// Validate map storage and canonicalize duplicate keys.
     ///
-    /// Rejects null entries or keys in live rows; drops them elsewhere. Duplicate keys keep
-    /// their first position and last value.
+    /// Rejects null entries or keys that a live row owns. Duplicate keys keep their first
+    /// position and last value.
     pub fn try_from_storage(dtype: DataType, storage: Series) -> PolarsResult<Self> {
         dtype.ensure_valid_map_dtype()?;
 
@@ -72,8 +71,7 @@ impl MapChunked {
             storage.dtype()
         );
 
-        let storage =
-            canonicalize_map_storage(&storage, CanonicalizeMode::Full)?.unwrap_or(storage);
+        let storage = canonicalize_map_storage(&storage)?.unwrap_or(storage);
         Ok(Self { dtype, storage })
     }
 
@@ -101,11 +99,11 @@ impl MapChunked {
         self.dtype.as_map().unwrap().1
     }
 
-    /// The raw `List(Struct {key, value})` storage.
+    /// The raw `List(Struct {key, value})` storage, including entries that no live row owns.
     ///
-    /// Entries and keys are non-null and null rows span no entries, so the offset windows
-    /// hold exactly the live entries. Slicing can still leave entries outside the windows,
-    /// as it does for any [`ListChunked`].
+    /// Entries and keys are non-null within the offset windows of live rows. Null rows and
+    /// slicing can hide arbitrary entries, as they can for any [`ListChunked`];
+    /// [`Self::live_storage`] empties the null rows.
     pub fn storage(&self) -> &Series {
         &self.storage
     }
@@ -125,10 +123,6 @@ impl MapChunked {
             storage.dtype(),
             self.storage.dtype(),
             "operation on Map storage changed its dtype",
-        );
-        debug_assert!(
-            null_rows_are_empty(&storage),
-            "Map null rows must span no entries"
         );
         Self {
             dtype: self.dtype.clone(),
@@ -171,19 +165,17 @@ impl MapChunked {
         map_av(unsafe { self.storage.get_unchecked(i) })
     }
 
-    /// Keys of all entries, flattened in row order.
+    /// Keys of all entries in live rows, flattened in row order.
     pub fn keys(&self) -> Series {
         self.entry_field(&MAP_KEY_NAME)
     }
 
-    /// Values of all entries, flattened in row order.
+    /// Values of all entries in live rows, flattened in row order.
     pub fn values(&self) -> Series {
         self.entry_field(&MAP_VALUE_NAME)
     }
 
-    /// Flatten one entry field without touching the other.
-    ///
-    /// Slices each chunk's offset window; nested fields may also propagate nulls.
+    /// Flatten one entry field over live rows without filtering the other field.
     fn entry_field(&self, name: &PlSmallStr) -> Series {
         let storage = self.storage.list().unwrap();
         let DataType::Struct(fields) = storage.inner_dtype() else {
@@ -203,21 +195,25 @@ impl MapChunked {
                     .as_any()
                     .downcast_ref::<StructArray>()
                     .expect("map entries are a struct");
-                entries.values()[i].clone()
+                let field = entries.values()[i].clone();
+                match live_entry_mask(arr) {
+                    Some(mask) => filter_with_bitmap(field.as_ref(), &mask),
+                    None => field,
+                }
             })
             .collect();
 
-        // SAFETY: the chunks are one entry field, windowed to the list offsets.
+        // SAFETY: the chunks are one entry field, filtered to the entries of live rows.
         unsafe { Series::from_chunks_and_dtype_unchecked(name.clone(), chunks, fields[i].dtype()) }
     }
 
-    /// Replace entry values.
+    /// Replace live entry values.
     ///
-    /// Requires one value per entry, in [`Self::values`] order, and a valid Map value
+    /// Requires one value per live entry, in [`Self::values`] order, and a valid Map value
     /// dtype. This also applies to list-valued entries.
     ///
-    /// Preserves row count, validity, keys and entry order. Drops entries sliced away
-    /// and may rebase offsets.
+    /// Preserves row count, validity, live keys and entry order. Drops entries that no live
+    /// row owns and may rebase offsets.
     pub fn with_values(&self, values: &Series) -> PolarsResult<Self> {
         let dtype = DataType::Map(
             Box::new(self.key_dtype().clone()),
@@ -225,8 +221,8 @@ impl MapChunked {
         );
         dtype.ensure_valid_map_dtype()?;
 
-        let storage = self.storage.list().unwrap();
-        let keys = unpack_map_entries(&windowed_entries(storage)).0;
+        let storage = self.live_storage();
+        let keys = unpack_map_entries(&windowed_entries(&storage)).0;
         polars_ensure!(
             values.len() == keys.len(),
             ShapeMismatch:
@@ -234,42 +230,40 @@ impl MapChunked {
             keys.len(),
             values.len(),
         );
-        let storage = repack_map_storage(storage, &keys, values).into_series();
+        let storage = repack_map_storage(&storage, &keys, values).into_series();
 
-        // SAFETY: keys and row assignments are preserved; replacements have a valid Map
-        // value dtype.
+        // SAFETY: live keys and row assignments are preserved; replacements have a valid
+        // Map value dtype. Only entries no live row owns are dropped.
         Ok(unsafe { Self::from_storage_unchecked(dtype, storage) })
     }
 
-    /// Propagate nulls within entry children without changing row or entry validity.
+    /// Propagate nulls through the storage, exactly as for a [`ListChunked`].
+    ///
+    /// Entries under null rows may end up null, which the contract allows.
     pub(crate) fn propagate_nulls(&self) -> Option<Self> {
-        let storage = self.storage.list().unwrap();
-        // Construct without implicit propagation so its changes are reported, not
-        // discarded when a subsequent propagation call returns `None`.
-        // SAFETY: chunks are slices of this Map's non-null entry structs.
-        let entries = unsafe {
-            StructChunked::from_chunks_and_dtype_unchecked(
-                storage.name().clone(),
-                storage
-                    .downcast_iter()
-                    .map(windowed_entries_array)
-                    .collect(),
-                storage.inner_dtype().clone(),
-            )
-        };
-        let entries = entries.propagate_nulls()?.into_series();
-        let (keys, values) = unpack_map_entries(&entries);
-        let storage = repack_map_storage(storage, &keys, &values).into_series();
+        let storage = self.storage.propagate_nulls()?;
 
-        // SAFETY: only values below nested nulls change; layout and key semantics remain.
+        // SAFETY: only child validity changes; rows, live entries and keys remain.
         Some(unsafe { self.with_storage_unchecked(storage) })
     }
 
-    /// All entries, flattened in row order.
+    /// All entries in live rows, flattened in row order.
     ///
-    /// Excludes entries sliced away.
+    /// Excludes entries retained by null rows or sliced away.
     pub fn entries(&self) -> Series {
-        windowed_entries(self.storage.list().unwrap())
+        windowed_entries(&self.live_storage())
+    }
+
+    /// Storage with empty windows for null rows.
+    ///
+    /// Preserves row count, validity and live entries. Borrows if no compaction is needed.
+    /// Mutating the returned [`Cow`] affects only its owned copy.
+    pub fn live_storage(&self) -> Cow<'_, ListChunked> {
+        let storage = self.storage.list().unwrap();
+        match compact_null_map_rows(storage) {
+            Some(compacted) => Cow::Owned(compacted),
+            None => Cow::Borrowed(storage),
+        }
     }
 
     pub fn cast_with_options(
@@ -283,14 +277,15 @@ impl MapChunked {
 
         match dtype {
             DataType::Map(key, value) => self.cast_entries(key, value, options),
-            DataType::List(_) => self.storage.cast_with_options(dtype, options),
+            DataType::List(_) => self.live_storage().cast_with_options(dtype, options),
             _ => polars_bail!(InvalidOperation: "cannot cast `{}` to `{dtype}`", self.dtype),
         }
     }
 
-    /// Cast the entry children, preserving row count and outer validity.
+    /// Cast the live entry children, preserving row count and outer validity.
     ///
-    /// Drops entries sliced away and may rebase offsets. Key casts may merge duplicate keys.
+    /// Drops entries that no live row owns and may rebase offsets. Key casts may merge
+    /// duplicate keys.
     fn cast_entries(
         &self,
         to_key: &DataType,
@@ -306,7 +301,7 @@ impl MapChunked {
 
         let dtype = DataType::Map(Box::new(to_key.clone()), Box::new(to_value.clone()));
         dtype.ensure_valid_map_dtype()?;
-        let storage = try_apply_map_entries(self.storage.list().unwrap(), |key, value| {
+        let storage = try_apply_map_entries(&self.live_storage(), |key, value| {
             // `Series::cast_with_options` only short-circuits an identity cast for
             // primitives, so a nested key or value would be rebuilt for nothing.
             let key = if cast_key {
@@ -425,7 +420,7 @@ fn windowed_entries_array(arr: &LargeListArray) -> ArrayRef {
 }
 
 /// Count entries under null rows using an allocation-free scan of validity runs.
-fn hidden_entry_count(arr: &LargeListArray) -> usize {
+pub(crate) fn hidden_entry_count(arr: &LargeListArray) -> usize {
     let Some(validity) = arr.validity().filter(|v| v.unset_bits() > 0) else {
         return 0;
     };
@@ -444,40 +439,46 @@ fn hidden_entry_count(arr: &LargeListArray) -> usize {
     hidden
 }
 
-/// Whether every null row of Map storage spans no entries.
-fn null_rows_are_empty(storage: &Series) -> bool {
-    storage
-        .list()
-        .expect("map storage is a list")
-        .downcast_iter()
-        .all(|arr| hidden_entry_count(arr) == 0)
+/// Mask the windowed entries by row validity; `None` if no null row spans an entry.
+///
+/// Scans validity runs once, allocating only once a null row is found to span entries.
+fn live_entry_mask(arr: &LargeListArray) -> Option<Bitmap> {
+    let validity = arr.validity().filter(|v| v.unset_bits() > 0)?;
+    let offsets = arr.offsets();
+    let first = *offsets.first() as usize;
+    let n_entries = offsets.range() as usize;
+
+    let mut mask: Option<BitmapBuilder> = None;
+    let mut runs = validity.iter();
+    let mut row = 0;
+    while runs.num_remaining() > 0 {
+        row += runs.take_leading_ones();
+        let end = row + runs.take_leading_zeros();
+        let (start, stop) = (offsets[row] as usize, offsets[end] as usize);
+        if stop > start {
+            // Fill the live run before this null-row window in bulk.
+            let mask = mask.get_or_insert_with(|| BitmapBuilder::with_capacity(n_entries));
+            mask.extend_constant(start - first - mask.len(), true);
+            mask.extend_constant(stop - start, false);
+        }
+        row = end;
+    }
+
+    let mut mask = mask?;
+    mask.extend_constant(n_entries - mask.len(), true);
+    Some(mask.freeze())
 }
 
 /// Filter out entries under null rows and rebuild offsets; `None` if unchanged.
-fn compact_null_rows_chunk(arr: &LargeListArray) -> Option<LargeListArray> {
-    if hidden_entry_count(arr) == 0 {
-        return None;
-    }
-    let validity = arr.validity().expect("hidden entries need a null row");
-    let offsets = arr.offsets();
-
-    // Fill live runs between null-row windows in bulk.
-    let first = *offsets.first() as usize;
-    let n_entries = offsets.range() as usize;
-    let mut mask = BitmapBuilder::with_capacity(n_entries);
-    for i in (!validity).true_idx_iter() {
-        let (start, end) = offsets.start_end(i);
-        mask.extend_constant(start - first - mask.len(), true);
-        mask.extend_constant(end - start, false);
-    }
-    mask.extend_constant(n_entries - mask.len(), true);
-
+pub(crate) fn compact_null_rows_chunk(arr: &LargeListArray) -> Option<LargeListArray> {
+    let mask = live_entry_mask(arr)?;
     let entries = windowed_entries_array(arr);
-    let entries = filter_with_bitmap(entries.as_ref(), &mask.freeze());
+    let entries = filter_with_bitmap(entries.as_ref(), &mask);
 
+    let validity = arr.validity().expect("a masked chunk has null rows");
     let live_lengths = validity
         .iter()
-        .zip(offsets.lengths())
+        .zip(arr.offsets().lengths())
         .map(|(valid, len)| if valid { len } else { 0 });
     let offsets = Offsets::try_from_lengths(live_lengths)
         .expect("live lengths sum to at most the entry count");
@@ -490,7 +491,8 @@ fn compact_null_rows_chunk(arr: &LargeListArray) -> Option<LargeListArray> {
     ))
 }
 
-/// Empty null rows before wrapping raw storage as a Map; `None` if unchanged.
+/// Drop entries under null rows; `None` if unchanged.
+///
 /// Rebuilt chunks have trimmed children and zero-based offsets.
 pub(crate) fn compact_null_map_rows(storage: &ListChunked) -> Option<ListChunked> {
     if storage.null_count() == 0 {
@@ -521,55 +523,6 @@ pub(crate) fn compact_null_map_rows(storage: &ListChunked) -> Option<ListChunked
             storage.dtype().clone(),
         )
     })
-}
-
-/// Build a container child, compacting null Map rows and reporting whether it changed.
-///
-/// Skip implicit Struct propagation so the caller can track and retain its repairs.
-///
-/// # Safety
-/// `chunks` must satisfy [`Series::from_chunks_and_dtype_unchecked`] for `dtype`, except
-/// that Map null rows may still span entries.
-pub(crate) unsafe fn compacted_child_series(
-    name: PlSmallStr,
-    chunks: Vec<ArrayRef>,
-    dtype: &DataType,
-) -> (Series, bool) {
-    match dtype {
-        DataType::Map(_, _) => {
-            let storage = unsafe {
-                Series::from_chunks_and_dtype_unchecked(
-                    name,
-                    chunks,
-                    &dtype.map_storage_dtype().unwrap(),
-                )
-            };
-            let compacted = compact_null_map_rows(storage.list().unwrap());
-            let changed = compacted.is_some();
-            let storage = compacted.map_or(storage, IntoSeries::into_series);
-            // SAFETY: the caller's payloads are valid and null rows now span no entries.
-            let map = unsafe { MapChunked::from_storage_unchecked(dtype.clone(), storage) };
-            (map.into_series(), changed)
-        },
-        #[cfg(feature = "dtype-extension")]
-        DataType::Extension(typ, inner) => {
-            let (storage, changed) = unsafe { compacted_child_series(name, chunks, inner) };
-            (storage.into_extension(typ.clone()), changed)
-        },
-        #[cfg(feature = "dtype-struct")]
-        DataType::Struct(_) => {
-            // SAFETY: same layout requirements as `Series::from_chunks_and_dtype_unchecked`.
-            let ca = unsafe {
-                StructChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype.clone())
-            };
-            (ca.into_series(), false)
-        },
-        _ => {
-            // SAFETY: forwarded from this function's own contract.
-            let s = unsafe { Series::from_chunks_and_dtype_unchecked(name, chunks, dtype) };
-            (s, false)
-        },
-    }
 }
 
 /// Flatten entries within each chunk's offsets.
@@ -668,30 +621,78 @@ fn map_av(av: AnyValue<'_>) -> AnyValue<'_> {
     }
 }
 
-/// Both modes empty null rows and reject null entries or keys in live rows. Callers must
-/// validate the dtype and child payloads separately.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CanonicalizeMode {
-    /// Also deduplicate keys within each row.
-    Full,
-    /// Skip row encoding and deduplication; preserve any existing uniqueness.
-    NullsOnly,
+/// Reject null entries or keys under live rows.
+///
+/// Entries that no live row owns are unconstrained, so only the offset window of each run
+/// of valid rows is checked. Callers must validate the dtype and child payloads separately.
+pub(crate) fn ensure_live_entries_non_null(storage: &ListChunked) -> PolarsResult<()> {
+    for arr in storage.downcast_iter() {
+        let entries = arr.values();
+        let entries = entries
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("map entries are a struct");
+        let [key_arr, _] = entries.values() else {
+            unreachable!("map entries must have two arrays")
+        };
+
+        // Nothing can be null anywhere, so the windows need not be walked at all.
+        let entry_nulls = entries.validity().filter(|v| v.unset_bits() > 0);
+        let key_nulls = key_arr.validity().filter(|v| v.unset_bits() > 0);
+        if entry_nulls.is_none() && key_nulls.is_none() {
+            continue;
+        }
+
+        let offsets = arr.offsets();
+        let Some(validity) = arr.validity().filter(|v| v.unset_bits() > 0) else {
+            ensure_window_non_null(
+                entry_nulls,
+                key_nulls,
+                *offsets.first() as usize,
+                offsets.range() as usize,
+            )?;
+            continue;
+        };
+
+        let mut runs = validity.iter();
+        let mut row = 0;
+        while runs.num_remaining() > 0 {
+            let end = row + runs.take_leading_ones();
+            let start = offsets[row] as usize;
+            ensure_window_non_null(entry_nulls, key_nulls, start, offsets[end] as usize - start)?;
+            row = end + runs.take_leading_zeros();
+        }
+    }
+
+    Ok(())
 }
 
-/// Canonicalize raw Map storage. [`CanonicalizeMode::Full`] also deduplicates keys,
-/// keeping each key's first position and last value.
+fn ensure_window_non_null(
+    entries: Option<&Bitmap>,
+    keys: Option<&Bitmap>,
+    start: usize,
+    len: usize,
+) -> PolarsResult<()> {
+    polars_ensure!(
+        entries.is_none_or(|v| v.null_count_range(start, len) == 0),
+        InvalidOperation: "Map entries cannot be null"
+    );
+    polars_ensure!(
+        keys.is_none_or(|v| v.null_count_range(start, len) == 0),
+        InvalidOperation: "Map keys cannot be null"
+    );
+    Ok(())
+}
+
+/// Deduplicate keys within each row, keeping each key's first position and last value.
 ///
-/// Empty null rows. Reject null entries/keys in live rows; drop them elsewhere.
-/// Callers must validate the dtype and child payloads.
-///
-/// Filter for null-row compaction alone; gather for entry/key nulls or deduplication.
+/// Rejects null entries or keys under live rows; entries that no live row owns are left
+/// alone, except that the deduplicating gather drops them when it runs. Callers must
+/// validate the dtype and child payloads.
 ///
 /// Returns `None` if unchanged; use [`Series::canonicalize_maps`] to also reach maps
 /// nested inside the keys or values.
-pub(crate) fn canonicalize_map_storage(
-    storage: &Series,
-    mode: CanonicalizeMode,
-) -> PolarsResult<Option<Series>> {
+pub(crate) fn canonicalize_map_storage(storage: &Series) -> PolarsResult<Option<Series>> {
     let DataType::List(entries_dtype) = storage.dtype() else {
         unreachable!("map storage must be List(Struct {{key, value}})")
     };
@@ -702,11 +703,13 @@ pub(crate) fn canonicalize_map_storage(
         unreachable!("map entries must have two fields")
     };
     let list_ca = storage.list().unwrap();
+    ensure_live_entries_non_null(list_ca)?;
+
     // Allocate only after the first changed chunk.
     let mut new_chunks: Option<Vec<ArrayRef>> = None;
 
     for (i, chunk) in list_ca.downcast_iter().enumerate() {
-        match canonicalize_list_chunk(chunk, key_field.dtype(), mode)? {
+        match canonicalize_list_chunk(chunk, key_field.dtype())? {
             Some(canonicalized) => new_chunks
                 .get_or_insert_with(|| list_ca.chunks()[..i].to_vec())
                 .push(canonicalized),
@@ -729,58 +732,32 @@ struct CanonicalMapIndices {
     offsets: OffsetsBuffer<i64>,
 }
 
-/// Entry and key validity for a chunk containing nulls.
-#[derive(Clone, Copy)]
-struct EntryNulls<'a> {
-    entries: Option<&'a Bitmap>,
-    keys: Option<&'a Bitmap>,
-}
-
-impl EntryNulls<'_> {
-    fn entry_nulls_in(&self, start: usize, len: usize) -> usize {
-        self.entries.map_or(0, |v| v.null_count_range(start, len))
-    }
-
-    fn key_nulls_in(&self, start: usize, len: usize) -> usize {
-        self.keys.map_or(0, |v| v.null_count_range(start, len))
-    }
-}
-
-fn has_unset_bits(validity: Option<&Bitmap>) -> bool {
-    validity.is_some_and(|v| v.unset_bits() > 0)
-}
-
-/// Build take indices for deduplication, null removal or emptying null rows; return `None`
-/// if unchanged.
+/// Build take indices that deduplicate keys within each row; `None` if unchanged.
 ///
-/// `keys` contains row encodings in [`CanonicalizeMode::Full`]; `nulls` tracks child nulls;
-/// `hidden` is the [`hidden_entry_count`]. Gathering visits only the windows of live rows,
-/// dropping every other entry.
+/// `keys` holds the row encodings of the whole entry child. Only live rows are scanned for
+/// duplicates: two hidden keys can encode identically without anyone being able to see it.
+/// A gather visits the windows of live rows only, so it also drops every hidden entry.
 fn canonical_map_indices(
     arr: &LargeListArray,
-    keys: Option<&BinaryArray<i64>>,
-    nulls: Option<EntryNulls<'_>>,
-    hidden: usize,
-) -> PolarsResult<Option<CanonicalMapIndices>> {
+    keys: &BinaryArray<i64>,
+) -> Option<CanonicalMapIndices> {
     let offsets = arr.offsets();
+    let row_validity = arr.validity().filter(|v| v.unset_bits() > 0);
 
-    if nulls.is_none() && hidden == 0 {
-        let Some(keys) = keys else {
-            return Ok(None);
-        };
-        let mut seen = PlHashSet::new();
-        let has_duplicates = offsets.as_slice().windows(2).any(|range| {
-            seen.clear();
-            (range[0] as usize..range[1] as usize)
-                .any(|i| !seen.insert(unsafe { keys.value_unchecked(i) }))
-        });
-        if !has_duplicates {
-            return Ok(None);
+    let mut seen = PlHashSet::new();
+    let has_duplicates = (0..arr.len()).any(|row| {
+        if row_validity.is_some_and(|v| !v.get_bit(row)) {
+            return false;
         }
+        let (start, end) = offsets.start_end(row);
+        seen.clear();
+        (start..end).any(|i| !seen.insert(unsafe { keys.value_unchecked(i) }))
+    });
+    if !has_duplicates {
+        return None;
     }
 
-    let row_validity = arr.validity();
-    let n_live_entries = offsets.range() as usize - hidden;
+    let n_live_entries = offsets.range() as usize - hidden_entry_count(arr);
     let mut key_idx = Vec::with_capacity(n_live_entries);
     let mut value_idx = Vec::with_capacity(n_live_entries);
     let mut new_offsets = Vec::with_capacity(offsets.len());
@@ -788,51 +765,32 @@ fn canonical_map_indices(
 
     let mut slots = PlHashMap::new();
     for row in 0..arr.len() {
-        // Null rows own no entries, so their whole window is dropped.
+        // A null row owns nothing an observer can reach, so its whole window is dropped.
         if row_validity.is_some_and(|v| !v.get_bit(row)) {
             new_offsets.push(key_idx.len() as i64);
             continue;
         }
         let (start, end) = offsets.start_end(row);
 
-        if let Some(nulls) = nulls {
-            polars_ensure!(
-                nulls.entry_nulls_in(start, end - start) == 0,
-                InvalidOperation: "Map entries cannot be null"
-            );
-            polars_ensure!(
-                nulls.key_nulls_in(start, end - start) == 0,
-                InvalidOperation: "Map keys cannot be null"
-            );
-        }
-
         slots.clear();
         for i in start..end {
-            match keys {
-                Some(keys) => {
-                    let key = unsafe { keys.value_unchecked(i) };
-                    if let Some(&slot) = slots.get(key) {
-                        value_idx[slot] = i as IdxSize;
-                    } else {
-                        slots.insert(key, key_idx.len());
-                        key_idx.push(i as IdxSize);
-                        value_idx.push(i as IdxSize);
-                    }
-                },
-                None => {
-                    key_idx.push(i as IdxSize);
-                    value_idx.push(i as IdxSize);
-                },
+            let key = unsafe { keys.value_unchecked(i) };
+            if let Some(&slot) = slots.get(key) {
+                value_idx[slot] = i as IdxSize;
+            } else {
+                slots.insert(key, key_idx.len());
+                key_idx.push(i as IdxSize);
+                value_idx.push(i as IdxSize);
             }
         }
         new_offsets.push(key_idx.len() as i64);
     }
 
-    Ok(Some(CanonicalMapIndices {
+    Some(CanonicalMapIndices {
         first_keys: IdxArr::from_vec(key_idx),
         last_values: IdxArr::from_vec(value_idx),
         offsets: unsafe { OffsetsBuffer::new_unchecked(new_offsets.into()) },
-    }))
+    })
 }
 
 fn gather_entries(
@@ -869,11 +827,10 @@ fn gather_entries(
     .boxed()
 }
 
-/// Returns `None` if neither null removal nor the requested deduplication changes `arr`.
+/// Returns `None` if no live row has duplicate keys.
 fn canonicalize_list_chunk(
     arr: &LargeListArray,
     key_dtype: &DataType,
-    mode: CanonicalizeMode,
 ) -> PolarsResult<Option<ArrayRef>> {
     let entries = arr.values();
     let entries = entries.as_any().downcast_ref::<StructArray>().unwrap();
@@ -881,49 +838,20 @@ fn canonicalize_list_chunk(
         unreachable!("map entries must have two arrays")
     };
 
-    // Check entries and keys over the whole child, which flat storage access exposes.
-    // Values may be null.
-    let nulls = EntryNulls {
-        entries: entries.validity(),
-        keys: key_arr.validity(),
+    // Row encoding matches logical key equality without reading null payloads.
+    let keys = unsafe {
+        Series::from_chunks_and_dtype_unchecked(PlSmallStr::EMPTY, vec![key_arr.clone()], key_dtype)
     };
-    let dirty = has_unset_bits(nulls.entries) || has_unset_bits(nulls.keys);
-    let hidden = hidden_entry_count(arr);
-    if !dirty && mode == CanonicalizeMode::NullsOnly {
-        if hidden == 0 {
-            return Ok(None);
-        }
-        // Whole null-row windows are the only defect, so filter them out instead of
-        // building take indices and row encodings.
-        let compacted = compact_null_rows_chunk(arr).expect("hidden entries need compaction");
-        return Ok(Some(compacted.boxed()));
-    }
+    let encoded = encode_rows_unordered(&[keys.into_column()])?;
+    let encoded = encoded.downcast_iter().next().unwrap();
 
-    let encoded = match mode {
-        CanonicalizeMode::Full => {
-            // Row encoding matches logical key equality without reading null payloads.
-            let keys = unsafe {
-                Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::EMPTY,
-                    vec![key_arr.clone()],
-                    key_dtype,
-                )
-            };
-            Some(encode_rows_unordered(&[keys.into_column()])?)
-        },
-        CanonicalizeMode::NullsOnly => None,
-    };
-    let encoded = encoded
-        .as_ref()
-        .map(|ca| ca.downcast_iter().next().unwrap());
-
-    let Some(indices) = canonical_map_indices(arr, encoded, dirty.then_some(nulls), hidden)? else {
+    let Some(indices) = canonical_map_indices(arr, encoded) else {
         return Ok(None);
     };
     Ok(Some(gather_entries(arr, entries, indices)))
 }
 
-/// Check storage invariants directly, before higher-level operations can repair them.
+/// Check storage invariants directly, before higher-level operations can mask them.
 #[cfg(test)]
 mod test {
     use arrow::array::PrimitiveArray;
@@ -981,12 +909,10 @@ mod test {
         storage.list().unwrap().get_inner().len()
     }
 
-    /// Check nulls over the whole child, including outside the offsets.
-    fn assert_no_null_entries_or_keys(storage: &Series) {
-        let entries = storage.list().unwrap().get_inner();
-        assert_eq!(entries.null_count(), 0, "null entries");
-        let (keys, _) = unpack_map_entries(&entries);
-        assert_eq!(keys.null_count(), 0, "null keys");
+    /// Check nulls over the entries that live rows own.
+    fn assert_no_live_null_entries_or_keys(map: &MapChunked) {
+        assert_eq!(map.entries().null_count(), 0, "null entries");
+        assert_eq!(map.keys().null_count(), 0, "null keys");
     }
 
     /// Rows `{a: 1, b: 2}`, `{c: 3}`, `{d: 4, e: 5}`.
@@ -1007,7 +933,7 @@ mod test {
 
     #[cfg(feature = "dtype-categorical")]
     #[test]
-    fn hidden_null_enum_key_is_compacted_not_fabricated() {
+    fn hidden_null_enum_key_is_masked_not_fabricated() {
         use polars_dtype::categorical::FrozenCategories;
 
         // With no categories, exposing a null payload would make formatting access
@@ -1020,11 +946,9 @@ mod test {
 
         let dtype = map_dtype(enum_dtype, DataType::Int64);
         let map = MapChunked::try_from_storage(dtype, storage).unwrap();
-        assert_eq!(list_offsets(map.storage()), [0, 0]);
-        assert_eq!(child_len(map.storage()), 0);
         assert_eq!(map.keys().len(), 0);
-        assert_no_null_entries_or_keys(map.storage());
-        // Formatting resolves all remaining codes.
+        assert_no_live_null_entries_or_keys(&map);
+        // Formatting resolves all reachable codes.
         let _ = format!("{}", map.keys());
         let _ = format!("{}", map.into_series());
     }
@@ -1047,15 +971,15 @@ mod test {
         assert_eq!(sliced.values().len(), 3);
         // Valid entries outside the offsets need no repair.
         assert!(
-            canonicalize_map_storage(sliced.storage(), CanonicalizeMode::Full)
+            canonicalize_map_storage(sliced.storage())
                 .unwrap()
                 .is_none()
         );
     }
 
     #[test]
-    fn sliced_storage_with_null_entries_outside_the_window_is_compacted() {
-        // Slicing away row 0 must allow its null key to be dropped.
+    fn sliced_storage_with_null_entries_outside_the_window_is_accepted() {
+        // Slicing away row 0 must put its null key beyond the reach of validation.
         let keys = str_keys(&[None, Some("b"), Some("c")]);
         let values = i64_values(&[Some(1), Some(2), Some(3)]);
         let storage = storage(&pack_map_entries(&keys, &values), &[0, 1, 2, 3], None);
@@ -1064,9 +988,7 @@ mod test {
 
         let map = MapChunked::try_from_storage(dtype, storage.slice(1, 2)).unwrap();
         assert_eq!(map.len(), 2);
-        assert_eq!(list_offsets(map.storage()), [0, 1, 2]);
-        assert_eq!(child_len(map.storage()), 2);
-        assert_no_null_entries_or_keys(map.storage());
+        assert_no_live_null_entries_or_keys(&map);
         assert_eq!(
             str_values(&map.keys()),
             [Some("b".to_owned()), Some("c".to_owned())]
@@ -1099,7 +1021,7 @@ mod test {
     }
 
     #[test]
-    fn valid_entries_under_a_null_row_are_dropped() {
+    fn valid_entries_under_a_null_row_are_kept_but_hidden() {
         let keys = str_keys(&[Some("a"), Some("b")]);
         let values = i64_values(&[Some(1), Some(2)]);
         let storage = storage(
@@ -1110,30 +1032,35 @@ mod test {
         let dtype = map_dtype(DataType::String, DataType::Int64);
         let map = MapChunked::try_from_storage(dtype, storage).unwrap();
 
-        assert_eq!(list_offsets(map.storage()), [0, 0, 1]);
-        assert_eq!(child_len(map.storage()), 1);
+        // The storage keeps `a` where it was; only the accessors hide it.
+        assert_eq!(list_offsets(map.storage()), [0, 1, 2]);
         assert_eq!(map.storage().null_count(), 1);
         assert!(matches!(map.get_any_value(0).unwrap(), AnyValue::Null));
+        assert_eq!(map.entries().len(), 1);
         assert_eq!(str_values(&map.keys()), [Some("b".to_owned())]);
+        let live = map.live_storage().into_owned().into_series();
+        assert_eq!(list_offsets(&live), [0, 0, 1]);
     }
 
     #[test]
-    fn with_validity_empties_nulled_rows() {
+    fn with_validity_hides_the_entries_of_nulled_rows() {
         let map = three_row_map().into_series();
         let nulled = map.with_validity(Some(Bitmap::from([false, true, false])));
         let nulled = nulled.map().unwrap();
 
+        // Nulling rows in place leaves the offsets alone, as it does for a list.
         assert_eq!(nulled.storage().null_count(), 2);
-        assert_eq!(list_offsets(nulled.storage()), [0, 0, 1, 1]);
-        assert_no_null_entries_or_keys(nulled.storage());
+        assert_eq!(list_offsets(nulled.storage()), [0, 2, 3, 5]);
+        assert_no_live_null_entries_or_keys(nulled);
         assert_eq!(str_values(&nulled.keys()), [Some("c".to_owned())]);
 
         // A physical round trip must preserve storage validity.
         let physical = nulled.clone().into_series().to_physical_repr().into_owned();
         let back = unsafe { physical.from_physical_unchecked(nulled.dtype()) }.unwrap();
         let back = back.map().unwrap();
-        assert_no_null_entries_or_keys(back.storage());
+        assert_no_live_null_entries_or_keys(back);
         assert_eq!(back.storage().null_count(), 2);
+        assert_eq!(str_values(&back.keys()), [Some("c".to_owned())]);
     }
 
     #[test]
@@ -1142,8 +1069,8 @@ mod test {
         let nulled = map.with_validity(Some(Bitmap::from([false, true, false])));
         let nulled = nulled.map().unwrap();
 
-        // Nulling rows 0 and 2 dropped their entries; only row 1's `c` is left.
-        assert_eq!(child_len(nulled.storage()), 1);
+        // Nulling rows 0 and 2 hid their entries; only row 1's `c` is reachable.
+        assert_eq!(child_len(nulled.storage()), 5);
         assert_eq!(str_values(&nulled.keys()), [Some("c".to_owned())]);
 
         let out = nulled.with_values(&i64_values(&[Some(30)])).unwrap();
@@ -1200,8 +1127,8 @@ mod test {
     }
 
     #[test]
-    fn from_physical_unchecked_repairs_entries_nulled_under_a_null_row() {
-        // Simulate dtype-blind propagation nulling the entry and key of a null row.
+    fn from_physical_unchecked_accepts_entries_nulled_under_a_null_row() {
+        // Null propagation nulls the entry and key of a null row; both stay hidden.
         let keys = str_keys(&[None, Some("b")]);
         let values = i64_values(&[None, Some(2)]);
         let entries =
@@ -1211,9 +1138,7 @@ mod test {
         let nulled = storage(&entries, &[0, 1, 2], Some(&[false, true]));
         let map = unsafe { nulled.from_physical_unchecked(&dtype) }.unwrap();
         let map = map.map().unwrap();
-        assert_eq!(list_offsets(map.storage()), [0, 0, 1]);
-        assert_eq!(child_len(map.storage()), 1);
-        assert_no_null_entries_or_keys(map.storage());
+        assert_no_live_null_entries_or_keys(map);
         assert_eq!(str_values(&map.keys()), [Some("b".to_owned())]);
 
         // The same null in a live row must be rejected.
@@ -1353,20 +1278,28 @@ mod test {
     }
 
     #[test]
-    fn deposit_pads_with_empty_null_rows() {
+    fn deposit_pads_with_null_rows() {
         let map = three_row_map().into_series();
         let deposited = map.deposit(&Bitmap::from([true, false, true, false, true]));
         let deposited = deposited.map().unwrap();
 
         assert_eq!(deposited.len(), 5);
         assert_eq!(deposited.storage().null_count(), 2);
-        assert_eq!(list_offsets(deposited.storage()), [0, 2, 2, 3, 3, 5]);
-        assert_eq!(child_len(deposited.storage()), 5);
+        for row in [1, 3] {
+            assert!(matches!(
+                deposited.get_any_value(row).unwrap(),
+                AnyValue::Null
+            ));
+        }
+        assert_eq!(
+            str_values(&deposited.keys()),
+            ["a", "b", "c", "d", "e"].map(|k| Some(k.to_owned()))
+        );
     }
 
     #[cfg(feature = "algorithm_group_by")]
     #[test]
-    fn agg_first_on_a_scalar_empties_empty_group_rows() {
+    fn agg_first_on_a_scalar_nulls_empty_group_rows() {
         let scalar = Column::new_scalar(
             PlSmallStr::from_static("m"),
             Scalar::new(
@@ -1385,8 +1318,8 @@ mod test {
         let agg = unsafe { scalar.agg_first(&groups) };
         let agg = agg.as_materialized_series().map().unwrap();
         assert_eq!(agg.storage().null_count(), 1);
-        assert_eq!(list_offsets(agg.storage()), [0, 2, 2, 4]);
-        assert_eq!(child_len(agg.storage()), 4);
+        assert!(matches!(agg.get_any_value(1).unwrap(), AnyValue::Null));
+        assert_eq!(agg.keys().len(), 4);
     }
 
     #[cfg(all(feature = "algorithm_group_by", feature = "dtype-struct"))]

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::offset::{Offsets, OffsetsBuffer};
 use polars_compute::filter::filter_with_bitmap;
@@ -23,10 +21,11 @@ use crate::prelude::*;
 /// 2. Child arrays are valid over their entire extent, including outside the list offsets:
 ///    categorical codes in range, no `Object`.
 /// 3. Entries and keys have no nulls anywhere in the child arrays.
+/// 4. Null rows span no entries: `offsets[i] == offsets[i + 1]` for every null row.
 ///
-/// Map values are nullable. [`Self::entries`], [`Self::keys`] and [`Self::values`] skip
-/// entries retained by null rows. Repairs drop null entries or keys; removing their
-/// validity masks would expose arbitrary payloads.
+/// Map values are nullable. Null rows own no entries, so flat accessors can read the whole
+/// offset window. Repairs drop offending entries rather than clearing their validity, which
+/// would expose arbitrary payloads.
 ///
 /// # Canonical semantics
 ///
@@ -51,6 +50,10 @@ impl MapChunked {
         debug_assert!(
             dtype.ensure_valid_map_dtype().is_ok(),
             "invalid Map dtype: {dtype}"
+        );
+        debug_assert!(
+            null_rows_are_empty(&storage),
+            "Map null rows must span no entries"
         );
         Self { dtype, storage }
     }
@@ -98,11 +101,12 @@ impl MapChunked {
         self.dtype.as_map().unwrap().1
     }
 
-    /// Raw storage, including entries hidden by null rows or slicing.
+    /// The raw `List(Struct {key, value})` storage.
     ///
-    /// Entries and keys remain non-null by contract. Flat accessors skip hidden entries;
-    /// [`Self::live_storage`] gives null rows empty windows.
-    pub(crate) fn storage(&self) -> &Series {
+    /// Entries and keys are non-null and null rows span no entries, so the offset windows
+    /// hold exactly the live entries. Slicing can still leave entries outside the windows,
+    /// as it does for any [`ListChunked`].
+    pub fn storage(&self) -> &Series {
         &self.storage
     }
 
@@ -121,6 +125,10 @@ impl MapChunked {
             storage.dtype(),
             self.storage.dtype(),
             "operation on Map storage changed its dtype",
+        );
+        debug_assert!(
+            null_rows_are_empty(&storage),
+            "Map null rows must span no entries"
         );
         Self {
             dtype: self.dtype.clone(),
@@ -163,18 +171,20 @@ impl MapChunked {
         map_av(unsafe { self.storage.get_unchecked(i) })
     }
 
-    /// Keys of all entries in live rows, flattened in row order.
+    /// Keys of all entries, flattened in row order.
     pub fn keys(&self) -> Series {
-        self.live_entry_field(&MAP_KEY_NAME)
+        self.entry_field(&MAP_KEY_NAME)
     }
 
-    /// Values of all entries in live rows, flattened in row order.
+    /// Values of all entries, flattened in row order.
     pub fn values(&self) -> Series {
-        self.live_entry_field(&MAP_VALUE_NAME)
+        self.entry_field(&MAP_VALUE_NAME)
     }
 
-    /// Flatten one entry field over live rows without filtering the other field.
-    fn live_entry_field(&self, name: &PlSmallStr) -> Series {
+    /// Flatten one entry field without touching the other.
+    ///
+    /// Slices each chunk's offset window; nested fields may also propagate nulls.
+    fn entry_field(&self, name: &PlSmallStr) -> Series {
         let storage = self.storage.list().unwrap();
         let DataType::Struct(fields) = storage.inner_dtype() else {
             unreachable!("map entries are a struct")
@@ -193,24 +203,20 @@ impl MapChunked {
                     .as_any()
                     .downcast_ref::<StructArray>()
                     .expect("map entries are a struct");
-                let field = entries.values()[i].clone();
-                match live_entry_mask(arr) {
-                    Some(mask) => filter_with_bitmap(field.as_ref(), &mask),
-                    None => field,
-                }
+                entries.values()[i].clone()
             })
             .collect();
 
-        // SAFETY: the chunks are one entry field, filtered to the entries of live rows.
+        // SAFETY: the chunks are one entry field, windowed to the list offsets.
         unsafe { Series::from_chunks_and_dtype_unchecked(name.clone(), chunks, fields[i].dtype()) }
     }
 
-    /// Replace live entry values.
+    /// Replace entry values.
     ///
-    /// Requires one value per live entry, in [`Self::values`] order, and a valid Map
-    /// value dtype. This also applies to list-valued entries.
+    /// Requires one value per entry, in [`Self::values`] order, and a valid Map value
+    /// dtype. This also applies to list-valued entries.
     ///
-    /// Preserves row count, validity, live keys and entry order. Drops hidden entries
+    /// Preserves row count, validity, keys and entry order. Drops entries sliced away
     /// and may rebase offsets.
     pub fn with_values(&self, values: &Series) -> PolarsResult<Self> {
         let dtype = DataType::Map(
@@ -219,8 +225,8 @@ impl MapChunked {
         );
         dtype.ensure_valid_map_dtype()?;
 
-        let storage = self.live_storage();
-        let keys = unpack_map_entries(&windowed_entries(&storage)).0;
+        let storage = self.storage.list().unwrap();
+        let keys = unpack_map_entries(&windowed_entries(storage)).0;
         polars_ensure!(
             values.len() == keys.len(),
             ShapeMismatch:
@@ -228,48 +234,42 @@ impl MapChunked {
             keys.len(),
             values.len(),
         );
-        let storage = repack_map_storage(&storage, &keys, values).into_series();
+        let storage = repack_map_storage(storage, &keys, values).into_series();
 
-        // SAFETY: live keys and row assignments are preserved; replacements have a valid
-        // Map value dtype. Only hidden entries are dropped.
+        // SAFETY: keys and row assignments are preserved; replacements have a valid Map
+        // value dtype.
         Ok(unsafe { Self::from_storage_unchecked(dtype, storage) })
     }
 
     /// Propagate nulls within entry children without changing row or entry validity.
     pub(crate) fn propagate_nulls(&self) -> Option<Self> {
         let storage = self.storage.list().unwrap();
-        let (keys, values) = unpack_map_entries(&windowed_entries(storage));
-
-        let new_keys = keys.propagate_nulls();
-        let new_values = values.propagate_nulls();
-        if new_keys.is_none() && new_values.is_none() {
-            return None;
-        }
-        let keys = new_keys.unwrap_or(keys);
-        let values = new_values.unwrap_or(values);
+        // Construct without implicit propagation so its changes are reported, not
+        // discarded when a subsequent propagation call returns `None`.
+        // SAFETY: chunks are slices of this Map's non-null entry structs.
+        let entries = unsafe {
+            StructChunked::from_chunks_and_dtype_unchecked(
+                storage.name().clone(),
+                storage
+                    .downcast_iter()
+                    .map(windowed_entries_array)
+                    .collect(),
+                storage.inner_dtype().clone(),
+            )
+        };
+        let entries = entries.propagate_nulls()?.into_series();
+        let (keys, values) = unpack_map_entries(&entries);
         let storage = repack_map_storage(storage, &keys, &values).into_series();
 
         // SAFETY: only values below nested nulls change; layout and key semantics remain.
         Some(unsafe { self.with_storage_unchecked(storage) })
     }
 
-    /// All entries in live rows, flattened in row order.
+    /// All entries, flattened in row order.
     ///
-    /// Excludes entries retained by null rows or sliced away.
+    /// Excludes entries sliced away.
     pub fn entries(&self) -> Series {
-        windowed_entries(&self.live_storage())
-    }
-
-    /// Storage with empty windows for null rows.
-    ///
-    /// Preserves row count, validity and live entries. Borrows if no compaction is needed.
-    /// Mutating the returned [`Cow`] affects only its owned copy.
-    pub fn live_storage(&self) -> Cow<'_, ListChunked> {
-        let storage = self.storage.list().unwrap();
-        match compact_null_map_rows(storage) {
-            Some(compacted) => Cow::Owned(compacted),
-            None => Cow::Borrowed(storage),
-        }
+        windowed_entries(self.storage.list().unwrap())
     }
 
     pub fn cast_with_options(
@@ -283,14 +283,14 @@ impl MapChunked {
 
         match dtype {
             DataType::Map(key, value) => self.cast_entries(key, value, options),
-            DataType::List(_) => self.live_storage().cast_with_options(dtype, options),
+            DataType::List(_) => self.storage.cast_with_options(dtype, options),
             _ => polars_bail!(InvalidOperation: "cannot cast `{}` to `{dtype}`", self.dtype),
         }
     }
 
-    /// Cast live entry children, preserving row count and outer validity.
+    /// Cast the entry children, preserving row count and outer validity.
     ///
-    /// Drops hidden entries and may rebase offsets. Key casts may merge duplicate keys.
+    /// Drops entries sliced away and may rebase offsets. Key casts may merge duplicate keys.
     fn cast_entries(
         &self,
         to_key: &DataType,
@@ -306,7 +306,7 @@ impl MapChunked {
 
         let dtype = DataType::Map(Box::new(to_key.clone()), Box::new(to_value.clone()));
         dtype.ensure_valid_map_dtype()?;
-        let storage = try_apply_map_entries(&self.live_storage(), |key, value| {
+        let storage = try_apply_map_entries(self.storage.list().unwrap(), |key, value| {
             // `Series::cast_with_options` only short-circuits an identity cast for
             // primitives, so a nested key or value would be rebuilt for nothing.
             let key = if cast_key {
@@ -334,8 +334,7 @@ impl MapChunked {
             // Decimal rescaling can merge distinct keys even when schemas match.
             Ok(Self::try_from_storage(dtype, storage)?.into_series())
         } else {
-            // SAFETY: live keys and row assignments are preserved; cast values remain valid.
-            // Only hidden entries are dropped.
+            // SAFETY: keys and row assignments are preserved; cast values remain valid.
             Ok(unsafe { Self::from_storage_unchecked(dtype, storage) }.into_series())
         }
     }
@@ -425,39 +424,60 @@ fn windowed_entries_array(arr: &LargeListArray) -> ArrayRef {
     }
 }
 
-/// Mask windowed entries by row validity; `None` if all belong to live rows.
-fn live_entry_mask(arr: &LargeListArray) -> Option<Bitmap> {
-    let validity = arr.validity().filter(|v| v.unset_bits() > 0)?;
+/// Count entries under null rows using an allocation-free scan of validity runs.
+fn hidden_entry_count(arr: &LargeListArray) -> usize {
+    let Some(validity) = arr.validity().filter(|v| v.unset_bits() > 0) else {
+        return 0;
+    };
     let offsets = arr.offsets();
-    let null_rows = !validity;
-    if null_rows.true_idx_iter().all(|i| offsets.length_at(i) == 0) {
+
+    let mut validity = validity.iter();
+    let mut hidden = 0;
+    let mut row = 0;
+    while validity.num_remaining() > 0 {
+        row += validity.take_leading_ones();
+        let end = row + validity.take_leading_zeros();
+        hidden += (offsets[end] - offsets[row]) as usize;
+        row = end;
+    }
+
+    hidden
+}
+
+/// Whether every null row of Map storage spans no entries.
+fn null_rows_are_empty(storage: &Series) -> bool {
+    storage
+        .list()
+        .expect("map storage is a list")
+        .downcast_iter()
+        .all(|arr| hidden_entry_count(arr) == 0)
+}
+
+/// Filter out entries under null rows and rebuild offsets; `None` if unchanged.
+fn compact_null_rows_chunk(arr: &LargeListArray) -> Option<LargeListArray> {
+    if hidden_entry_count(arr) == 0 {
         return None;
     }
+    let validity = arr.validity().expect("hidden entries need a null row");
+    let offsets = arr.offsets();
 
     // Fill live runs between null-row windows in bulk.
     let first = *offsets.first() as usize;
     let n_entries = offsets.range() as usize;
     let mut mask = BitmapBuilder::with_capacity(n_entries);
-    for i in null_rows.true_idx_iter() {
+    for i in (!validity).true_idx_iter() {
         let (start, end) = offsets.start_end(i);
         mask.extend_constant(start - first - mask.len(), true);
         mask.extend_constant(end - start, false);
     }
     mask.extend_constant(n_entries - mask.len(), true);
 
-    Some(mask.freeze())
-}
-
-/// Drop entries under null rows; `None` if unchanged.
-fn drop_null_row_entries(arr: &LargeListArray) -> Option<LargeListArray> {
-    let mask = live_entry_mask(arr)?;
     let entries = windowed_entries_array(arr);
-    let entries = filter_with_bitmap(entries.as_ref(), &mask);
+    let entries = filter_with_bitmap(entries.as_ref(), &mask.freeze());
 
-    let validity = arr.validity().expect("a masked chunk has null rows");
     let live_lengths = validity
         .iter()
-        .zip(arr.offsets().lengths())
+        .zip(offsets.lengths())
         .map(|(valid, len)| if valid { len } else { 0 });
     let offsets = Offsets::try_from_lengths(live_lengths)
         .expect("live lengths sum to at most the entry count");
@@ -470,15 +490,18 @@ fn drop_null_row_entries(arr: &LargeListArray) -> Option<LargeListArray> {
     ))
 }
 
-/// Drop entries under null rows; `None` if unchanged.
-///
+/// Empty null rows before wrapping raw storage as a Map; `None` if unchanged.
 /// Rebuilt chunks have trimmed children and zero-based offsets.
 pub(crate) fn compact_null_map_rows(storage: &ListChunked) -> Option<ListChunked> {
+    if storage.null_count() == 0 {
+        return None;
+    }
+
     // Allocate only after the first changed chunk.
     let mut new_chunks: Option<Vec<ArrayRef>> = None;
 
     for (i, chunk) in storage.downcast_iter().enumerate() {
-        match drop_null_row_entries(chunk) {
+        match compact_null_rows_chunk(chunk) {
             Some(dropped) => new_chunks
                 .get_or_insert_with(|| storage.chunks()[..i].to_vec())
                 .push(dropped.boxed()),
@@ -500,7 +523,56 @@ pub(crate) fn compact_null_map_rows(storage: &ListChunked) -> Option<ListChunked
     })
 }
 
-/// Flatten entries within each chunk's offsets, including those retained by null rows.
+/// Build a container child, compacting null Map rows and reporting whether it changed.
+///
+/// Skip implicit Struct propagation so the caller can track and retain its repairs.
+///
+/// # Safety
+/// `chunks` must satisfy [`Series::from_chunks_and_dtype_unchecked`] for `dtype`, except
+/// that Map null rows may still span entries.
+pub(crate) unsafe fn compacted_child_series(
+    name: PlSmallStr,
+    chunks: Vec<ArrayRef>,
+    dtype: &DataType,
+) -> (Series, bool) {
+    match dtype {
+        DataType::Map(_, _) => {
+            let storage = unsafe {
+                Series::from_chunks_and_dtype_unchecked(
+                    name,
+                    chunks,
+                    &dtype.map_storage_dtype().unwrap(),
+                )
+            };
+            let compacted = compact_null_map_rows(storage.list().unwrap());
+            let changed = compacted.is_some();
+            let storage = compacted.map_or(storage, IntoSeries::into_series);
+            // SAFETY: the caller's payloads are valid and null rows now span no entries.
+            let map = unsafe { MapChunked::from_storage_unchecked(dtype.clone(), storage) };
+            (map.into_series(), changed)
+        },
+        #[cfg(feature = "dtype-extension")]
+        DataType::Extension(typ, inner) => {
+            let (storage, changed) = unsafe { compacted_child_series(name, chunks, inner) };
+            (storage.into_extension(typ.clone()), changed)
+        },
+        #[cfg(feature = "dtype-struct")]
+        DataType::Struct(_) => {
+            // SAFETY: same layout requirements as `Series::from_chunks_and_dtype_unchecked`.
+            let ca = unsafe {
+                StructChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype.clone())
+            };
+            (ca.into_series(), false)
+        },
+        _ => {
+            // SAFETY: forwarded from this function's own contract.
+            let s = unsafe { Series::from_chunks_and_dtype_unchecked(name, chunks, dtype) };
+            (s, false)
+        },
+    }
+}
+
+/// Flatten entries within each chunk's offsets.
 /// Unlike [`ListChunked::get_inner`], excludes sliced-away entries.
 fn windowed_entries(storage: &ListChunked) -> Series {
     let chunks = storage
@@ -596,8 +668,8 @@ fn map_av(av: AnyValue<'_>) -> AnyValue<'_> {
     }
 }
 
-/// Both modes reject live null entries/keys and compact hidden ones. Callers must validate
-/// the dtype and child payloads separately.
+/// Both modes empty null rows and reject null entries or keys in live rows. Callers must
+/// validate the dtype and child payloads separately.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CanonicalizeMode {
     /// Also deduplicate keys within each row.
@@ -606,11 +678,13 @@ pub(crate) enum CanonicalizeMode {
     NullsOnly,
 }
 
-/// Remove hidden null entries/keys and reject live ones. [`CanonicalizeMode::Full`] also
-/// deduplicates keys, keeping each key's first position and last value.
+/// Canonicalize raw Map storage. [`CanonicalizeMode::Full`] also deduplicates keys,
+/// keeping each key's first position and last value.
 ///
-/// Hidden means under a null row or outside the list offsets. Valid entries under null rows
-/// are retained. Null payloads are never exposed; dtype and payload validity are not checked.
+/// Empty null rows. Reject null entries/keys in live rows; drop them elsewhere.
+/// Callers must validate the dtype and child payloads.
+///
+/// Filter for null-row compaction alone; gather for entry/key nulls or deduplication.
 ///
 /// Returns `None` if unchanged; use [`Series::canonicalize_maps`] to also reach maps
 /// nested inside the keys or values.
@@ -670,28 +744,27 @@ impl EntryNulls<'_> {
     fn key_nulls_in(&self, start: usize, len: usize) -> usize {
         self.keys.map_or(0, |v| v.null_count_range(start, len))
     }
-
-    fn is_null(&self, i: usize) -> bool {
-        self.entries.is_some_and(|v| !v.get_bit(i)) || self.keys.is_some_and(|v| !v.get_bit(i))
-    }
 }
 
 fn has_unset_bits(validity: Option<&Bitmap>) -> bool {
     validity.is_some_and(|v| v.unset_bits() > 0)
 }
 
-/// Build take indices for deduplication or null removal; return `None` if unchanged.
+/// Build take indices for deduplication, null removal or emptying null rows; return `None`
+/// if unchanged.
 ///
-/// `keys` contains row encodings in [`CanonicalizeMode::Full`]; `nulls` tracks child nulls.
-/// Gathering visits only row windows, dropping entries outside them.
+/// `keys` contains row encodings in [`CanonicalizeMode::Full`]; `nulls` tracks child nulls;
+/// `hidden` is the [`hidden_entry_count`]. Gathering visits only the windows of live rows,
+/// dropping every other entry.
 fn canonical_map_indices(
     arr: &LargeListArray,
     keys: Option<&BinaryArray<i64>>,
     nulls: Option<EntryNulls<'_>>,
+    hidden: usize,
 ) -> PolarsResult<Option<CanonicalMapIndices>> {
     let offsets = arr.offsets();
 
-    if nulls.is_none() {
+    if nulls.is_none() && hidden == 0 {
         let Some(keys) = keys else {
             return Ok(None);
         };
@@ -707,33 +780,34 @@ fn canonical_map_indices(
     }
 
     let row_validity = arr.validity();
-    let n_entries = offsets.range() as usize;
-    let mut key_idx = Vec::with_capacity(n_entries);
-    let mut value_idx = Vec::with_capacity(n_entries);
+    let n_live_entries = offsets.range() as usize - hidden;
+    let mut key_idx = Vec::with_capacity(n_live_entries);
+    let mut value_idx = Vec::with_capacity(n_live_entries);
     let mut new_offsets = Vec::with_capacity(offsets.len());
     new_offsets.push(0i64);
 
     let mut slots = PlHashMap::new();
     for row in 0..arr.len() {
+        // Null rows own no entries, so their whole window is dropped.
+        if row_validity.is_some_and(|v| !v.get_bit(row)) {
+            new_offsets.push(key_idx.len() as i64);
+            continue;
+        }
         let (start, end) = offsets.start_end(row);
 
-        // Reject null entries/keys in live rows; skip them in null rows.
-        let entry_nulls = nulls.map_or(0, |n| n.entry_nulls_in(start, end - start));
-        let key_nulls = nulls.map_or(0, |n| n.key_nulls_in(start, end - start));
-        let dirty_row = nulls.filter(|_| entry_nulls > 0 || key_nulls > 0);
-        if dirty_row.is_some() && row_validity.is_none_or(|v| v.get_bit(row)) {
+        if let Some(nulls) = nulls {
             polars_ensure!(
-                entry_nulls == 0,
+                nulls.entry_nulls_in(start, end - start) == 0,
                 InvalidOperation: "Map entries cannot be null"
             );
-            polars_bail!(InvalidOperation: "Map keys cannot be null");
+            polars_ensure!(
+                nulls.key_nulls_in(start, end - start) == 0,
+                InvalidOperation: "Map keys cannot be null"
+            );
         }
 
         slots.clear();
         for i in start..end {
-            if dirty_row.is_some_and(|nulls| nulls.is_null(i)) {
-                continue;
-            }
             match keys {
                 Some(keys) => {
                     let key = unsafe { keys.value_unchecked(i) };
@@ -814,8 +888,15 @@ fn canonicalize_list_chunk(
         keys: key_arr.validity(),
     };
     let dirty = has_unset_bits(nulls.entries) || has_unset_bits(nulls.keys);
+    let hidden = hidden_entry_count(arr);
     if !dirty && mode == CanonicalizeMode::NullsOnly {
-        return Ok(None);
+        if hidden == 0 {
+            return Ok(None);
+        }
+        // Whole null-row windows are the only defect, so filter them out instead of
+        // building take indices and row encodings.
+        let compacted = compact_null_rows_chunk(arr).expect("hidden entries need compaction");
+        return Ok(Some(compacted.boxed()));
     }
 
     let encoded = match mode {
@@ -836,7 +917,7 @@ fn canonicalize_list_chunk(
         .as_ref()
         .map(|ca| ca.downcast_iter().next().unwrap());
 
-    let Some(indices) = canonical_map_indices(arr, encoded, dirty.then_some(nulls))? else {
+    let Some(indices) = canonical_map_indices(arr, encoded, dirty.then_some(nulls), hidden)? else {
         return Ok(None);
     };
     Ok(Some(gather_entries(arr, entries, indices)))
@@ -850,6 +931,8 @@ mod test {
     use arrow::offset::OffsetsBuffer;
 
     use super::*;
+    use crate::frame::column::Column;
+    use crate::scalar::Scalar;
 
     fn map_dtype(key: DataType, value: DataType) -> DataType {
         DataType::Map(Box::new(key), Box::new(value))
@@ -863,7 +946,7 @@ mod test {
         Series::new(MAP_VALUE_NAME.clone(), values)
     }
 
-    /// Build storage with explicit offsets and validity to test hidden entries.
+    /// Build raw storage with explicit offsets and validity, bypassing every repair.
     fn storage(entries: &Series, offsets: &[i64], row_validity: Option<&[bool]>) -> Series {
         let entries = entries.rechunk();
         let values = entries.chunks()[0].clone();
@@ -893,7 +976,7 @@ mod test {
             .to_vec()
     }
 
-    /// Whole-child length, including entries outside the offsets.
+    /// Whole-child length, including any entries left outside the offsets by slicing.
     fn child_len(storage: &Series) -> usize {
         storage.list().unwrap().get_inner().len()
     }
@@ -1016,7 +1099,7 @@ mod test {
     }
 
     #[test]
-    fn valid_entries_under_a_null_row_are_retained() {
+    fn valid_entries_under_a_null_row_are_dropped() {
         let keys = str_keys(&[Some("a"), Some("b")]);
         let values = i64_values(&[Some(1), Some(2)]);
         let storage = storage(
@@ -1027,24 +1110,21 @@ mod test {
         let dtype = map_dtype(DataType::String, DataType::Int64);
         let map = MapChunked::try_from_storage(dtype, storage).unwrap();
 
-        assert_eq!(list_offsets(map.storage()), [0, 1, 2]);
+        assert_eq!(list_offsets(map.storage()), [0, 0, 1]);
+        assert_eq!(child_len(map.storage()), 1);
         assert_eq!(map.storage().null_count(), 1);
         assert!(matches!(map.get_any_value(0).unwrap(), AnyValue::Null));
-        // Retained entries stay hidden from flat access.
         assert_eq!(str_values(&map.keys()), [Some("b".to_owned())]);
-        let live = map.live_storage().into_owned().into_series();
-        assert_eq!(list_offsets(&live), [0, 0, 1]);
-        assert_eq!(child_len(&live), 1);
     }
 
     #[test]
-    fn with_validity_keeps_retained_entries_valid() {
+    fn with_validity_empties_nulled_rows() {
         let map = three_row_map().into_series();
         let nulled = map.with_validity(Some(Bitmap::from([false, true, false])));
         let nulled = nulled.map().unwrap();
 
         assert_eq!(nulled.storage().null_count(), 2);
-        assert_eq!(list_offsets(nulled.storage()), [0, 2, 3, 5]);
+        assert_eq!(list_offsets(nulled.storage()), [0, 0, 1, 1]);
         assert_no_null_entries_or_keys(nulled.storage());
         assert_eq!(str_values(&nulled.keys()), [Some("c".to_owned())]);
 
@@ -1062,8 +1142,8 @@ mod test {
         let nulled = map.with_validity(Some(Bitmap::from([false, true, false])));
         let nulled = nulled.map().unwrap();
 
-        // Rows 0 and 2 keep their entries in storage; only row 1's `c` is live.
-        assert_eq!(child_len(nulled.storage()), 5);
+        // Nulling rows 0 and 2 dropped their entries; only row 1's `c` is left.
+        assert_eq!(child_len(nulled.storage()), 1);
         assert_eq!(str_values(&nulled.keys()), [Some("c".to_owned())]);
 
         let out = nulled.with_values(&i64_values(&[Some(30)])).unwrap();
@@ -1120,8 +1200,8 @@ mod test {
     }
 
     #[test]
-    fn from_physical_unchecked_compacts_nulled_hidden_entries() {
-        // Simulate dtype-blind propagation nulling a hidden entry and its key.
+    fn from_physical_unchecked_repairs_entries_nulled_under_a_null_row() {
+        // Simulate dtype-blind propagation nulling the entry and key of a null row.
         let keys = str_keys(&[None, Some("b")]);
         let values = i64_values(&[None, Some(2)]);
         let entries =
@@ -1132,6 +1212,7 @@ mod test {
         let map = unsafe { nulled.from_physical_unchecked(&dtype) }.unwrap();
         let map = map.map().unwrap();
         assert_eq!(list_offsets(map.storage()), [0, 0, 1]);
+        assert_eq!(child_len(map.storage()), 1);
         assert_no_null_entries_or_keys(map.storage());
         assert_eq!(str_values(&map.keys()), [Some("b".to_owned())]);
 
@@ -1253,6 +1334,81 @@ mod test {
                 );
             }
         }
+    }
+
+    #[test]
+    fn compact_null_map_rows_is_noop_on_canonical_storage() {
+        let map = three_row_map();
+        assert!(compact_null_map_rows(map.storage().list().unwrap()).is_none());
+
+        let dtype = map_dtype(DataType::String, DataType::Int64);
+        let nulls = Series::full_null(PlSmallStr::from_static("m"), 3, &dtype);
+        assert!(compact_null_map_rows(nulls.map().unwrap().storage().list().unwrap()).is_none());
+
+        let sliced = map.into_series().slice(1, 2);
+        assert!(
+            compact_null_map_rows(sliced.map().unwrap().storage().list().unwrap()).is_none(),
+            "entries outside the offsets are not hidden by null rows"
+        );
+    }
+
+    #[test]
+    fn deposit_pads_with_empty_null_rows() {
+        let map = three_row_map().into_series();
+        let deposited = map.deposit(&Bitmap::from([true, false, true, false, true]));
+        let deposited = deposited.map().unwrap();
+
+        assert_eq!(deposited.len(), 5);
+        assert_eq!(deposited.storage().null_count(), 2);
+        assert_eq!(list_offsets(deposited.storage()), [0, 2, 2, 3, 3, 5]);
+        assert_eq!(child_len(deposited.storage()), 5);
+    }
+
+    #[cfg(feature = "algorithm_group_by")]
+    #[test]
+    fn agg_first_on_a_scalar_empties_empty_group_rows() {
+        let scalar = Column::new_scalar(
+            PlSmallStr::from_static("m"),
+            Scalar::new(
+                three_row_map().dtype().clone(),
+                three_row_map()
+                    .into_series()
+                    .slice(0, 1)
+                    .get(0)
+                    .unwrap()
+                    .into_static(),
+            ),
+            2,
+        );
+        let groups = GroupsType::new_slice(vec![[0, 1], [1, 0], [1, 1]], false, false);
+
+        let agg = unsafe { scalar.agg_first(&groups) };
+        let agg = agg.as_materialized_series().map().unwrap();
+        assert_eq!(agg.storage().null_count(), 1);
+        assert_eq!(list_offsets(agg.storage()), [0, 2, 2, 4]);
+        assert_eq!(child_len(agg.storage()), 4);
+    }
+
+    #[cfg(all(feature = "algorithm_group_by", feature = "dtype-struct"))]
+    #[test]
+    fn agg_first_on_a_struct_scalar_propagates_the_empty_group_nulls() {
+        let inner = Series::new(PlSmallStr::from_static("f"), [1i64]);
+        let value =
+            StructChunked::from_series(PlSmallStr::from_static("s"), 1, [&inner].into_iter())
+                .unwrap()
+                .into_series();
+        let scalar = Column::new_scalar(
+            PlSmallStr::from_static("s"),
+            Scalar::new(value.dtype().clone(), value.get(0).unwrap().into_static()),
+            2,
+        );
+        let groups = GroupsType::new_slice(vec![[0, 1], [1, 0]], false, false);
+
+        let agg = unsafe { scalar.agg_first(&groups) };
+        let agg = agg.as_materialized_series();
+        assert_eq!(agg.null_count(), 1);
+        // The outer null must reach the field, as it would for a non-scalar column.
+        assert_eq!(agg.struct_().unwrap().fields_as_series()[0].null_count(), 1);
     }
 
     #[test]

--- a/crates/polars-core/src/chunked_array/logical/map.rs
+++ b/crates/polars-core/src/chunked_array/logical/map.rs
@@ -1168,7 +1168,7 @@ mod test {
         let revived = map.into_series().with_validity(None);
         let revived = revived.map().unwrap();
 
-        assert_eq!(revived.null_count(), 0);
+        assert_eq!(revived.storage().null_count(), 0);
         assert_no_live_null_entries_or_keys(revived);
         assert_eq!(list_offsets(revived.storage()), [0, 0, 1]);
         assert_eq!(str_values(&revived.keys()), [Some("b".to_owned())]);
@@ -1196,7 +1196,7 @@ mod test {
             .with_validity(Some(Bitmap::from([false, false])));
         let nulled = nulled.map().unwrap();
 
-        assert_eq!(nulled.null_count(), 2);
+        assert_eq!(nulled.storage().null_count(), 2);
         assert_eq!(list_offsets(nulled.storage()), offsets);
         assert_eq!(child_len(nulled.storage()), 2);
     }

--- a/crates/polars-core/src/chunked_array/ops/nesting_utils.rs
+++ b/crates/polars-core/src/chunked_array/ops/nesting_utils.rs
@@ -4,7 +4,7 @@ use polars_utils::IdxSize;
 
 use super::ListChunked;
 use crate::chunked_array::flags::StatisticsFlags;
-use crate::prelude::{ChunkedArray, FalseT, PolarsDataType};
+use crate::prelude::{ArrayRef, ChunkedArray, DataType, FalseT, PlSmallStr, PolarsDataType};
 use crate::series::Series;
 use crate::series::implementations::null::NullChunked;
 use crate::utils::align_chunks_binary_ca_series;
@@ -375,51 +375,99 @@ impl ChunkNestingUtils for super::StructChunked {
     }
 }
 
-/// Propagate through [`Series`] to respect logical dtypes. Arrow recursion treats Map
-/// storage as a list and would null entries retained by null Map rows.
+/// Build a container child, compacting null Map rows left by shallow propagation.
+///
+/// # Safety
+/// `chunks` must satisfy [`Series::from_chunks_and_dtype_unchecked`] for `dtype`, except
+/// that Map null rows may still span entries.
+unsafe fn container_child(
+    name: PlSmallStr,
+    chunks: Vec<ArrayRef>,
+    dtype: &DataType,
+) -> (Series, bool) {
+    #[cfg(feature = "dtype-map")]
+    {
+        // SAFETY: forwarded from this function's own contract.
+        unsafe { crate::chunked_array::logical::compacted_child_series(name, chunks, dtype) }
+    }
+    #[cfg(not(feature = "dtype-map"))]
+    {
+        // SAFETY: forwarded from this function's own contract.
+        let s = unsafe { Series::from_chunks_and_dtype_unchecked(name, chunks, dtype) };
+        (s, false)
+    }
+}
+
+/// Propagate through logical dtypes, emptying null Map rows instead of nulling entries.
 trait PropagateValuesNulls: Sized {
     fn values_propagate_nulls(&self) -> Option<Self>;
 }
 
 impl PropagateValuesNulls for ListChunked {
     fn values_propagate_nulls(&self) -> Option<Self> {
-        let values = self.get_inner().propagate_nulls()?;
-        Some(self.with_inner_values(&values))
+        let chunks = self.downcast_iter().map(|c| c.values().clone()).collect();
+        // SAFETY: the chunks are this list's own child.
+        let (values, compacted) =
+            unsafe { container_child(self.name().clone(), chunks, self.inner_dtype()) };
+
+        let propagated = values.propagate_nulls();
+        if !compacted && propagated.is_none() {
+            return None;
+        }
+        Some(self.with_inner_values(propagated.as_ref().unwrap_or(&values)))
     }
 }
 
 #[cfg(feature = "dtype-array")]
 impl PropagateValuesNulls for super::ArrayChunked {
     fn values_propagate_nulls(&self) -> Option<Self> {
-        let values = self.get_inner().propagate_nulls()?;
-        Some(self.with_inner_values(&values))
+        let chunks = self.downcast_iter().map(|c| c.values().clone()).collect();
+        // SAFETY: the chunks are this array's own child.
+        let (values, compacted) =
+            unsafe { container_child(self.name().clone(), chunks, self.inner_dtype()) };
+
+        let propagated = values.propagate_nulls();
+        if !compacted && propagated.is_none() {
+            return None;
+        }
+        Some(self.with_inner_values(propagated.as_ref().unwrap_or(&values)))
     }
 }
 
 #[cfg(feature = "dtype-struct")]
 impl PropagateValuesNulls for super::StructChunked {
     fn values_propagate_nulls(&self) -> Option<Self> {
-        let fields = self.fields_as_series();
-        let mut new_fields = Vec::with_capacity(fields.len());
+        let struct_fields = self.struct_fields().to_vec();
+        let mut new_fields = Vec::with_capacity(struct_fields.len());
         let mut changed = false;
-        for field in &fields {
-            let new_field = field.propagate_nulls();
-            changed |= new_field.is_some();
-            new_fields.push(new_field);
+        for (i, field) in struct_fields.iter().enumerate() {
+            let chunks = self
+                .downcast_iter()
+                .map(|chunk| chunk.values()[i].clone())
+                .collect();
+            // SAFETY: the chunks are this struct's own field.
+            let (child, compacted) =
+                unsafe { container_child(field.name.clone(), chunks, &field.dtype) };
+            changed |= compacted;
+
+            match child.propagate_nulls() {
+                Some(propagated) => {
+                    changed = true;
+                    new_fields.push(propagated);
+                },
+                None => new_fields.push(child),
+            }
         }
 
         if !changed {
             return None;
         }
 
-        // Field names, lengths, and outer validity are unchanged, so this cannot fail.
-        let mut new_fields = new_fields.into_iter();
-        let out = self
-            .try_apply_fields(|field| {
-                Ok(new_fields.next().unwrap().unwrap_or_else(|| field.clone()))
-            })
+        // Use repaired fields; `try_apply_fields` would reconstruct uncompacted Maps.
+        let out = Self::from_series(self.name().clone(), self.len(), new_fields.iter())
             .expect("propagating nulls keeps the struct fields");
-        Some(out)
+        // Restore outer validity without repeating propagation.
+        Some(out.with_outer_validity_from(self))
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/nesting_utils.rs
+++ b/crates/polars-core/src/chunked_array/ops/nesting_utils.rs
@@ -4,7 +4,7 @@ use polars_utils::IdxSize;
 
 use super::ListChunked;
 use crate::chunked_array::flags::StatisticsFlags;
-use crate::prelude::{ArrayRef, ChunkedArray, DataType, FalseT, PlSmallStr, PolarsDataType};
+use crate::prelude::{ChunkedArray, FalseT, PolarsDataType};
 use crate::series::Series;
 use crate::series::implementations::null::NullChunked;
 use crate::utils::align_chunks_binary_ca_series;
@@ -25,7 +25,7 @@ pub trait ChunkNestingUtils: Sized {
 
 impl ChunkNestingUtils for ListChunked {
     fn propagate_nulls(&self) -> Option<Self> {
-        use polars_compute::propagate_nulls::{propagate_nulls_list, propagate_nulls_list_shallow};
+        use polars_compute::propagate_nulls::propagate_nulls_list;
 
         let flags = self.get_flags();
 
@@ -39,18 +39,9 @@ impl ChunkNestingUtils for ListChunked {
             return None;
         }
 
-        let map_aware = self.inner_dtype().contains_map();
-        let propagate_chunk = |chunk| {
-            if map_aware {
-                propagate_nulls_list_shallow(chunk)
-            } else {
-                propagate_nulls_list(chunk)
-            }
-        };
-
         let mut chunks = Vec::new();
         for (i, chunk) in self.downcast_iter().enumerate() {
-            if let Some(propagated_chunk) = propagate_chunk(chunk) {
+            if let Some(propagated_chunk) = propagate_nulls_list(chunk) {
                 chunks.reserve(self.chunks.len());
                 chunks.extend(self.chunks[..i].iter().cloned());
                 chunks.push(propagated_chunk.into_boxed());
@@ -59,25 +50,21 @@ impl ChunkNestingUtils for ListChunked {
         }
 
         // If we found a chunk that needs propagating, create a new ListChunked
-        let mut out = if chunks.is_empty() {
+        let out = if chunks.is_empty() {
             None
         } else {
-            chunks.extend(self.downcast_iter().skip(chunks.len()).map(
-                |chunk| match propagate_chunk(chunk) {
+            chunks.extend(self.downcast_iter().skip(chunks.len()).map(|chunk| {
+                match propagate_nulls_list(chunk) {
                     None => chunk.to_boxed(),
                     Some(chunk) => chunk.into_boxed(),
-                },
-            ));
+                }
+            }));
 
             // SAFETY: The length and null_count should remain the same.
             Some(unsafe {
                 Self::new_with_dims(self.field.clone(), chunks, self.length, self.null_count)
             })
         };
-
-        if map_aware {
-            out = propagate_values_nulls(out, self);
-        }
 
         finish_propagate_nulls(out, self, flags)
     }
@@ -141,7 +128,7 @@ impl ChunkNestingUtils for ListChunked {
 #[cfg(feature = "dtype-array")]
 impl ChunkNestingUtils for super::ArrayChunked {
     fn propagate_nulls(&self) -> Option<Self> {
-        use polars_compute::propagate_nulls::{propagate_nulls_fsl, propagate_nulls_fsl_shallow};
+        use polars_compute::propagate_nulls::propagate_nulls_fsl;
 
         let flags = self.get_flags();
 
@@ -155,18 +142,9 @@ impl ChunkNestingUtils for super::ArrayChunked {
             return None;
         }
 
-        let map_aware = self.inner_dtype().contains_map();
-        let propagate_chunk = |chunk| {
-            if map_aware {
-                propagate_nulls_fsl_shallow(chunk)
-            } else {
-                propagate_nulls_fsl(chunk)
-            }
-        };
-
         let mut chunks = Vec::new();
         for (i, chunk) in self.downcast_iter().enumerate() {
-            if let Some(propagated_chunk) = propagate_chunk(chunk) {
+            if let Some(propagated_chunk) = propagate_nulls_fsl(chunk) {
                 chunks.reserve(self.chunks.len());
                 chunks.extend(self.chunks[..i].iter().cloned());
                 chunks.push(propagated_chunk.into_boxed());
@@ -174,25 +152,21 @@ impl ChunkNestingUtils for super::ArrayChunked {
             }
         }
 
-        let mut out = if chunks.is_empty() {
+        let out = if chunks.is_empty() {
             None
         } else {
-            chunks.extend(self.downcast_iter().skip(chunks.len()).map(
-                |chunk| match propagate_chunk(chunk) {
+            chunks.extend(self.downcast_iter().skip(chunks.len()).map(|chunk| {
+                match propagate_nulls_fsl(chunk) {
                     None => chunk.to_boxed(),
                     Some(chunk) => chunk.into_boxed(),
-                },
-            ));
+                }
+            }));
 
             // SAFETY: The length and null_count should remain the same.
             Some(unsafe {
                 Self::new_with_dims(self.field.clone(), chunks, self.length, self.null_count)
             })
         };
-
-        if map_aware {
-            out = propagate_values_nulls(out, self);
-        }
 
         finish_propagate_nulls(out, self, flags)
     }
@@ -257,9 +231,7 @@ impl ChunkNestingUtils for super::ArrayChunked {
 #[cfg(feature = "dtype-struct")]
 impl ChunkNestingUtils for super::StructChunked {
     fn propagate_nulls(&self) -> Option<Self> {
-        use polars_compute::propagate_nulls::{
-            propagate_nulls_struct, propagate_nulls_struct_shallow,
-        };
+        use polars_compute::propagate_nulls::propagate_nulls_struct;
 
         let flags = self.get_flags();
 
@@ -273,18 +245,9 @@ impl ChunkNestingUtils for super::StructChunked {
             return None;
         }
 
-        let map_aware = self.dtype().contains_map();
-        let propagate_chunk = |chunk| {
-            if map_aware {
-                propagate_nulls_struct_shallow(chunk)
-            } else {
-                propagate_nulls_struct(chunk)
-            }
-        };
-
         let mut chunks = Vec::new();
         for (i, chunk) in self.downcast_iter().enumerate() {
-            if let Some(propagated_chunk) = propagate_chunk(chunk) {
+            if let Some(propagated_chunk) = propagate_nulls_struct(chunk) {
                 chunks.reserve(self.chunks.len());
                 chunks.extend(self.chunks[..i].iter().cloned());
                 chunks.push(propagated_chunk.into_boxed());
@@ -292,25 +255,21 @@ impl ChunkNestingUtils for super::StructChunked {
             }
         }
 
-        let mut out = if chunks.is_empty() {
+        let out = if chunks.is_empty() {
             None
         } else {
-            chunks.extend(self.downcast_iter().skip(chunks.len()).map(
-                |chunk| match propagate_chunk(chunk) {
+            chunks.extend(self.downcast_iter().skip(chunks.len()).map(|chunk| {
+                match propagate_nulls_struct(chunk) {
                     None => chunk.to_boxed(),
                     Some(chunk) => chunk.into_boxed(),
-                },
-            ));
+                }
+            }));
 
             // SAFETY: The length and null_count should remain the same.
             Some(unsafe {
                 Self::new_with_dims(self.field.clone(), chunks, self.length, self.null_count)
             })
         };
-
-        if map_aware {
-            out = propagate_values_nulls(out, self);
-        }
 
         finish_propagate_nulls(out, self, flags)
     }
@@ -373,110 +332,6 @@ impl ChunkNestingUtils for super::StructChunked {
             offset += l.len() as IdxSize;
         }
     }
-}
-
-/// Build a container child, compacting null Map rows left by shallow propagation.
-///
-/// # Safety
-/// `chunks` must satisfy [`Series::from_chunks_and_dtype_unchecked`] for `dtype`, except
-/// that Map null rows may still span entries.
-unsafe fn container_child(
-    name: PlSmallStr,
-    chunks: Vec<ArrayRef>,
-    dtype: &DataType,
-) -> (Series, bool) {
-    #[cfg(feature = "dtype-map")]
-    {
-        // SAFETY: forwarded from this function's own contract.
-        unsafe { crate::chunked_array::logical::compacted_child_series(name, chunks, dtype) }
-    }
-    #[cfg(not(feature = "dtype-map"))]
-    {
-        // SAFETY: forwarded from this function's own contract.
-        let s = unsafe { Series::from_chunks_and_dtype_unchecked(name, chunks, dtype) };
-        (s, false)
-    }
-}
-
-/// Propagate through logical dtypes, emptying null Map rows instead of nulling entries.
-trait PropagateValuesNulls: Sized {
-    fn values_propagate_nulls(&self) -> Option<Self>;
-}
-
-impl PropagateValuesNulls for ListChunked {
-    fn values_propagate_nulls(&self) -> Option<Self> {
-        let chunks = self.downcast_iter().map(|c| c.values().clone()).collect();
-        // SAFETY: the chunks are this list's own child.
-        let (values, compacted) =
-            unsafe { container_child(self.name().clone(), chunks, self.inner_dtype()) };
-
-        let propagated = values.propagate_nulls();
-        if !compacted && propagated.is_none() {
-            return None;
-        }
-        Some(self.with_inner_values(propagated.as_ref().unwrap_or(&values)))
-    }
-}
-
-#[cfg(feature = "dtype-array")]
-impl PropagateValuesNulls for super::ArrayChunked {
-    fn values_propagate_nulls(&self) -> Option<Self> {
-        let chunks = self.downcast_iter().map(|c| c.values().clone()).collect();
-        // SAFETY: the chunks are this array's own child.
-        let (values, compacted) =
-            unsafe { container_child(self.name().clone(), chunks, self.inner_dtype()) };
-
-        let propagated = values.propagate_nulls();
-        if !compacted && propagated.is_none() {
-            return None;
-        }
-        Some(self.with_inner_values(propagated.as_ref().unwrap_or(&values)))
-    }
-}
-
-#[cfg(feature = "dtype-struct")]
-impl PropagateValuesNulls for super::StructChunked {
-    fn values_propagate_nulls(&self) -> Option<Self> {
-        let struct_fields = self.struct_fields().to_vec();
-        let mut new_fields = Vec::with_capacity(struct_fields.len());
-        let mut changed = false;
-        for (i, field) in struct_fields.iter().enumerate() {
-            let chunks = self
-                .downcast_iter()
-                .map(|chunk| chunk.values()[i].clone())
-                .collect();
-            // SAFETY: the chunks are this struct's own field.
-            let (child, compacted) =
-                unsafe { container_child(field.name.clone(), chunks, &field.dtype) };
-            changed |= compacted;
-
-            match child.propagate_nulls() {
-                Some(propagated) => {
-                    changed = true;
-                    new_fields.push(propagated);
-                },
-                None => new_fields.push(child),
-            }
-        }
-
-        if !changed {
-            return None;
-        }
-
-        // Use repaired fields; `try_apply_fields` would reconstruct uncompacted Maps.
-        let out = Self::from_series(self.name().clone(), self.len(), new_fields.iter())
-            .expect("propagating nulls keeps the struct fields");
-        // Restore outer validity without repeating propagation.
-        Some(out.with_outer_validity_from(self))
-    }
-}
-
-/// Propagate child nulls in `out`, or `orig` if unchanged.
-fn propagate_values_nulls<T: PropagateValuesNulls>(out: Option<T>, orig: &T) -> Option<T> {
-    out.as_ref()
-        .unwrap_or(orig)
-        .values_propagate_nulls()
-        .or(out)
 }
 
 /// Mark `out` or `orig` as having propagated nulls.

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -357,31 +357,41 @@ impl StructChunked {
             .iter()
             .map(func)
             .collect::<PolarsResult<Vec<_>>>()?;
-        Self::from_series(self.name().clone(), self.len(), fields.iter()).map(|mut ca| {
-            assert_eq!(ca.len(), self.len());
-            if self.null_count > 0 {
-                if ca
-                    .chunk_lengths()
-                    .zip(self.chunk_lengths())
-                    .all(|(l, r)| l == r)
-                {
-                    // SAFETY: only null_count adjusted, recalculated afterwards.
-                    for (new, this) in unsafe { ca.downcast_iter_mut() }.zip(self.downcast_iter()) {
-                        new.set_validity(this.validity().cloned())
-                    }
-                } else {
-                    let mut slf_validity = self.rechunk_validity().unwrap();
-                    // SAFETY: only null_count adjusted, recalculated afterwards.
-                    for new in unsafe { ca.downcast_iter_mut() } {
-                        let this_validity;
-                        (this_validity, slf_validity) = slf_validity.split_at(new.len());
-                        new.set_validity((this_validity.unset_bits() > 0).then_some(this_validity));
-                    }
-                }
-                ca.compute_len();
+        let ca = Self::from_series(self.name().clone(), self.len(), fields.iter())?;
+        assert_eq!(ca.len(), self.len());
+        Ok(ca.with_outer_validity_from(self))
+    }
+
+    /// Copy `other`'s outer validity, without propagating it into the fields.
+    ///
+    /// # Panics
+    /// If `other` has a different length.
+    pub(crate) fn with_outer_validity_from(mut self, other: &Self) -> Self {
+        assert_eq!(self.len(), other.len());
+        if other.null_count == 0 {
+            return self;
+        }
+
+        if self
+            .chunk_lengths()
+            .zip(other.chunk_lengths())
+            .all(|(l, r)| l == r)
+        {
+            // SAFETY: only null_count adjusted, recalculated afterwards.
+            for (new, this) in unsafe { self.downcast_iter_mut() }.zip(other.downcast_iter()) {
+                new.set_validity(this.validity().cloned())
             }
-            ca
-        })
+        } else {
+            let mut other_validity = other.rechunk_validity().unwrap();
+            // SAFETY: only null_count adjusted, recalculated afterwards.
+            for new in unsafe { self.downcast_iter_mut() } {
+                let this_validity;
+                (this_validity, other_validity) = other_validity.split_at(new.len());
+                new.set_validity((this_validity.unset_bits() > 0).then_some(this_validity));
+            }
+        }
+        self.compute_len();
+        self
     }
 
     pub fn get_row_encoded_array(&self, options: SortOptions) -> PolarsResult<BinaryArray<i64>> {

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -366,7 +366,7 @@ impl StructChunked {
     ///
     /// # Panics
     /// If `other` has a different length.
-    pub(crate) fn with_outer_validity_from(mut self, other: &Self) -> Self {
+    fn with_outer_validity_from(mut self, other: &Self) -> Self {
         assert_eq!(self.len(), other.len());
         if other.null_count == 0 {
             return self;

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -714,13 +714,10 @@ impl Column {
                     scalar.into_nulls().into_column()
                 } else {
                     let validity = indices.rechunk_validity();
-                    let series = scalar.take_materialized_series();
-                    let name = series.name().clone();
-                    let dtype = series.dtype().clone();
-                    let mut chunks = series.into_chunks();
-                    assert_eq!(chunks.len(), 1);
-                    chunks[0] = chunks[0].with_validity(validity);
-                    unsafe { Series::from_chunks_and_dtype_unchecked(name, chunks, &dtype) }
+                    // Use dtype-aware validity updates to preserve Map/Struct invariants.
+                    scalar
+                        .take_materialized_series()
+                        .with_validity(validity)
                         .into_column()
                 }
             },
@@ -800,14 +797,9 @@ impl Column {
                 };
                 validity.extend_trusted_len_iter(iter);
 
-                let mut s = scalar_col.take_materialized_series().rechunk();
-                // SAFETY: We perform a compute_len afterwards.
-                let chunks = unsafe { s.chunks_mut() };
-                let arr = &mut chunks[0];
-                *arr = arr.with_validity(validity.into_opt_validity());
-                s.compute_len();
-
-                s.into_column()
+                // Use dtype-aware validity updates to preserve Map/Struct invariants.
+                let s = scalar_col.take_materialized_series().rechunk();
+                s.with_validity(validity.into_opt_validity()).into_column()
             },
         }
     }

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -714,7 +714,7 @@ impl Column {
                     scalar.into_nulls().into_column()
                 } else {
                     let validity = indices.rechunk_validity();
-                    // Use dtype-aware validity updates to preserve Map/Struct invariants.
+                    // Use dtype-aware validity updates so Struct fields see the nulls.
                     scalar
                         .take_materialized_series()
                         .with_validity(validity)
@@ -797,7 +797,7 @@ impl Column {
                 };
                 validity.extend_trusted_len_iter(iter);
 
-                // Use dtype-aware validity updates to preserve Map/Struct invariants.
+                // Use dtype-aware validity updates so Struct fields see the nulls.
                 let s = scalar_col.take_materialized_series().rechunk();
                 s.with_validity(validity.into_opt_validity()).into_column()
             },

--- a/crates/polars-core/src/series/arrow_export/mod.rs
+++ b/crates/polars-core/src/series/arrow_export/mod.rs
@@ -47,12 +47,8 @@ macro_rules! primitive_to_boxed_with_logical {
 /// chunk already spans exactly its child.
 fn normalize_map_entries(arr: &ListArray<i64>) -> Option<ListArray<i64>> {
     #[cfg(feature = "dtype-map")]
-    {
-        use crate::chunked_array::logical::{compact_null_rows_chunk, hidden_entry_count};
-
-        if hidden_entry_count(arr) > 0 {
-            return compact_null_rows_chunk(arr);
-        }
+    if let Some(compacted) = crate::chunked_array::logical::compact_null_rows_chunk(arr) {
+        return Some(compacted);
     }
 
     let offsets = arr.offsets();

--- a/crates/polars-core/src/series/arrow_export/mod.rs
+++ b/crates/polars-core/src/series/arrow_export/mod.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use polars_compute::cast::cast_unchecked;
+use polars_compute::rebuild_list::rebuild_list_shallow;
 use polars_error::{PolarsError, PolarsResult, polars_ensure, polars_err};
 
 use crate::prelude::{
@@ -40,6 +41,31 @@ macro_rules! primitive_to_boxed_with_logical {
         let arr: &PrimitiveArray<$physical> = $array.as_any().downcast_ref().unwrap();
         arr.clone().to($logical_arrow_dtype).to_boxed()
     }};
+}
+
+/// Drop the entries no live row owns and rebase the offsets onto the rest; `None` if the
+/// chunk already spans exactly its child.
+fn normalize_map_entries(arr: &ListArray<i64>) -> Option<ListArray<i64>> {
+    #[cfg(feature = "dtype-map")]
+    {
+        use crate::chunked_array::logical::{compact_null_rows_chunk, hidden_entry_count};
+
+        if hidden_entry_count(arr) > 0 {
+            return compact_null_rows_chunk(arr);
+        }
+    }
+
+    let offsets = arr.offsets();
+    let first = *offsets.first() as usize;
+    let len = offsets.range() as usize;
+    if first == 0 && len == arr.values().len() {
+        return None;
+    }
+    Some(rebuild_list_shallow(
+        arr,
+        arr.dtype().clone(),
+        arr.values().sliced(first, len),
+    ))
 }
 
 fn ensure_no_nulls(array: &dyn Array) -> PolarsResult<()> {
@@ -449,6 +475,10 @@ impl ToArrowConverter {
         use arrow::offset::OffsetsBuffer;
 
         let arr: &ListArray<i64> = array.as_any().downcast_ref().unwrap();
+        // Arrow's MAP entries and keys are non-nullable and its offsets start at zero, so
+        // normalize before the child is read: everything no live row owns is dropped.
+        let normalized = normalize_map_entries(arr);
+        let arr = normalized.as_ref().unwrap_or(arr);
 
         let mut arrow_dtype = to_owned_dtype(arrow_field);
 

--- a/crates/polars-core/src/series/arrow_export/mod.rs
+++ b/crates/polars-core/src/series/arrow_export/mod.rs
@@ -471,8 +471,8 @@ impl ToArrowConverter {
         use arrow::offset::OffsetsBuffer;
 
         let arr: &ListArray<i64> = array.as_any().downcast_ref().unwrap();
-        // Arrow's MAP entries and keys are non-nullable and its offsets start at zero, so
-        // normalize before the child is read: everything no live row owns is dropped.
+        // Arrow's MAP entries and keys are non-nullable, and entries that no live row owns
+        // may be null, so normalize before the child is read: those entries are dropped.
         let normalized = normalize_map_entries(arr);
         let arr = normalized.as_ref().unwrap_or(arr);
 

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -79,7 +79,8 @@ impl Series {
     ///
     /// - `Categorical` / `Enum`: every non-null code names a category;
     /// - `Object`: chunks originate from this process;
-    /// - `Map`: storage satisfies the `MapChunked` storage safety contract. Keys may repeat.
+    /// - `Map`: storage satisfies the `MapChunked` storage safety contract, including null
+    ///   rows spanning no entries. Keys may repeat.
     pub unsafe fn from_chunks_and_dtype_unchecked(
         name: PlSmallStr,
         chunks: Vec<ArrayRef>,
@@ -610,8 +611,8 @@ impl Series {
                             CanonicalizeMode, canonicalize_map_storage,
                         };
 
-                        // Reject live null entries/keys and compact hidden ones.
-                        // Trust the producer's key uniqueness, as Arrow does.
+                        // Empty null rows (potentially copying Arrow buffers) and reject
+                        // live null entries/keys. Trust the producer's key uniqueness.
                         let storage =
                             canonicalize_map_storage(&storage, CanonicalizeMode::NullsOnly)?
                                 .unwrap_or(storage);

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -79,8 +79,8 @@ impl Series {
     ///
     /// - `Categorical` / `Enum`: every non-null code names a category;
     /// - `Object`: chunks originate from this process;
-    /// - `Map`: storage satisfies the `MapChunked` storage safety contract, including null
-    ///   rows spanning no entries. Keys may repeat.
+    /// - `Map`: storage satisfies the `MapChunked` storage safety contract, so entries and
+    ///   keys are non-null within the offset windows of live rows. Keys may repeat.
     pub unsafe fn from_chunks_and_dtype_unchecked(
         name: PlSmallStr,
         chunks: Vec<ArrayRef>,
@@ -607,17 +607,13 @@ impl Series {
                 match map_dtype {
                     #[cfg(feature = "dtype-map")]
                     Some(dtype) => {
-                        use crate::chunked_array::logical::{
-                            CanonicalizeMode, canonicalize_map_storage,
-                        };
+                        use crate::chunked_array::logical::ensure_live_entries_non_null;
 
-                        // Empty null rows (potentially copying Arrow buffers) and reject
-                        // live null entries/keys. Trust the producer's key uniqueness.
-                        let storage =
-                            canonicalize_map_storage(&storage, CanonicalizeMode::NullsOnly)?
-                                .unwrap_or(storage);
-                        // SAFETY: dtype and imported children are valid; null entries/keys
-                        // have been removed.
+                        // Entries a null row spans are left where the producer put them, so
+                        // the import stays zero-copy. Trust the producer's key uniqueness.
+                        ensure_live_entries_non_null(storage.list().unwrap())?;
+                        // SAFETY: dtype and imported children are valid; live rows own no
+                        // null entries or keys.
                         Ok(
                             unsafe { MapChunked::from_storage_unchecked(dtype, storage) }
                                 .into_series(),

--- a/crates/polars-core/src/series/implementations/map.rs
+++ b/crates/polars-core/src/series/implementations/map.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::chunked_array::logical::compact_null_map_rows;
 use crate::chunked_array::ops::sort::arg_sort_multiple::argsort_multiple_row_fmt;
 use crate::prelude::*;
 
@@ -17,8 +16,7 @@ impl SeriesWrap<MapChunked> {
     }
 
     /// # Safety
-    /// `apply` must only add, remove, or reorder whole rows; anything that can null a row
-    /// uses [`Self::apply_on_storage_compacting`] instead.
+    /// `apply` must only add, remove, reorder or null whole rows.
     unsafe fn apply_on_storage<F>(&self, apply: F) -> Series
     where
         F: FnOnce(&Series) -> Series,
@@ -34,34 +32,6 @@ impl SeriesWrap<MapChunked> {
     {
         Ok(unsafe { self.rewrap(apply(self.0.storage())?) })
     }
-
-    /// Like [`Self::apply_on_storage`], but empties the rows `apply` nulled.
-    ///
-    /// Repair raw storage before wrapping it as a Map.
-    ///
-    /// # Safety
-    /// `apply` must only add, remove, reorder or null whole rows.
-    unsafe fn apply_on_storage_compacting<F>(&self, apply: F) -> Series
-    where
-        F: FnOnce(&Series) -> Series,
-    {
-        unsafe { self.rewrap(compact_storage(apply(self.0.storage()))) }
-    }
-
-    /// # Safety
-    /// See [`Self::apply_on_storage_compacting`].
-    unsafe fn try_apply_on_storage_compacting<F>(&self, apply: F) -> PolarsResult<Series>
-    where
-        F: Fn(&Series) -> PolarsResult<Series>,
-    {
-        Ok(unsafe { self.rewrap(compact_storage(apply(self.0.storage())?)) })
-    }
-}
-
-/// Empty any null rows that still span entries.
-fn compact_storage(storage: Series) -> Series {
-    let compacted = compact_null_map_rows(storage.list().unwrap()).map(IntoSeries::into_series);
-    compacted.unwrap_or(storage)
 }
 
 impl private::PrivateSeries for SeriesWrap<MapChunked> {
@@ -114,13 +84,8 @@ impl private::PrivateSeries for SeriesWrap<MapChunked> {
     #[cfg(feature = "zip_with")]
     fn zip_with_same_type(&self, mask: &BooleanChunked, other: &Series) -> PolarsResult<Series> {
         assert!(self._dtype() == other.dtype());
-        // SAFETY: picks whole rows from two Maps that have the same dtype. A unit-length
-        // null on either side nulls rows in place, so the result is compacted.
-        unsafe {
-            self.try_apply_on_storage_compacting(|s| {
-                s.zip_with_same_type(mask, other.map()?.storage())
-            })
-        }
+        // SAFETY: picks whole rows from two Maps that have the same dtype.
+        unsafe { self.try_apply_on_storage(|s| s.zip_with_same_type(mask, other.map()?.storage())) }
     }
 
     #[cfg(feature = "algorithm_group_by")]
@@ -176,9 +141,8 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     /// # Safety
-    /// Mutations must preserve the dtype and [`MapChunked`] storage safety contract,
-    /// including leaving null rows with empty windows. Preserving key uniqueness also
-    /// requires keeping keys and their row membership.
+    /// Mutations must preserve the dtype and [`MapChunked`] storage safety contract.
+    /// Preserving key uniqueness also requires keeping keys and their row membership.
     unsafe fn chunks_mut(&mut self) -> &mut Vec<ArrayRef> {
         self.0.storage_mut().chunks_mut()
     }
@@ -254,8 +218,8 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Series {
-        // SAFETY: only row validity changes; newly nulled rows are emptied.
-        unsafe { self.apply_on_storage_compacting(move |s| s.with_validity(validity)) }
+        // SAFETY: only row validity changes; nulled rows keep their entries hidden.
+        unsafe { self.apply_on_storage(move |s| s.with_validity(validity)) }
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {
@@ -264,15 +228,19 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn deposit(&self, validity: &Bitmap) -> Series {
-        // SAFETY: gathers whole rows; compaction empties rows masked null by padding.
-        unsafe { self.apply_on_storage_compacting(|s| s.deposit(validity)) }
+        // SAFETY: gathers whole rows and pads with nulls.
+        unsafe { self.apply_on_storage(|s| s.deposit(validity)) }
     }
 
     fn find_validity_mismatch(&self, other: &Series, idxs: &mut Vec<IdxSize>) {
-        // `other` is same-length cast output, possibly with a different dtype.
-        // Both inputs must have recursively propagated nulls and empty null Map rows.
-        let other = other.try_map().map_or(other, |map| map.storage());
-        self.0.storage().find_validity_mismatch(other, idxs)
+        // `other` is same-length cast output, possibly with a different dtype. Both inputs
+        // must have recursively propagated nulls, and entries that no live row owns would
+        // misalign the children, so compare compacted storage.
+        let live = other
+            .try_map()
+            .map(|map| map.live_storage().into_owned().into_series());
+        let other = live.as_ref().unwrap_or(other);
+        self.0.live_storage().find_validity_mismatch(other, idxs)
     }
 
     fn cast(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Series> {
@@ -356,7 +324,6 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn propagate_nulls(&self) -> Option<Series> {
-        // Null rows are empty; only entry children need propagation.
         self.0.propagate_nulls().map(IntoSeries::into_series)
     }
 

--- a/crates/polars-core/src/series/implementations/map.rs
+++ b/crates/polars-core/src/series/implementations/map.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::chunked_array::logical::compact_null_map_rows;
 use crate::chunked_array::ops::sort::arg_sort_multiple::argsort_multiple_row_fmt;
 use crate::prelude::*;
 
@@ -16,7 +17,8 @@ impl SeriesWrap<MapChunked> {
     }
 
     /// # Safety
-    /// `apply` must only add, remove, or reorder whole rows.
+    /// `apply` must only add, remove, or reorder whole rows; anything that can null a row
+    /// uses [`Self::apply_on_storage_compacting`] instead.
     unsafe fn apply_on_storage<F>(&self, apply: F) -> Series
     where
         F: FnOnce(&Series) -> Series,
@@ -32,6 +34,34 @@ impl SeriesWrap<MapChunked> {
     {
         Ok(unsafe { self.rewrap(apply(self.0.storage())?) })
     }
+
+    /// Like [`Self::apply_on_storage`], but empties the rows `apply` nulled.
+    ///
+    /// Repair raw storage before wrapping it as a Map.
+    ///
+    /// # Safety
+    /// `apply` must only add, remove, reorder or null whole rows.
+    unsafe fn apply_on_storage_compacting<F>(&self, apply: F) -> Series
+    where
+        F: FnOnce(&Series) -> Series,
+    {
+        unsafe { self.rewrap(compact_storage(apply(self.0.storage()))) }
+    }
+
+    /// # Safety
+    /// See [`Self::apply_on_storage_compacting`].
+    unsafe fn try_apply_on_storage_compacting<F>(&self, apply: F) -> PolarsResult<Series>
+    where
+        F: Fn(&Series) -> PolarsResult<Series>,
+    {
+        Ok(unsafe { self.rewrap(compact_storage(apply(self.0.storage())?)) })
+    }
+}
+
+/// Empty any null rows that still span entries.
+fn compact_storage(storage: Series) -> Series {
+    let compacted = compact_null_map_rows(storage.list().unwrap()).map(IntoSeries::into_series);
+    compacted.unwrap_or(storage)
 }
 
 impl private::PrivateSeries for SeriesWrap<MapChunked> {
@@ -84,8 +114,13 @@ impl private::PrivateSeries for SeriesWrap<MapChunked> {
     #[cfg(feature = "zip_with")]
     fn zip_with_same_type(&self, mask: &BooleanChunked, other: &Series) -> PolarsResult<Series> {
         assert!(self._dtype() == other.dtype());
-        // SAFETY: picks whole rows from two Maps that have the same dtype.
-        unsafe { self.try_apply_on_storage(|s| s.zip_with_same_type(mask, other.map()?.storage())) }
+        // SAFETY: picks whole rows from two Maps that have the same dtype. A unit-length
+        // null on either side nulls rows in place, so the result is compacted.
+        unsafe {
+            self.try_apply_on_storage_compacting(|s| {
+                s.zip_with_same_type(mask, other.map()?.storage())
+            })
+        }
     }
 
     #[cfg(feature = "algorithm_group_by")]
@@ -141,8 +176,9 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     /// # Safety
-    /// Mutations must preserve the dtype and [`MapChunked`] storage safety contract.
-    /// Preserving key uniqueness also requires keeping keys and their row membership.
+    /// Mutations must preserve the dtype and [`MapChunked`] storage safety contract,
+    /// including leaving null rows with empty windows. Preserving key uniqueness also
+    /// requires keeping keys and their row membership.
     unsafe fn chunks_mut(&mut self) -> &mut Vec<ArrayRef> {
         self.0.storage_mut().chunks_mut()
     }
@@ -218,8 +254,8 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Series {
-        // SAFETY: only row validity changes; entries remain intact.
-        unsafe { self.apply_on_storage(move |s| s.with_validity(validity)) }
+        // SAFETY: only row validity changes; newly nulled rows are emptied.
+        unsafe { self.apply_on_storage_compacting(move |s| s.with_validity(validity)) }
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {
@@ -228,13 +264,13 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn deposit(&self, validity: &Bitmap) -> Series {
-        // SAFETY: gathers whole rows and pads with nulls.
-        unsafe { self.apply_on_storage(|s| s.deposit(validity)) }
+        // SAFETY: gathers whole rows; compaction empties rows masked null by padding.
+        unsafe { self.apply_on_storage_compacting(|s| s.deposit(validity)) }
     }
 
     fn find_validity_mismatch(&self, other: &Series, idxs: &mut Vec<IdxSize>) {
-        // `other` is same-length cast output and may have a different dtype.
-        // `handle_casting_failures` compacts null Map rows at every depth first.
+        // `other` is same-length cast output, possibly with a different dtype.
+        // Both inputs must have recursively propagated nulls and empty null Map rows.
         let other = other.try_map().map_or(other, |map| map.storage());
         self.0.storage().find_validity_mismatch(other, idxs)
     }
@@ -320,7 +356,7 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn propagate_nulls(&self) -> Option<Series> {
-        // List propagation would null entries retained by null Map rows.
+        // Null rows are empty; only entry children need propagation.
         self.0.propagate_nulls().map(IntoSeries::into_series)
     }
 

--- a/crates/polars-core/src/series/implementations/map.rs
+++ b/crates/polars-core/src/series/implementations/map.rs
@@ -1,3 +1,5 @@
+use polars_compute::find_validity_mismatch::find_validity_mismatch_shallow;
+
 use super::*;
 use crate::chunked_array::ops::sort::arg_sort_multiple::argsort_multiple_row_fmt;
 use crate::prelude::*;
@@ -16,7 +18,8 @@ impl SeriesWrap<MapChunked> {
     }
 
     /// # Safety
-    /// `apply` must only add, remove, reorder or null whole rows.
+    /// `apply` must only add, remove, reorder or null whole rows. It must never make a null
+    /// row valid: that row's entries are unconstrained.
     unsafe fn apply_on_storage<F>(&self, apply: F) -> Series
     where
         F: FnOnce(&Series) -> Series,
@@ -218,8 +221,7 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Series {
-        // SAFETY: only row validity changes; nulled rows keep their entries hidden.
-        unsafe { self.apply_on_storage(move |s| s.with_validity(validity)) }
+        self.0.with_row_validity(validity).into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {
@@ -233,14 +235,14 @@ impl SeriesTrait for SeriesWrap<MapChunked> {
     }
 
     fn find_validity_mismatch(&self, other: &Series, idxs: &mut Vec<IdxSize>) {
-        // `other` is same-length cast output, possibly with a different dtype. Both inputs
-        // must have recursively propagated nulls, and entries that no live row owns would
-        // misalign the children, so compare compacted storage.
-        let live = other
-            .try_map()
-            .map(|map| map.live_storage().into_owned().into_series());
-        let other = live.as_ref().unwrap_or(other);
-        self.0.live_storage().find_validity_mismatch(other, idxs)
+        // `other` is same-length cast output, possibly with a different dtype. Entries that
+        // no live row owns, and the key merging a cast can do, would misalign the children,
+        // so only rows are comparable.
+        find_validity_mismatch_shallow(
+            self.0.storage().rechunk_validity().as_ref(),
+            other.rechunk_validity().as_ref(),
+            idxs,
+        )
     }
 
     fn cast(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -534,8 +534,9 @@ impl Series {
     ///
     /// Payloads must be safe to read as `dtype`: categorical codes in range for every
     /// non-null slot, and Maps satisfying the `MapChunked` storage safety contract. Null
-    /// entries or keys under null rows are allowed and compacted; those in live rows are
-    /// errors. Unsafe payloads can cause invalid memory access downstream.
+    /// Map rows may span entries on input, and those entries may themselves be null; both
+    /// are compacted away. Null entries or keys in live rows are errors. Unsafe payloads
+    /// can cause invalid memory access downstream.
     ///
     /// # Key uniqueness
     /// Not required for safety. Whole-row transformations preserve existing uniqueness;
@@ -619,7 +620,8 @@ impl Series {
                 use crate::chunked_array::logical::{CanonicalizeMode, canonicalize_map_storage};
 
                 let storage = self.from_physical_unchecked(&dtype.map_storage_dtype().unwrap())?;
-                // Repair hidden nulls from dtype-blind propagation; reject live ones.
+                // Empty null rows and repair hidden nulls left by dtype-blind
+                // propagation; reject null entries or keys in live rows.
                 let storage = canonicalize_map_storage(&storage, CanonicalizeMode::NullsOnly)?
                     .unwrap_or(storage);
                 Ok(MapChunked::from_storage_unchecked(dtype.clone(), storage).into_series())

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -534,9 +534,9 @@ impl Series {
     ///
     /// Payloads must be safe to read as `dtype`: categorical codes in range for every
     /// non-null slot, and Maps satisfying the `MapChunked` storage safety contract. Null
-    /// Map rows may span entries on input, and those entries may themselves be null; both
-    /// are compacted away. Null entries or keys in live rows are errors. Unsafe payloads
-    /// can cause invalid memory access downstream.
+    /// Map rows may span entries, and those entries may themselves be null; they are left
+    /// alone. Null entries or keys in live rows are errors. Unsafe payloads can cause
+    /// invalid memory access downstream.
     ///
     /// # Key uniqueness
     /// Not required for safety. Whole-row transformations preserve existing uniqueness;
@@ -617,13 +617,12 @@ impl Series {
 
             #[cfg(feature = "dtype-map")]
             (D::List(_), D::Map(_, _)) => {
-                use crate::chunked_array::logical::{CanonicalizeMode, canonicalize_map_storage};
+                use crate::chunked_array::logical::ensure_live_entries_non_null;
 
                 let storage = self.from_physical_unchecked(&dtype.map_storage_dtype().unwrap())?;
-                // Empty null rows and repair hidden nulls left by dtype-blind
-                // propagation; reject null entries or keys in live rows.
-                let storage = canonicalize_map_storage(&storage, CanonicalizeMode::NullsOnly)?
-                    .unwrap_or(storage);
+                // Nulls that propagation left under null rows are legal; only live rows
+                // must own no null entry or key.
+                ensure_live_entries_non_null(storage.list().unwrap())?;
                 Ok(MapChunked::from_storage_unchecked(dtype.clone(), storage).into_series())
             },
             #[cfg(feature = "dtype-extension")]

--- a/crates/polars-core/src/series/ops/canonicalize_maps.rs
+++ b/crates/polars-core/src/series/ops/canonicalize_maps.rs
@@ -1,18 +1,6 @@
 #[cfg(feature = "dtype-map")]
-use crate::chunked_array::logical::{
-    CanonicalizeMode, canonicalize_map_storage, compact_null_map_rows,
-};
+use crate::chunked_array::logical::{CanonicalizeMode, canonicalize_map_storage};
 use crate::prelude::*;
-
-/// Operation applied to each nested Map.
-#[cfg(feature = "dtype-map")]
-#[derive(Clone, Copy)]
-enum MapPass {
-    /// Deduplicate keys using first-position/last-value semantics.
-    Canonicalize,
-    /// Drop entries under null rows.
-    CompactNullRows,
-}
 
 impl Series {
     /// Canonicalize all nested `Map`s bottom-up using first-position/last-value
@@ -20,21 +8,7 @@ impl Series {
     pub fn canonicalize_maps(&self) -> PolarsResult<Option<Series>> {
         #[cfg(feature = "dtype-map")]
         {
-            map_pass(self, MapPass::Canonicalize)
-        }
-        #[cfg(not(feature = "dtype-map"))]
-        {
-            Ok(None)
-        }
-    }
-
-    /// Drop entries under null Map rows at every depth; return `None` if unchanged.
-    ///
-    /// Aligns physical child layouts for strict-cast validity comparisons.
-    pub fn compact_map_null_rows(&self) -> PolarsResult<Option<Series>> {
-        #[cfg(feature = "dtype-map")]
-        {
-            map_pass(self, MapPass::CompactNullRows)
+            canonicalize_maps_rec(self)
         }
         #[cfg(not(feature = "dtype-map"))]
         {
@@ -44,7 +18,7 @@ impl Series {
 }
 
 #[cfg(feature = "dtype-map")]
-fn map_pass(series: &Series, pass: MapPass) -> PolarsResult<Option<Series>> {
+fn canonicalize_maps_rec(series: &Series) -> PolarsResult<Option<Series>> {
     if !series.dtype().contains_map() {
         return Ok(None);
     }
@@ -54,14 +28,9 @@ fn map_pass(series: &Series, pass: MapPass) -> PolarsResult<Option<Series>> {
             let map = series.map().unwrap();
 
             // Visit children first so canonicalization row-encodes normalized keys.
-            let nested = map_pass(map.storage(), pass)?;
+            let nested = canonicalize_maps_rec(map.storage())?;
             let storage = nested.as_ref().unwrap_or(map.storage());
-            let changed = match pass {
-                MapPass::Canonicalize => canonicalize_map_storage(storage, CanonicalizeMode::Full)?,
-                MapPass::CompactNullRows => {
-                    compact_null_map_rows(storage.list().unwrap()).map(IntoSeries::into_series)
-                },
-            };
+            let changed = canonicalize_map_storage(storage, CanonicalizeMode::Full)?;
 
             match changed.or(nested) {
                 None => Ok(None),
@@ -73,13 +42,13 @@ fn map_pass(series: &Series, pass: MapPass) -> PolarsResult<Option<Series>> {
         },
         DataType::List(_) => {
             let ca = series.list().unwrap();
-            Ok(map_pass(&ca.get_inner(), pass)?
+            Ok(canonicalize_maps_rec(&ca.get_inner())?
                 .map(|values| ca.with_inner_values(&values).into_series()))
         },
         #[cfg(feature = "dtype-array")]
         DataType::Array(_, _) => {
             let ca = series.array().unwrap();
-            Ok(map_pass(&ca.get_inner(), pass)?
+            Ok(canonicalize_maps_rec(&ca.get_inner())?
                 .map(|values| ca.with_inner_values(&values).into_series()))
         },
         #[cfg(feature = "dtype-struct")]
@@ -91,7 +60,7 @@ fn map_pass(series: &Series, pass: MapPass) -> PolarsResult<Option<Series>> {
             let mut new_fields = Vec::with_capacity(fields.len());
             let mut changed = false;
             for field in &fields {
-                let new_field = map_pass(field, pass)?;
+                let new_field = canonicalize_maps_rec(field)?;
                 changed |= new_field.is_some();
                 new_fields.push(new_field);
             }
@@ -109,10 +78,8 @@ fn map_pass(series: &Series, pass: MapPass) -> PolarsResult<Option<Series>> {
             Ok(Some(out.into_series()))
         },
         #[cfg(feature = "dtype-extension")]
-        DataType::Extension(typ, _) => {
-            Ok(map_pass(series.ext().unwrap().storage(), pass)?
-                .map(|s| s.into_extension(typ.clone())))
-        },
+        DataType::Extension(typ, _) => Ok(canonicalize_maps_rec(series.ext().unwrap().storage())?
+            .map(|s| s.into_extension(typ.clone()))),
         _ => Ok(None),
     }
 }

--- a/crates/polars-core/src/series/ops/canonicalize_maps.rs
+++ b/crates/polars-core/src/series/ops/canonicalize_maps.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "dtype-map")]
-use crate::chunked_array::logical::{CanonicalizeMode, canonicalize_map_storage};
+use crate::chunked_array::logical::canonicalize_map_storage;
 use crate::prelude::*;
 
 impl Series {
@@ -30,7 +30,7 @@ fn canonicalize_maps_rec(series: &Series) -> PolarsResult<Option<Series>> {
             // Visit children first so canonicalization row-encodes normalized keys.
             let nested = canonicalize_maps_rec(map.storage())?;
             let storage = nested.as_ref().unwrap_or(map.storage());
-            let changed = canonicalize_map_storage(storage, CanonicalizeMode::Full)?;
+            let changed = canonicalize_map_storage(storage)?;
 
             match changed.or(nested) {
                 None => Ok(None),

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -432,8 +432,6 @@ pub trait SeriesTrait:
     fn deposit(&self, validity: &Bitmap) -> Series;
 
     /// Find the indices of elements where the null masks are different recursively.
-    ///
-    /// First compact null Map rows with [`Series::compact_map_null_rows`].
     fn find_validity_mismatch(&self, other: &Series, idxs: &mut Vec<IdxSize>);
 
     fn cast(&self, _dtype: &DataType, options: CastOptions) -> PolarsResult<Series>;

--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -1,4 +1,6 @@
-use polars_compute::find_validity_mismatch::find_validity_mismatch;
+use polars_compute::find_validity_mismatch::{
+    find_validity_mismatch, find_validity_mismatch_shallow,
+};
 use polars_compute::gather::take_unchecked;
 
 use crate::prelude::*;
@@ -65,17 +67,27 @@ pub fn check_is_valid_struct_cast(
 pub fn handle_casting_failures(input: &Series, output: &Series) -> PolarsResult<()> {
     check_is_valid_struct_cast(input.dtype(), output.dtype(), output.name())?;
 
-    // Map entries are not positionally comparable with a cast's -- which
-    // `find_validity_mismatch` requires -- because casting merges duplicate keys and drops
-    // the entries that no live row owns. Strictness still holds, since a Map is nested, so
-    // its key and value child casts run with the same options.
-    #[cfg(feature = "dtype-map")]
-    if input.dtype().contains_map() || output.dtype().contains_map() {
-        return Ok(());
-    }
-
     let mut idxs = Vec::new();
-    input.find_validity_mismatch(output, &mut idxs);
+
+    #[cfg(feature = "dtype-map")]
+    let maps_involved = input.dtype().contains_map() || output.dtype().contains_map();
+    #[cfg(not(feature = "dtype-map"))]
+    let maps_involved = false;
+
+    if maps_involved {
+        // Map entries are not positionally comparable with a cast's -- which
+        // `find_validity_mismatch` requires -- because casting merges duplicate keys and
+        // drops the entries that no live row owns. Rows still line up, and strictness holds
+        // below, since a Map is nested, so its key and value child casts run with the same
+        // options.
+        find_validity_mismatch_shallow(
+            input.rechunk_validity().as_ref(),
+            output.rechunk_validity().as_ref(),
+            &mut idxs,
+        );
+    } else {
+        input.find_validity_mismatch(output, &mut idxs);
+    }
 
     if idxs.is_empty() {
         return Ok(());

--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -73,13 +73,6 @@ pub fn handle_casting_failures(input: &Series, output: &Series) -> PolarsResult<
         return Ok(());
     }
 
-    // Match the cast's compacted Map layout at every depth: physical validity comparison
-    // cannot distinguish Map storage from lists.
-    #[cfg(feature = "dtype-map")]
-    let compacted = input.compact_map_null_rows()?;
-    #[cfg(feature = "dtype-map")]
-    let input = compacted.as_ref().unwrap_or(input);
-
     let mut idxs = Vec::new();
     input.find_validity_mismatch(output, &mut idxs);
 

--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -65,11 +65,12 @@ pub fn check_is_valid_struct_cast(
 pub fn handle_casting_failures(input: &Series, output: &Series) -> PolarsResult<()> {
     check_is_valid_struct_cast(input.dtype(), output.dtype(), output.name())?;
 
-    // Casting to a Map merges duplicate keys, so its entries are not positionally
-    // comparable with the input's -- which `find_validity_mismatch` requires. Strictness
-    // still holds, since the key and value child casts run with the same options.
+    // Map entries are not positionally comparable with a cast's -- which
+    // `find_validity_mismatch` requires -- because casting merges duplicate keys and drops
+    // the entries that no live row owns. Strictness still holds, since a Map is nested, so
+    // its key and value child casts run with the same options.
     #[cfg(feature = "dtype-map")]
-    if output.dtype().contains_map() {
+    if input.dtype().contains_map() || output.dtype().contains_map() {
         return Ok(());
     }
 

--- a/crates/polars-expr/src/dispatch/map.rs
+++ b/crates/polars-expr/src/dispatch/map.rs
@@ -13,5 +13,5 @@ pub fn function_expr_to_udf(func: IRMapFunction) -> SpecialEq<Arc<dyn ColumnsUdf
 }
 
 fn map_entries(c: &Column) -> PolarsResult<Column> {
-    c.try_apply_unary_elementwise(|s| Ok(s.map()?.storage().clone()))
+    c.try_apply_unary_elementwise(|s| Ok(s.map()?.live_storage().into_owned().into_series()))
 }

--- a/crates/polars-expr/src/dispatch/map.rs
+++ b/crates/polars-expr/src/dispatch/map.rs
@@ -13,5 +13,5 @@ pub fn function_expr_to_udf(func: IRMapFunction) -> SpecialEq<Arc<dyn ColumnsUdf
 }
 
 fn map_entries(c: &Column) -> PolarsResult<Column> {
-    c.try_apply_unary_elementwise(|s| Ok(s.map()?.live_storage().into_owned().into_series()))
+    c.try_apply_unary_elementwise(|s| Ok(s.map()?.storage().clone()))
 }

--- a/crates/polars-plan/src/dsl/map.rs
+++ b/crates/polars-plan/src/dsl/map.rs
@@ -6,7 +6,7 @@ pub struct MapNameSpace(pub(crate) Expr);
 impl MapNameSpace {
     /// Convert this `Map` to a `List` of `Struct {key, value}` entries.
     ///
-    /// Null rows remain null; their stored entries are omitted.
+    /// Null maps remain null.
     pub fn entries(self) -> Expr {
         self.0.map_unary(MapFunction::Entries)
     }

--- a/py-polars/src/polars/expr/map.py
+++ b/py-polars/src/polars/expr/map.py
@@ -23,7 +23,7 @@ class ExprMapNameSpace:
         Each entry is a `Struct` with a `key` and a `value` field. Entry order is
         preserved. The inverse of :meth:`Expr.list.to_map`.
 
-        Null maps remain null; their stored entries are omitted.
+        Null maps remain null.
 
         .. engine-support:: in-memory, streaming, distributed
 

--- a/py-polars/src/polars/series/map.py
+++ b/py-polars/src/polars/series/map.py
@@ -25,7 +25,7 @@ class MapNameSpace:
         Each entry is a `Struct` with a `key` and a `value` field. Entry order is
         preserved. The inverse of :meth:`Series.list.to_map`.
 
-        Null maps remain null; their stored entries are omitted.
+        Null maps remain null.
 
         Examples
         --------

--- a/py-polars/tests/unit/datatypes/test_map.py
+++ b/py-polars/tests/unit/datatypes/test_map.py
@@ -879,6 +879,7 @@ def test_map_null_row_export_compaction_validity_runs(
     )
     # Slice before import to exercise nonzero bitmap and list offsets.
     result = pl.from_arrow(arr.slice(skip, n))
+    assert isinstance(result, pl.Series)
     expected = [
         {keys[j]: values[j] for j in range(offsets[i], offsets[i + 1])}
         if valid[i]
@@ -1490,7 +1491,9 @@ def test_map_strict_cast_ignores_values_hidden_by_a_null_row() -> None:
     # The same payload as a `List(Struct)`, where propagation nulls the hidden entry.
     entries = pa.StructArray.from_arrays([keys, values], names=["key", "value"])
     lst = pa.ListArray.from_arrays(pa.array([0, 1, 2], pa.int32()), entries, mask=mask)
-    assert pl.from_arrow(lst).cast(MAP).to_list() == [None, {"b": 7}]  # type: ignore[union-attr]
+    from_list = pl.from_arrow(lst)
+    assert isinstance(from_list, pl.Series)
+    assert from_list.cast(MAP).to_list() == [None, {"b": 7}]
 
 
 def test_map_sliced_export_rebases_offsets() -> None:
@@ -1669,6 +1672,7 @@ def test_map_propagation_keeps_repaired_entry_children(
         value_dtype = pl.List(ENTRIES)
 
     s = pl.from_arrow(pa.MapArray.from_arrays([0, 2], ["x", "y"], values))
+    assert isinstance(s, pl.Series)
     target = (
         pl.List(pl.Struct({"key": pl.String, "value": value_dtype}))
         if cast_to_entries

--- a/py-polars/tests/unit/datatypes/test_map.py
+++ b/py-polars/tests/unit/datatypes/test_map.py
@@ -834,7 +834,7 @@ def test_map_entries_expr_and_series() -> None:
 def arrow_map_retaining_entries(
     keys: list[str], values: list[int], offsets: list[int], valid: list[bool]
 ) -> pl.Series:
-    """Use PyArrow's standard constructor to retain entries under null rows."""
+    """Use PyArrow's standard constructor to keep entries under null rows."""
     pa = pytest.importorskip("pyarrow")
     arr = pa.MapArray.from_arrays(
         pa.array(offsets, pa.int32()),
@@ -848,7 +848,7 @@ def arrow_map_retaining_entries(
 
 
 def retaining_null_row_map() -> pl.Series:
-    """Rows `null` and `{b: 2, c: 3}`, with entry `a` under the null row on input."""
+    """Rows `null` and `{b: 2, c: 3}`, with entry `a` kept under the null row."""
     return arrow_map_retaining_entries(
         ["a", "b", "c"], [1, 2, 3], [0, 1, 3], [False, True]
     )
@@ -857,7 +857,9 @@ def retaining_null_row_map() -> pl.Series:
 @pytest.mark.parametrize("n", [0, 1, 7, 8, 9, 63, 64, 65, 127, 128, 129])
 @pytest.mark.parametrize("skip", [0, 1, 3, 9])
 @pytest.mark.parametrize("pattern", ["valid", "null", "alternating", "runs"])
-def test_map_null_row_compaction_validity_runs(n: int, skip: int, pattern: str) -> None:
+def test_map_null_row_export_compaction_validity_runs(
+    n: int, skip: int, pattern: str
+) -> None:
     pa = pytest.importorskip("pyarrow")
     lengths = [i % 3 for i in range(n + skip)]
     offsets = list(accumulate(lengths, initial=0))
@@ -885,21 +887,18 @@ def test_map_null_row_compaction_validity_runs(n: int, skip: int, pattern: str) 
     ]
     assert result.to_list() == expected
     exported = result.to_arrow()
-    out_offsets = exported.offsets.to_pylist()
-    first, last = out_offsets[0], out_offsets[-1]
-    # Unchanged chunks may retain entries outside the sliced offset window.
-    assert [offset - first for offset in out_offsets] == list(
+    exported.validate(full=True)
+    # Export compacts and rebases, so the entries are exactly the live ones.
+    assert exported.offsets.to_pylist() == list(
         accumulate((len(row) if row is not None else 0 for row in expected), initial=0)
     )
-    assert exported.keys.slice(first, last - first).to_pylist() == [
-        key for row in expected if row for key in row
-    ]
+    assert exported.keys.to_pylist() == [key for row in expected if row for key in row]
 
 
-def test_map_import_empties_a_null_row_that_spans_entries() -> None:
+def test_map_export_compacts_a_null_row_that_spans_entries() -> None:
     s = retaining_null_row_map()
     assert s.to_list() == [None, {"b": 2, "c": 3}]
-    # The import dropped entry `a`, so the null row spans nothing.
+    # The import left entry `a` where the producer put it; the export drops it.
     assert s.to_arrow().offsets.to_pylist() == [0, 0, 2]
     assert s.to_arrow().values.to_pylist() == [
         {"key": "b", "value": 2},
@@ -918,7 +917,7 @@ def test_map_import_empties_a_null_row_that_spans_entries() -> None:
 
 
 def test_map_null_row_strict_cast_inside_a_container() -> None:
-    # Null rows span no entries, so strict-cast validity checks compare like for like.
+    # Entries a null row hides must not reach a strict-cast validity check.
     s = retaining_null_row_map()
     entries = [None, [{"key": "b", "value": 2}, {"key": "c", "value": 3}]]
 
@@ -962,8 +961,8 @@ def test_map_null_row_strict_cast_reaches_a_nested_map() -> None:
     ]
 
 
-def test_map_null_row_compaction_survives_slicing() -> None:
-    # Rows 0 and 2 arrive null while still spanning entries `a` and `d`.
+def test_map_null_row_masking_survives_slicing() -> None:
+    # Rows 0 and 2 are null while still spanning entries `a` and `d`.
     s = arrow_map_retaining_entries(
         ["a", "b", "c", "d", "e"],
         [1, 2, 3, 4, 5],
@@ -1399,7 +1398,7 @@ LIVE_ROW = {Decimal("2.500"): 2}
 
 
 def test_map_null_row_keeping_its_entries() -> None:
-    # Arrow may retain entries under null rows; import drops them without nulling keys.
+    # Arrow may keep entries under null rows; polars keeps them too and hides them.
     s = _map_with_null_row_keeping_its_entries()
     assert s.dtype == DEC_MAP
     assert s.to_arrow().offsets.to_pylist() == [0, 0, 1]
@@ -1418,8 +1417,8 @@ def test_map_null_row_keeping_its_entries() -> None:
     assert s.to_frame().sort("m")["m"].to_list() == [None, {Decimal("2.50"): 2}]
 
 
-def test_map_sliced_null_row_spans_nothing() -> None:
-    # The null row was emptied on import, so slicing it away leaves nothing behind.
+def test_map_sliced_null_row_leaves_nothing_reachable() -> None:
+    # The null row's entry is hidden, so slicing the row away exposes nothing.
     sliced = _map_with_null_row_keeping_its_entries().slice(1, 1)
     assert sliced.to_list() == [{Decimal("2.50"): 2}]
 
@@ -1445,7 +1444,97 @@ def test_map_slicing_leaves_live_entries_outside_the_window() -> None:
     assert sliced.map.entries().to_arrow().offsets.to_pylist() == [0, 1]
 
 
-def test_map_null_rows_written_in_place_span_no_entries() -> None:
+def masked_null_row_map() -> pl.Series:
+    """Rows `{a: 1, b: 2}`, null, `{d: 4, e: 5}`, with `c` hidden under the null row."""
+    s = pl.Series("m", [{"a": 1, "b": 2}, {"c": 3}, {"d": 4, "e": 5}], dtype=MAP)
+    df = pl.DataFrame({"m": s, "keep": [True, False, True]})
+    return df.select(
+        pl.when(pl.col("keep")).then(pl.col("m")).otherwise(None)
+    ).to_series()
+
+
+def test_map_flat_accessors_skip_entries_hidden_by_a_null_row() -> None:
+    s = masked_null_row_map()
+    assert s.to_list() == [{"a": 1, "b": 2}, None, {"d": 4, "e": 5}]
+
+    # `entries` and the `List(Struct)` cast both expose live entries only.
+    expected = [
+        [{"key": "a", "value": 1}, {"key": "b", "value": 2}],
+        None,
+        [{"key": "d", "value": 4}, {"key": "e", "value": 5}],
+    ]
+    for out in (s.map.entries(), s.cast(ENTRIES)):
+        assert out.to_list() == expected
+        assert out.to_arrow().offsets.to_pylist() == [0, 2, 2, 4]
+
+    # A value cast pairs `values()` with `with_values()`, so both must skip `c`.
+    widened = s.cast(FLOAT_MAP)
+    assert widened.to_list() == [{"a": 1.0, "b": 2.0}, None, {"d": 4.0, "e": 5.0}]
+    assert widened.to_arrow().items.to_pylist() == [1.0, 2.0, 4.0, 5.0]
+
+
+def test_map_strict_cast_ignores_values_hidden_by_a_null_row() -> None:
+    pa = pytest.importorskip("pyarrow")
+    # Only the hidden entry's value is unparsable, so a strict cast of it would fail.
+    keys = pa.array(["a", "b"], pa.large_string())
+    values = pa.array(["xyz", "7"], pa.large_string())
+    mask = pa.array([True, False])
+    arr = pa.MapArray.from_arrays(
+        pa.array([0, 1, 2], pa.int32()), keys, values, mask=mask
+    )
+    s = pl.from_arrow(arr)
+    assert isinstance(s, pl.Series)
+    assert s.dtype == pl.Map(pl.String, pl.String)
+    assert s.cast(MAP).to_list() == [None, {"b": 7}]
+
+    # The same payload as a `List(Struct)`, where propagation nulls the hidden entry.
+    entries = pa.StructArray.from_arrays([keys, values], names=["key", "value"])
+    lst = pa.ListArray.from_arrays(pa.array([0, 1, 2], pa.int32()), entries, mask=mask)
+    assert pl.from_arrow(lst).cast(MAP).to_list() == [None, {"b": 7}]  # type: ignore[union-attr]
+
+
+def test_map_sliced_export_rebases_offsets() -> None:
+    pytest.importorskip("pyarrow")
+    rows = [{"a": 1}, {"b": 2, "c": 3}, {"d": 4}]
+    s = pl.Series("m", rows, dtype=MAP)
+
+    for offset, length in [(0, 3), (1, 2), (2, 1), (1, 1), (3, 0)]:
+        exported = s.slice(offset, length).to_arrow()
+        exported.validate(full=True)
+        assert exported.offsets.to_pylist()[0] == 0
+        assert exported.to_pylist() == [
+            list(row.items()) for row in rows[offset : offset + length]
+        ]
+
+
+@pytest.mark.parametrize("container", ["list", "struct"])
+def test_map_hidden_entries_under_a_nulled_container_row_export_valid_arrow(
+    container: str,
+) -> None:
+    pytest.importorskip("pyarrow")
+    # Nulling the outer row propagates nulls into the hidden Map entries, which the
+    # export must drop rather than hand to Arrow's non-nullable entries field.
+    df = pl.DataFrame({"m": masked_null_row_map().cast(FLOAT_MAP)})
+    if container == "list":
+        nested = _outer_nulled_container(df["m"].head(2))
+        dtype: pl.DataType = pl.List(FLOAT_MAP)
+        expected: list[Any] = [None, [None]]
+    else:
+        nested = df.select(
+            pl.when(pl.Series([False, True, True])).then(pl.struct("m")).otherwise(None)
+        ).to_series()
+        dtype = pl.Struct({"m": FLOAT_MAP})
+        expected = [None, {"m": None}, {"m": [("d", 4.0), ("e", 5.0)]}]
+
+    exported = nested.cast(dtype).to_arrow()
+    exported.validate(full=True)
+    assert exported.to_pylist() == expected
+    inner = exported.field("m") if container == "struct" else exported.values
+    assert inner.values.null_count == 0
+    assert inner.keys.null_count == 0
+
+
+def test_map_null_rows_written_in_place_are_compacted_on_export() -> None:
     # Several paths null a Map row without touching its offsets. These are the ones an
     # expression can reach; `deposit` and the empty-group aggregation of a scalar
     # column are covered by the Rust tests in `logical::map`.
@@ -1470,7 +1559,7 @@ def test_map_null_rows_written_in_place_span_no_entries() -> None:
     assert gathered.to_arrow().offsets.to_pylist() == [0, 2, 2, 4, 4]
 
 
-def test_map_null_rows_in_a_container_span_no_entries() -> None:
+def test_map_null_rows_in_a_container_are_compacted_on_export() -> None:
     s = pl.Series("m", [{"a": 1.0, "b": 2.0}, {"c": 3.0}], dtype=FLOAT_MAP)
     df = pl.DataFrame({"m": s, "keep": [False, True]})
 
@@ -1601,11 +1690,11 @@ def test_map_propagation_keeps_repaired_entry_children(
 
 
 @pytest.mark.parametrize("wrap_in_struct", [False, True], ids=["map", "struct-of-map"])
-def test_map_extension_container_null_rows_span_no_entries(
+def test_map_extension_container_null_rows_are_compacted_on_export(
     wrap_in_struct: bool,
 ) -> None:
     # `Extension` forwards propagation to its storage, so a Map under an extension
-    # must be repaired the same way.
+    # must be exported the same way.
     rows: list[Any] = [{"a": 1.0, "b": 2.0}, {"c": 3.0}]
     storage: pl.DataType = FLOAT_MAP
     live = [("c", 3.0)]
@@ -1679,8 +1768,8 @@ def test_map_null_rows_survive_nesting(
     rescaled_dtype: pl.DataType,
     expected: list[Any],
 ) -> None:
-    # Nested null propagation must empty Map rows rather than null their entries, which
-    # the key rescaling below would then reject.
+    # The key rescaling below revalidates the entries, so it must see only the live
+    # ones -- nested null propagation nulls the rest.
     nested = nest(_map_with_null_row_keeping_its_entries())
     assert nested.cast(rescaled_dtype).to_list() == expected
 
@@ -1713,9 +1802,9 @@ def _list_of_entries_with_null_row(keys: list[str | None]) -> pl.Series:
 
 
 @pytest.mark.parametrize("keys", [[None, "b"], ["a", "b"]], ids=["invalid", "valid"])
-def test_map_hidden_entry_is_compacted_by_the_list_cast(keys: list[str | None]) -> None:
-    # `List(Struct)` null propagation may null the entry under a null row, so the cast
-    # must drop it rather than carry a null entry or key into the Map.
+def test_map_hidden_entry_is_compacted_on_export(keys: list[str | None]) -> None:
+    # `List(Struct)` null propagation may null the entry under a null row. The Map keeps
+    # it hidden; only the export must not carry a null entry or key into Arrow.
     s = _list_of_entries_with_null_row(keys).cast(MAP)
     exported = s.to_arrow()
     assert exported.offsets.to_pylist() == [0, 0, 1]

--- a/py-polars/tests/unit/datatypes/test_map.py
+++ b/py-polars/tests/unit/datatypes/test_map.py
@@ -5,6 +5,7 @@ import math
 from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from itertools import accumulate
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -19,7 +20,11 @@ if TYPE_CHECKING:
     from typing import IO
 
 MAP = pl.Map(pl.String, pl.Int64)
+FLOAT_MAP = pl.Map(pl.String, pl.Float64)
 ENTRIES = pl.List(pl.Struct({"key": pl.String, "value": pl.Int64}))
+
+MAP_EXTENSION_NAME = "testing.map_container"
+pl.register_extension_type(MAP_EXTENSION_NAME, pl.Extension)
 
 
 class _CustomMapping(Mapping[str, Any]):
@@ -829,18 +834,13 @@ def test_map_entries_expr_and_series() -> None:
 def arrow_map_retaining_entries(
     keys: list[str], values: list[int], offsets: list[int], valid: list[bool]
 ) -> pl.Series:
-    """Build an Arrow Map with entries under null rows."""
+    """Use PyArrow's standard constructor to retain entries under null rows."""
     pa = pytest.importorskip("pyarrow")
-    entries = pa.StructArray.from_arrays(
-        [pa.array(keys, pa.large_string()), pa.array(values, pa.int64())],
-        names=["key", "value"],
-    )
-    map_type = pa.map_(pa.field("key", pa.large_string(), nullable=False), pa.int64())
-    arr = pa.Array.from_buffers(
-        map_type,
-        len(valid),
-        [pa.array(valid).buffers()[1], pa.array(offsets, pa.int32()).buffers()[1]],
-        children=[entries],
+    arr = pa.MapArray.from_arrays(
+        pa.array(offsets, pa.int32()),
+        pa.array(keys, pa.large_string()),
+        pa.array(values, pa.int64()),
+        mask=pa.array([not v for v in valid]),
     )
     s = pl.from_arrow(arr)
     assert isinstance(s, pl.Series)
@@ -848,15 +848,63 @@ def arrow_map_retaining_entries(
 
 
 def retaining_null_row_map() -> pl.Series:
-    """Rows `null` and `{b: 2, c: 3}`, with entry `a` hidden under the null row."""
+    """Rows `null` and `{b: 2, c: 3}`, with entry `a` under the null row on input."""
     return arrow_map_retaining_entries(
         ["a", "b", "c"], [1, 2, 3], [0, 1, 3], [False, True]
     )
 
 
-def test_map_null_row_hides_retained_entries() -> None:
+@pytest.mark.parametrize("n", [0, 1, 7, 8, 9, 63, 64, 65, 127, 128, 129])
+@pytest.mark.parametrize("skip", [0, 1, 3, 9])
+@pytest.mark.parametrize("pattern", ["valid", "null", "alternating", "runs"])
+def test_map_null_row_compaction_validity_runs(n: int, skip: int, pattern: str) -> None:
+    pa = pytest.importorskip("pyarrow")
+    lengths = [i % 3 for i in range(n + skip)]
+    offsets = list(accumulate(lengths, initial=0))
+    valid = [
+        pattern == "valid"
+        or (pattern == "alternating" and i % 2 == 0)
+        or (pattern == "runs" and (i // 17) % 2 == 0)
+        for i in range(n + skip)
+    ]
+    keys = [str(i) for i in range(offsets[-1])]
+    values = list(range(offsets[-1]))
+    arr = pa.MapArray.from_arrays(
+        pa.array(offsets, pa.int32()),
+        pa.array(keys, pa.large_string()),
+        pa.array(values, pa.int64()),
+        mask=pa.array([not v for v in valid], pa.bool_()),
+    )
+    # Slice before import to exercise nonzero bitmap and list offsets.
+    result = pl.from_arrow(arr.slice(skip, n))
+    expected = [
+        {keys[j]: values[j] for j in range(offsets[i], offsets[i + 1])}
+        if valid[i]
+        else None
+        for i in range(skip, skip + n)
+    ]
+    assert result.to_list() == expected
+    exported = result.to_arrow()
+    out_offsets = exported.offsets.to_pylist()
+    first, last = out_offsets[0], out_offsets[-1]
+    # Unchanged chunks may retain entries outside the sliced offset window.
+    assert [offset - first for offset in out_offsets] == list(
+        accumulate((len(row) if row is not None else 0 for row in expected), initial=0)
+    )
+    assert exported.keys.slice(first, last - first).to_pylist() == [
+        key for row in expected if row for key in row
+    ]
+
+
+def test_map_import_empties_a_null_row_that_spans_entries() -> None:
     s = retaining_null_row_map()
     assert s.to_list() == [None, {"b": 2, "c": 3}]
+    # The import dropped entry `a`, so the null row spans nothing.
+    assert s.to_arrow().offsets.to_pylist() == [0, 0, 2]
+    assert s.to_arrow().values.to_pylist() == [
+        {"key": "b", "value": 2},
+        {"key": "c", "value": 3},
+    ]
 
     expected = [None, [{"key": "b", "value": 2}, {"key": "c", "value": 3}]]
     for out in (s.map.entries(), s.cast(ENTRIES)):
@@ -870,7 +918,7 @@ def test_map_null_row_hides_retained_entries() -> None:
 
 
 def test_map_null_row_strict_cast_inside_a_container() -> None:
-    # Hidden entries must not cause length mismatches in strict-cast validity checks.
+    # Null rows span no entries, so strict-cast validity checks compare like for like.
     s = retaining_null_row_map()
     entries = [None, [{"key": "b", "value": 2}, {"key": "c", "value": 3}]]
 
@@ -886,7 +934,7 @@ def test_map_null_row_strict_cast_inside_a_container() -> None:
 
 def test_map_null_row_strict_cast_reaches_a_nested_map() -> None:
     pa = pytest.importorskip("pyarrow")
-    # Inner maps of `{p: null, q: {b: 2, c: 3}}`, with `a` hidden under `p`.
+    # Inner maps of `{p: null, q: {b: 2, c: 3}}`, with `a` under `p` on input.
     inner = retaining_null_row_map().rename("value").to_arrow()
     keys = pa.array(["p", "q"], pa.large_string())
     outer_entries = pa.StructArray.from_arrays([keys, inner], names=["key", "value"])
@@ -915,7 +963,7 @@ def test_map_null_row_strict_cast_reaches_a_nested_map() -> None:
 
 
 def test_map_null_row_compaction_survives_slicing() -> None:
-    # Rows 0 and 2 are null but still span entries `a` and `d`.
+    # Rows 0 and 2 arrive null while still spanning entries `a` and `d`.
     s = arrow_map_retaining_entries(
         ["a", "b", "c", "d", "e"],
         [1, 2, 3, 4, 5],
@@ -1329,18 +1377,17 @@ def test_map_nested_key_conversion_is_an_error_not_a_panic(
 
 
 def _map_with_null_row_keeping_its_entries() -> pl.Series:
-    """An Arrow Map with entries retained under a null row."""
+    """An Arrow Map whose null row still spans an entry on input."""
     pa = pytest.importorskip("pyarrow")
 
     keys = pa.array([Decimal("1.50"), Decimal("2.50")], type=pa.decimal128(10, 2))
     values = pa.array([1, 2], type=pa.int64())
-    arr = pa.MapArray.from_arrays(pa.array([0, 1, 2], type=pa.int32()), keys, values)
-    # Mark row 0 null while the offsets keep pointing at its entry.
-    arr = pa.Array.from_buffers(
-        arr.type,
-        2,
-        [pa.py_buffer(bytes([0b10])), arr.buffers()[1]],
-        children=[arr.values],
+    # The mask nulls row 0 while the offsets keep pointing at its entry.
+    arr = pa.MapArray.from_arrays(
+        pa.array([0, 1, 2], type=pa.int32()),
+        keys,
+        values,
+        mask=pa.array([True, False]),
     )
     return pl.from_arrow(pa.table({"m": arr}))["m"]  # type: ignore[index]
 
@@ -1352,18 +1399,16 @@ LIVE_ROW = {Decimal("2.500"): 2}
 
 
 def test_map_null_row_keeping_its_entries() -> None:
-    # Arrow lets a null row keep its entries instead of being empty, and other producers
-    # do that. Null propagation must not null those entries: it runs before casting and
-    # row encoding, and nulling them breaks the non-null entry invariant.
+    # Arrow may retain entries under null rows; import drops them without nulling keys.
     s = _map_with_null_row_keeping_its_entries()
     assert s.dtype == DEC_MAP
-    assert s.to_arrow().offsets.to_pylist() == [0, 1, 2]
+    assert s.to_arrow().offsets.to_pylist() == [0, 0, 1]
     assert s.to_list() == [None, {Decimal("2.50"): 2}]
 
     # Rescaling a Decimal key is the cast that revalidates the entries.
     assert s.cast(RESCALED_MAP).to_list() == [None, LIVE_ROW]
 
-    # Value casts drop hidden entries and remain exportable.
+    # Value casts remain exportable.
     widened = s.cast(pl.Map(pl.Decimal(10, 2), pl.Float64))
     assert widened.to_list() == [None, {Decimal("2.50"): 2.0}]
     assert widened.to_arrow().values.null_count == 0
@@ -1373,8 +1418,8 @@ def test_map_null_row_keeping_its_entries() -> None:
     assert s.to_frame().sort("m")["m"].to_list() == [None, {Decimal("2.50"): 2}]
 
 
-def test_map_sliced_null_row_leaves_its_entries_outside_the_window() -> None:
-    # Slicing away the null row leaves its entry in the child, before the offsets.
+def test_map_sliced_null_row_spans_nothing() -> None:
+    # The null row was emptied on import, so slicing it away leaves nothing behind.
     sliced = _map_with_null_row_keeping_its_entries().slice(1, 1)
     assert sliced.to_list() == [{Decimal("2.50"): 2}]
 
@@ -1382,6 +1427,202 @@ def test_map_sliced_null_row_leaves_its_entries_outside_the_window() -> None:
     assert exported.offsets.to_pylist() == [0, 1]
     assert exported.keys.to_pylist() == [Decimal("2.50")]
     assert sliced.cast(RESCALED_MAP).to_list() == [LIVE_ROW]
+
+
+def test_map_slicing_leaves_live_entries_outside_the_window() -> None:
+    # Slicing past a live row may leave its entries outside the offsets, as with List.
+    s = pl.Series("m", [{Decimal("1.50"): 1}, {Decimal("2.50"): 2}], dtype=DEC_MAP)
+    sliced = s.slice(1, 1)
+    assert sliced.to_list() == [{Decimal("2.50"): 2}]
+
+    for out in (
+        sliced.cast(pl.Map(pl.Decimal(10, 2), pl.Float64)),
+        sliced.cast(RESCALED_MAP),
+    ):
+        exported = out.to_arrow()
+        assert exported.offsets.to_pylist() == [0, 1]
+        assert exported.keys.to_pylist() == [Decimal("2.50")]
+    assert sliced.map.entries().to_arrow().offsets.to_pylist() == [0, 1]
+
+
+def test_map_null_rows_written_in_place_span_no_entries() -> None:
+    # Several paths null a Map row without touching its offsets. These are the ones an
+    # expression can reach; `deposit` and the empty-group aggregation of a scalar
+    # column are covered by the Rust tests in `logical::map`.
+    s = pl.Series("m", [{"a": 1, "b": 2}, {"c": 3}, {"d": 4, "e": 5}], dtype=MAP)
+    df = pl.DataFrame({"m": s, "keep": [True, False, True]})
+
+    masked = df.select(
+        pl.when(pl.col("keep")).then(pl.col("m")).otherwise(None)
+    ).to_series()
+    assert masked.to_list() == [{"a": 1, "b": 2}, None, {"d": 4, "e": 5}]
+    assert masked.to_arrow().offsets.to_pylist() == [0, 2, 2, 4]
+
+    shifted = s.shift(1)
+    assert shifted.to_list() == [None, {"a": 1, "b": 2}, {"c": 3}]
+    assert shifted.to_arrow().offsets.to_pylist() == [0, 0, 2, 3]
+
+    # A broadcast scalar gathered with null indices nulls rows of the materialized copy.
+    gathered = pl.DataFrame({"i": [0, None, 0, None]}).select(
+        pl.lit(s.slice(0, 1)).first().gather(pl.col("i"))
+    )["m"]
+    assert gathered.to_list() == [{"a": 1, "b": 2}, None, {"a": 1, "b": 2}, None]
+    assert gathered.to_arrow().offsets.to_pylist() == [0, 2, 2, 4, 4]
+
+
+def test_map_null_rows_in_a_container_span_no_entries() -> None:
+    s = pl.Series("m", [{"a": 1.0, "b": 2.0}, {"c": 3.0}], dtype=FLOAT_MAP)
+    df = pl.DataFrame({"m": s, "keep": [False, True]})
+
+    # `to_arrow` alone does not propagate nulls into the container's child; the cast
+    # does.
+    nulled = df.select(
+        pl.when(pl.col("keep")).then(pl.col("m")).otherwise(None).implode()
+    ).to_series()
+    exported = nulled.cast(pl.List(FLOAT_MAP)).to_arrow()
+    assert exported.values.offsets.to_pylist() == [0, 0, 1]
+    assert exported.to_pylist() == [[None, [("c", 3.0)]]]
+
+    # Nulling the outer `List` row must reach the Map rows it spans.
+    lists = (
+        df.group_by("keep", maintain_order=True)
+        .agg("m")
+        .with_columns(outer_keep=pl.Series([False, True]))
+    )
+    outer_nulled = lists.select(
+        pl.when(pl.col("outer_keep")).then(pl.col("m")).otherwise(None)
+    ).to_series()
+    exported = outer_nulled.cast(pl.List(FLOAT_MAP)).to_arrow()
+    assert exported.to_pylist() == [None, [[("c", 3.0)]]]
+    assert exported.values.offsets.to_pylist() == [0, 0, 1]
+
+    struct_nulled = df.select(
+        pl.when(pl.col("keep")).then(pl.struct("m")).otherwise(None)
+    ).to_series()
+    exported = struct_nulled.cast(pl.Struct({"m": FLOAT_MAP})).to_arrow()
+    assert exported.to_pylist() == [None, {"m": [("c", 3.0)]}]
+    assert exported.field("m").offsets.to_pylist() == [0, 0, 1]
+
+    # Two array rows, so the nulled row is not the whole column.
+    wide = pl.Series(
+        "m",
+        [{"a": 1.0, "b": 2.0}, {"c": 3.0}, {"d": 4.0}, {"e": 5.0}],
+        dtype=FLOAT_MAP,
+    )
+    arrays = (
+        pl.DataFrame({"m": wide, "g": [1, 1, 2, 2]})
+        .group_by("g", maintain_order=True)
+        .agg("m")
+        .with_columns(
+            pl.col("m").cast(pl.Array(FLOAT_MAP, 2)), keep=pl.Series([False, True])
+        )
+    )
+    array_nulled = arrays.select(
+        pl.when(pl.col("keep")).then(pl.col("m")).otherwise(None)
+    ).to_series()
+    exported = array_nulled.cast(pl.Array(FLOAT_MAP, 2)).to_arrow()
+    assert exported.to_pylist() == [None, [[("d", 4.0)], [("e", 5.0)]]]
+    assert exported.values.offsets.to_pylist() == [0, 0, 0, 1, 2]
+
+
+def _outer_nulled_container(inner: pl.Series) -> pl.Series:
+    """Group `inner` into a two-row `List` and null the first row."""
+    lists = (
+        pl.DataFrame({"c": inner, "g": [1, 2]})
+        .group_by("g", maintain_order=True)
+        .agg("c")
+        .with_columns(keep=pl.Series([False, True]))
+    )
+    return lists.select(
+        pl.when(pl.col("keep")).then(pl.col("c")).otherwise(None)
+    ).to_series()
+
+
+def test_map_nested_container_is_compact_in_the_physical_tree() -> None:
+    # Inspect physical descendants: reconstructing children could mask lost repairs.
+    s = pl.Series("m", [{"a": 1.0, "b": 2.0}, {"c": 3.0}], dtype=FLOAT_MAP)
+    # Rows `{}` and `{c: 3, d: 4}`: nulling row 0 leaves this second field alone.
+    other = pl.Series("other", [{}, {"c": 3.0, "d": 4.0}], dtype=FLOAT_MAP)
+    structs = pl.DataFrame({"m": s, "other": other}).select(pl.struct("m", "other"))[
+        "m"
+    ]
+
+    exported = (
+        _outer_nulled_container(structs)
+        .cast(pl.List(pl.Struct({"m": FLOAT_MAP, "other": FLOAT_MAP})))
+        .to_arrow()
+    )
+    assert exported.to_pylist() == [
+        None,
+        [{"m": [("c", 3.0)], "other": [("c", 3.0), ("d", 4.0)]}],
+    ]
+    assert exported.values.field("m").offsets.to_pylist() == [0, 0, 1]
+    assert exported.values.field("other").offsets.to_pylist() == [0, 0, 2]
+
+
+@pytest.mark.parametrize("container", ["list", "array", "struct"])
+@pytest.mark.parametrize("cast_to_entries", [False, True], ids=["identity", "entries"])
+def test_map_propagation_keeps_repaired_entry_children(
+    container: str, cast_to_entries: bool
+) -> None:
+    pa = pytest.importorskip("pyarrow")
+    inner = pa.MapArray.from_arrays([0, 2, 3], ["a", "b", "c"], [1, 2, 3])
+    mask = pa.array([True, False])
+    value_dtype: pl.DataType
+    if container == "struct":
+        values = pa.StructArray.from_arrays([inner], names=["m"], mask=mask)
+        value_dtype = pl.Struct({"m": ENTRIES})
+    elif container == "array":
+        values = pa.FixedSizeListArray.from_arrays(inner, 1, mask=mask)
+        value_dtype = pl.Array(ENTRIES, 1)
+    else:
+        values = pa.ListArray.from_arrays([0, 1, 2], inner, mask=mask)
+        value_dtype = pl.List(ENTRIES)
+
+    s = pl.from_arrow(pa.MapArray.from_arrays([0, 2], ["x", "y"], values))
+    target = (
+        pl.List(pl.Struct({"key": pl.String, "value": value_dtype}))
+        if cast_to_entries
+        else s.dtype
+    )
+    result = s.cast(target)
+    if not cast_to_entries:
+        assert result.to_list() == s.to_list()
+
+    # Inspect the physical tree without reconstructing children, which could repair
+    # them and hide a discarded propagation result.
+    exported_values = result.to_arrow().values.field("value")
+    exported_inner = (
+        exported_values.field("m") if container == "struct" else exported_values.values
+    )
+    assert exported_inner.is_null().to_pylist() == [True, False]
+    assert exported_inner.offsets.to_pylist() == [0, 0, 1]
+    assert exported_inner.values.to_pylist() == [{"key": "c", "value": 3}]
+
+
+@pytest.mark.parametrize("wrap_in_struct", [False, True], ids=["map", "struct-of-map"])
+def test_map_extension_container_null_rows_span_no_entries(
+    wrap_in_struct: bool,
+) -> None:
+    # `Extension` forwards propagation to its storage, so a Map under an extension
+    # must be repaired the same way.
+    rows: list[Any] = [{"a": 1.0, "b": 2.0}, {"c": 3.0}]
+    storage: pl.DataType = FLOAT_MAP
+    live = [("c", 3.0)]
+    if wrap_in_struct:
+        rows = [{"m": row} for row in rows]
+        storage = pl.Struct({"m": FLOAT_MAP})
+        live = {"m": live}  # type: ignore[assignment]
+    ext = pl.Extension(name=MAP_EXTENSION_NAME, storage=storage)
+
+    exported = (
+        _outer_nulled_container(pl.Series("c", rows, dtype=ext))
+        .cast(pl.List(ext))
+        .to_arrow()
+    )
+    assert exported.to_pylist() == [None, [live]]
+    inner = exported.values.field("m") if wrap_in_struct else exported.values
+    assert inner.offsets.to_pylist() == [0, 0, 1]
 
 
 def test_map_sort_by_categorical_keys() -> None:
@@ -1433,18 +1674,19 @@ def test_map_sort_by_categorical_keys() -> None:
         ),
     ],
 )
-def test_map_null_row_entries_survive_nesting(
+def test_map_null_rows_survive_nesting(
     nest: Callable[[pl.Series], pl.Series],
     rescaled_dtype: pl.DataType,
     expected: list[Any],
 ) -> None:
-    # Entry validity must survive nested null propagation before key rescaling.
+    # Nested null propagation must empty Map rows rather than null their entries, which
+    # the key rescaling below would then reject.
     nested = nest(_map_with_null_row_keeping_its_entries())
     assert nested.cast(rescaled_dtype).to_list() == expected
 
 
 def test_map_null_entry_of_a_live_row_is_rejected() -> None:
-    # Only hidden null entries or keys may be dropped.
+    # Only null entries or keys that no live row owns may be dropped.
     entries = pl.Series("m", [[None, {"key": "a", "value": 1}]], dtype=ENTRIES)
     with pytest.raises(InvalidOperationError, match="Map entries cannot be null"):
         entries.cast(MAP)
@@ -1455,7 +1697,7 @@ def test_map_null_entry_of_a_live_row_is_rejected() -> None:
 
 
 def _list_of_entries_with_null_row(keys: list[str | None]) -> pl.Series:
-    """A `List(Struct)` with an entry retained under its first, null row."""
+    """A `List(Struct)` whose first, null row still spans an entry."""
     pa = pytest.importorskip("pyarrow")
     # `pa.MapArray.from_arrays` rejects null keys, so build the list by hand.
     entries = pa.StructArray.from_arrays(
@@ -1472,9 +1714,8 @@ def _list_of_entries_with_null_row(keys: list[str | None]) -> pl.Series:
 
 @pytest.mark.parametrize("keys", [[None, "b"], ["a", "b"]], ids=["invalid", "valid"])
 def test_map_hidden_entry_is_compacted_by_the_list_cast(keys: list[str | None]) -> None:
-    # List(Struct) null propagation causes hidden entries to be dropped during casting.
-    # Map import preserves valid hidden entries (test_map_null_row_keeping_its_entries).
-    # Neither path may export null entries or keys.
+    # `List(Struct)` null propagation may null the entry under a null row, so the cast
+    # must drop it rather than carry a null entry or key into the Map.
     s = _list_of_entries_with_null_row(keys).cast(MAP)
     exported = s.to_arrow()
     assert exported.offsets.to_pylist() == [0, 0, 1]

--- a/py-polars/tests/unit/datatypes/test_map.py
+++ b/py-polars/tests/unit/datatypes/test_map.py
@@ -162,6 +162,25 @@ def test_map_strict_cast_failure_reports_value_column() -> None:
         s.cast(pl.Map(pl.String, pl.Int64), strict=True)
 
 
+def test_map_strict_cast_still_checks_outer_row_validity() -> None:
+    # A Map anywhere in the dtype skips the entry comparison, not the row comparison.
+    m = pl.Series("m", [{"a": 1}], dtype=pl.Map(pl.String, pl.Int64))
+    x = pl.Series("x", [None], dtype=pl.Int64)
+
+    with_map = pl.DataFrame([m, x]).to_struct("s")
+    without_map = pl.DataFrame([x]).to_struct("s")
+    for s in (with_map, without_map):
+        with pytest.raises(InvalidOperationError, match="conversion from `struct"):
+            s.cast(pl.String, strict=True)
+
+
+def test_map_strict_cast_checks_a_null_row_of_a_struct_field() -> None:
+    m = pl.Series("m", [None], dtype=pl.Map(pl.String, pl.Int64))
+    s = pl.DataFrame([m]).to_struct("s")
+    with pytest.raises(InvalidOperationError, match="conversion from `struct"):
+        s.cast(pl.String, strict=True)
+
+
 def test_map_concat_requires_matching_dtypes() -> None:
     left = pl.Series("m", [{"a": 1}], dtype=pl.Map(pl.String, pl.Int32))
     right = pl.Series("m", [{"b": 2}], dtype=pl.Map(pl.String, pl.Int64))


### PR DESCRIPTION
Recall that a `Map` is stored as `List(Struct{key, value})`. Two properties of Arrow's
`Map` type pull against each other:
 - a null row may still span entries, i.e. `offsets[i] < offsets[i+1]` is fine for a null
   row `i`;
 - the entries and key fields are non-nullable, over the whole child.

Entries that only a null row spans we call **hidden entries**.

The 1st point is common for all lists, and `ListChunked` takes into account row validity when doing per-row operations. To see the hidden entries, you need to call `get_inner`, which is only used in some low-level contexts. This means that we can not naively/cheaply implement `.map.keys()` on top of it, or we would see keys that are not owned (anymore) by any row.

The 2nd point is specific to `Map`, and this fights the existing `ListChunked` recursive null propagation. We worked around this by having some parallel shallow propagation/compaction machinery for Map, but that was a lot of code for little benefit.

In this PR we change the invariant: entries and keys are non-null within the offset window of a non-null row. Anything a live row does not own -- under a null row, or outside the offsets after a slice -- is unconstrained, exactly as for a list.

This speeds up many of the existing operations, especially if there are no hidden entries.

The cost that we pay is constructing a liveness bitmap per chunk when accessing keys/values and exporting to Arrow, in the case when we have hidden entries in arbitrary positions.