### PR TITLE
perf: Fuse group-by pre-select into node after partition

### DIFF
--- a/crates/polars-descriptions/src/physical.rs
+++ b/crates/polars-descriptions/src/physical.rs
@@ -34,6 +34,7 @@ pub enum PhysicalPropsDescription {
     GroupBy {
         num_inputs: usize,
         key_per_input: Vec<Vec<String>>,
+        fused_agg_inputs_per_input: Vec<Vec<String>>,
         aggs_per_input: Vec<Vec<String>>,
     },
     DynamicGroupBy {

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -18,7 +18,7 @@ mod functions;
 pub mod hive;
 pub(crate) mod iterator;
 mod lit;
-pub(crate) mod optimizer;
+pub mod optimizer;
 pub mod options;
 #[cfg(feature = "python")]
 pub mod python;

--- a/crates/polars-plan/src/plans/optimizer/cse/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/mod.rs
@@ -1,6 +1,7 @@
 mod cache_states;
 mod csee;
 pub mod cspe;
+pub mod split_select;
 
 pub(crate) use cache_states::set_cache_states;
 pub(super) use csee::CommonSubExprOptimizer;

--- a/crates/polars-plan/src/plans/optimizer/cse/split_select.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/split_select.rs
@@ -1,0 +1,397 @@
+//! Splitting a select into a pre-select and an elementwise post-select.
+//!
+//! Consumers that materialize (or spill) the result of a select benefit from that
+//! intermediate being as narrow as possible, while still being allowed to finish the
+//! computation afterwards. [`split_pre_post_select_minsize_elementwise`] finds the
+//! cheapest such split.
+
+use polars_core::prelude::{DataType, InitHashMaps, PlIndexMap, PlIndexSet};
+use polars_core::schema::Schema;
+use polars_error::PolarsResult;
+use polars_utils::arena::{Arena, Node};
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::unique_column_name;
+use recursive::recursive;
+
+use crate::plans::{
+    AExpr, CanonicalExprId, CanonicalExprMap, ExprIR, OutputName, ToFieldContext, is_elementwise,
+};
+
+/// Assumed payload of one variable-length value, in bits.
+const ESTIMATED_VARLEN_PAYLOAD_BITS: u64 = 16 * 8;
+/// Assumed number of elements in one list value.
+const ESTIMATED_LIST_LEN: u64 = 4;
+/// Weight of a value whose size we cannot estimate, and the cap on any estimate. Large
+/// enough that we never prefer materializing one over anything we can size, small enough
+/// not to overflow when every node in the expression carries it.
+const MAX_ESTIMATED_BITS: u64 = 1 << 32;
+/// Capacity of a hard constraint; never part of a finite cut.
+const INF: u64 = u64::MAX / 4;
+
+/// Expected number of bits stored per row by a column of `dtype`.
+fn expected_row_bits(dtype: &DataType) -> u64 {
+    // Every column carries a validity bitmap. Counting it also breaks ties towards fewer
+    // intermediate columns.
+    const VALIDITY: u64 = 1;
+
+    use DataType as D;
+    let payload = match dtype.byte_width() {
+        Some(bytes) => (bytes * 8.0) as u64,
+        None => match dtype {
+            // A 16 byte view, plus the heap it points into.
+            D::String | D::Binary => 128 + ESTIMATED_VARLEN_PAYLOAD_BITS,
+            D::BinaryOffset => 64 + ESTIMATED_VARLEN_PAYLOAD_BITS,
+            D::List(inner) => 64 + ESTIMATED_LIST_LEN * expected_row_bits(inner),
+            #[cfg(feature = "dtype-array")]
+            D::Array(inner, width) => (*width as u64).saturating_mul(expected_row_bits(inner)),
+            #[cfg(feature = "dtype-struct")]
+            D::Struct(fields) => fields
+                .iter()
+                .map(|f| expected_row_bits(f.dtype()))
+                .fold(0, u64::saturating_add),
+            #[cfg(feature = "dtype-map")]
+            D::Map(key, value) => {
+                64 + ESTIMATED_LIST_LEN * (expected_row_bits(key) + expected_row_bits(value))
+            },
+            #[cfg(feature = "dtype-extension")]
+            D::Extension(_, storage) => expected_row_bits(storage),
+            _ => MAX_ESTIMATED_BITS,
+        },
+    };
+    VALIDITY + payload.min(MAX_ESTIMATED_BITS)
+}
+
+/// Dinic max-flow, used only to read off a minimum cut.
+struct FlowNetwork {
+    /// Edge `e` and edge `e ^ 1` are each other's reverse.
+    to: Vec<u32>,
+    cap: Vec<u64>,
+    adj: Vec<Vec<u32>>,
+}
+
+impl FlowNetwork {
+    fn new(num_nodes: usize) -> Self {
+        Self {
+            to: Vec::new(),
+            cap: Vec::new(),
+            adj: vec![Vec::new(); num_nodes],
+        }
+    }
+
+    fn add_edge(&mut self, from: usize, to: usize, cap: u64) {
+        let e = self.to.len() as u32;
+        self.to.push(to as u32);
+        self.cap.push(cap);
+        self.to.push(from as u32);
+        self.cap.push(0);
+        self.adj[from].push(e);
+        self.adj[to].push(e + 1);
+    }
+
+    /// Returns, per node, whether it is on the source side of a minimum `src`-`dst` cut.
+    fn min_cut_source_side(&mut self, src: usize, dst: usize) -> Vec<bool> {
+        let mut level = vec![u32::MAX; self.adj.len()];
+        let mut next_edge = vec![0usize; self.adj.len()];
+        let mut queue = Vec::new();
+
+        loop {
+            // Build the level graph over the residual edges.
+            level.fill(u32::MAX);
+            level[src] = 0;
+            queue.clear();
+            queue.push(src);
+            let mut head = 0;
+            while head < queue.len() {
+                let v = queue[head];
+                head += 1;
+                for i in 0..self.adj[v].len() {
+                    let e = self.adj[v][i] as usize;
+                    let w = self.to[e] as usize;
+                    if self.cap[e] > 0 && level[w] == u32::MAX {
+                        level[w] = level[v] + 1;
+                        queue.push(w);
+                    }
+                }
+            }
+
+            // The residual graph no longer reaches `dst`, so the flow is maximal and the
+            // nodes reached above are exactly the source side of a minimum cut.
+            if level[dst] == u32::MAX {
+                return level.iter().map(|l| *l != u32::MAX).collect();
+            }
+
+            next_edge.fill(0);
+            while self.augment(src, dst, INF, &level, &mut next_edge) > 0 {}
+        }
+    }
+
+    /// Pushes flow along a single `v`-`dst` path in the level graph, if there is one.
+    #[recursive]
+    fn augment(
+        &mut self,
+        v: usize,
+        dst: usize,
+        flow: u64,
+        level: &[u32],
+        next_edge: &mut [usize],
+    ) -> u64 {
+        if v == dst {
+            return flow;
+        }
+
+        while next_edge[v] < self.adj[v].len() {
+            let e = self.adj[v][next_edge[v]] as usize;
+            let w = self.to[e] as usize;
+            if self.cap[e] > 0 && level[w] == level[v] + 1 {
+                let pushed = self.augment(w, dst, flow.min(self.cap[e]), level, next_edge);
+                if pushed > 0 {
+                    self.cap[e] -= pushed;
+                    self.cap[e ^ 1] += pushed;
+                    return pushed;
+                }
+            }
+            next_edge[v] += 1;
+        }
+
+        0
+    }
+}
+
+/// One distinct sub-expression the split may cut at.
+struct DagNode {
+    /// An arena node representing this sub-expression.
+    node: Node,
+    /// Input indices, in the order [`AExpr::replace_inputs`] expects them. Only populated
+    /// for splittable nodes; a node that is materialized is computed inside the
+    /// pre-select as a whole, so its inputs never reach the intermediate schema.
+    inputs: Vec<usize>,
+    /// Whether this node's operation may be applied in the post-select.
+    splittable: bool,
+    /// Expected bits per row when this node is materialized.
+    weight: u64,
+}
+
+/// Whether `ae`'s own operation may be moved into the post-select, leaving its inputs to
+/// be produced by the pre-select. `inputs_rev` must be `ae.inputs_rev()`.
+fn is_splittable(ae: &AExpr, inputs_rev: &[Node], expr_arena: &Arena<AExpr>) -> bool {
+    match ae {
+        AExpr::Column(_) | AExpr::Element => return false,
+        #[cfg(feature = "dtype-struct")]
+        AExpr::StructEval { .. } => return false,
+        _ => {},
+    }
+
+    // `is_elementwise` reports which sub-expressions may be split off. Where that differs
+    // from `inputs_rev` an input has to stay attached to its parent (the literal
+    // right-hand side of `is_in`, say) and `replace_inputs` could no longer put rebuilt
+    // inputs back in the right places.
+    let mut detachable = UnitVec::new();
+    is_elementwise(&mut detachable, ae, expr_arena) && *detachable == *inputs_rev
+}
+
+#[recursive]
+fn collect_dag(
+    id: CanonicalExprId,
+    canonical: &mut CanonicalExprMap,
+    expr_arena: &Arena<AExpr>,
+    input_schema: &Schema,
+    idx_of: &mut PlIndexMap<CanonicalExprId, usize>,
+    dag: &mut Vec<DagNode>,
+) -> PolarsResult<usize> {
+    if let Some(idx) = idx_of.get(&id) {
+        return Ok(*idx);
+    }
+
+    let node = canonical.representative(id);
+    let ae = expr_arena.get(node);
+    let weight = expected_row_bits(&ae.to_dtype(&ToFieldContext::new(expr_arena, input_schema))?);
+    let mut inputs_rev = UnitVec::new();
+    ae.inputs_rev(&mut inputs_rev);
+    let splittable = is_splittable(ae, &inputs_rev, expr_arena);
+
+    let mut inputs = Vec::new();
+    if splittable {
+        for input in inputs_rev.iter().rev() {
+            let input_id = canonical.resolve(*input, expr_arena);
+            inputs.push(collect_dag(
+                input_id,
+                canonical,
+                expr_arena,
+                input_schema,
+                idx_of,
+                dag,
+            )?);
+        }
+    }
+
+    let idx = dag.len();
+    dag.push(DagNode {
+        node,
+        inputs,
+        splittable,
+        weight,
+    });
+    idx_of.insert(id, idx);
+    Ok(idx)
+}
+
+/// Rebuilds the post-select expressions, materializing into the pre-select wherever the
+/// post-select stops.
+struct Rebuilder<'a> {
+    dag: &'a [DagNode],
+    /// Whether a node's operation is applied in the post-select.
+    in_post: Vec<bool>,
+    /// The post-select node per already-rebuilt DAG node.
+    memo: Vec<Option<Node>>,
+    used_names: PlIndexSet<PlSmallStr>,
+    pre_select: Vec<ExprIR>,
+}
+
+impl Rebuilder<'_> {
+    #[recursive]
+    fn rebuild(&mut self, idx: usize, expr_arena: &mut Arena<AExpr>) -> Node {
+        if let Some(node) = self.memo[idx] {
+            return node;
+        }
+
+        let dag = self.dag;
+        let node = if self.in_post[idx] {
+            let ae = expr_arena.get(dag[idx].node).clone();
+            let inputs = dag[idx]
+                .inputs
+                .iter()
+                .map(|input| self.rebuild(*input, expr_arena))
+                .collect::<Vec<_>>();
+            expr_arena.add(ae.replace_inputs(&inputs))
+        } else {
+            let node = dag[idx].node;
+            // Pass a column straight through under its own name where we can, rather than
+            // renaming it for no reason.
+            let name = match expr_arena.get(node) {
+                AExpr::Column(name) if !self.used_names.contains(name) => name.clone(),
+                _ => unique_column_name(),
+            };
+            self.used_names.insert(name.clone());
+            self.pre_select
+                .push(ExprIR::new(node, OutputName::Alias(name.clone())));
+            expr_arena.add(AExpr::Column(name))
+        };
+
+        self.memo[idx] = Some(node);
+        node
+    }
+}
+
+/// Splits `exprs` into a pre-select and a post-select.
+///
+/// Selecting the returned pre-select on `input_schema` and then the returned post-select
+/// on that result produces exactly what selecting `exprs` on `input_schema` would, and:
+///
+/// * every post-select expression is elementwise,
+/// * every expression in `must_preselect` is an output of the pre-select, under its own
+///   output name,
+/// * the expected bytes per row of the intermediate schema is minimal.
+///
+/// The post-select reproduces `exprs` only; `must_preselect` is there for callers that
+/// need those values available in the intermediate (a group-by needs its keys there, for
+/// instance), and they are also offered to `exprs` as free building blocks, since they
+/// are materialized either way.
+///
+/// Note that the pre-select is empty when `exprs` and `must_preselect` need nothing from
+/// the input, which leaves the intermediate height undefined; a caller that cares must
+/// add a column of its own.
+pub fn split_pre_post_select_minsize_elementwise(
+    exprs: &[ExprIR],
+    must_preselect: &[ExprIR],
+    input_schema: &Schema,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<(Vec<ExprIR>, Vec<ExprIR>)> {
+    let mut canonical = CanonicalExprMap::new();
+    let mut idx_of = PlIndexMap::new();
+    let mut dag = Vec::new();
+
+    let mut roots = Vec::with_capacity(exprs.len());
+    for expr in exprs {
+        let id = canonical.resolve(expr.node(), expr_arena);
+        roots.push(collect_dag(
+            id,
+            &mut canonical,
+            expr_arena,
+            input_schema,
+            &mut idx_of,
+            &mut dag,
+        )?);
+    }
+
+    // A `must_preselect` expression is materialized whether or not `exprs` uses it, so it
+    // is free to build on and must never be split. Seeding the memo with its intermediate
+    // column makes the post-select refer to it instead of recomputing it.
+    let mut memo: Vec<Option<Node>> = vec![None; dag.len()];
+    let mut used_names = PlIndexSet::new();
+    let mut pre_select = Vec::with_capacity(must_preselect.len());
+    for expr in must_preselect {
+        let name = expr.output_name().clone();
+        let id = canonical.resolve(expr.node(), expr_arena);
+        if let Some(idx) = idx_of.get(&id).copied()
+            && memo[idx].is_none()
+        {
+            dag[idx].splittable = false;
+            dag[idx].weight = 0;
+            memo[idx] = Some(expr_arena.add(AExpr::Column(name.clone())));
+        }
+        used_names.insert(name);
+        pre_select.push(expr.clone());
+    }
+
+    // Minimize the intermediate width as a minimum cut. Per node we have two booleans:
+    //
+    //   post(n)  the node's operation is applied in the post-select
+    //   avail(n) the node's value is available to the post-select
+    //
+    // with `avail(n) && !post(n)` meaning `n` is materialized, at cost `weight(n)`. The
+    // only rule tying nodes together is that a node computed in the post-select needs its
+    // inputs available there. Nodes are otherwise free to disagree, because an input of a
+    // materialized node is recomputed inside the pre-select rather than passed through
+    // the intermediate.
+    //
+    // Assigning "source side" to `true`, each cost is of the form
+    // `w * [x == true && y == false]`, which is exactly an edge `x -> y` of capacity `w`,
+    // so the minimum cut is the minimum intermediate width.
+    let post = |idx: usize| 2 * idx;
+    let avail = |idx: usize| 2 * idx + 1;
+    let src = 2 * dag.len();
+    let dst = 2 * dag.len() + 1;
+
+    let mut network = FlowNetwork::new(2 * dag.len() + 2);
+    for (idx, dag_node) in dag.iter().enumerate() {
+        network.add_edge(avail(idx), post(idx), dag_node.weight);
+        if dag_node.splittable {
+            for input in &dag_node.inputs {
+                network.add_edge(post(idx), avail(*input), INF);
+            }
+        } else {
+            network.add_edge(post(idx), dst, INF);
+        }
+    }
+    for root in &roots {
+        network.add_edge(src, avail(*root), INF);
+    }
+
+    let source_side = network.min_cut_source_side(src, dst);
+    let mut rebuilder = Rebuilder {
+        in_post: (0..dag.len()).map(|idx| source_side[post(idx)]).collect(),
+        dag: &dag,
+        memo,
+        used_names,
+        pre_select,
+    };
+
+    let mut post_select = Vec::with_capacity(exprs.len());
+    for (expr, root) in exprs.iter().zip(&roots) {
+        let node = rebuilder.rebuild(*root, expr_arena);
+        post_select.push(ExprIR::new(node, expr.output_name_inner().clone()));
+    }
+
+    Ok((rebuilder.pre_select, post_select))
+}

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -11,7 +11,7 @@ mod cluster_with_columns;
 mod collapse_and_project;
 mod collect_members;
 #[cfg(feature = "cse")]
-mod cse;
+pub mod cse;
 #[cfg(feature = "merge_sorted")]
 mod flatten_merge_sorted;
 mod flatten_union;

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_async::executor;
-use polars_core::prelude::{IntoColumn, PlHashSet, PlRandomState};
+use polars_core::prelude::{Column, IntoColumn, PlRandomState};
 use polars_core::runtime::{ASYNC, RAYON};
 use polars_core::schema::Schema;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
@@ -15,7 +15,6 @@ use polars_utils::hashing::HashPartitioner;
 use polars_utils::itertools::Itertools;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::sparse_init_vec::SparseInitVec;
-use polars_utils::vec::reuse_vec;
 use polars_utils::{IdxSize, UnitVec};
 use rayon::prelude::*;
 use tokio::sync::mpsc::{Receiver, channel};
@@ -123,11 +122,100 @@ impl LocalGroupBySinkState {
     }
 }
 
+/// Which columns of an input's morsels are kept (and spilled), and how the reductions of
+/// that input read them.
+pub struct InputPayload {
+    /// The input columns which must be kept.
+    pub stored_cols: Vec<PlSmallStr>,
+    /// The subset of `stored_cols` needed to evaluate `fused_selectors` and the
+    /// `fused_reductions`.
+    pub gather_cols: Vec<PlSmallStr>,
+    /// Elementwise expressions evaluated inside the node on only the rows being reduced,
+    /// so that their output never enters the spilled cold morsels.
+    pub fused_selectors: Vec<StreamExpr>,
+
+    /// Reductions whose input columns are all in `stored_cols`.
+    pub direct_reductions: Vec<usize>,
+    /// Reductions with at least one input column produced by `fused_selectors`. A single
+    /// subset is shared by all input columns of one update call, so such a reduction reads
+    /// all of its inputs from the materialized frame.
+    pub fused_reductions: Vec<usize>,
+}
+
+impl InputPayload {
+    /// Materializes the fused columns for rows `idxs` of `df`.
+    async fn materialize_fused<'a>(
+        &self,
+        df: &DataFrame,
+        idxs: &'a [IdxSize],
+        identity_idxs: &'a mut Vec<IdxSize>,
+        exec_state: &ExecutionState,
+    ) -> PolarsResult<Option<(DataFrame, &'a [IdxSize])>> {
+        if self.fused_reductions.is_empty() || idxs.is_empty() {
+            return Ok(None);
+        }
+
+        let mut eval_df = unsafe { df.select_unchecked(&self.gather_cols) }?;
+        // 75% or more of the rows, don't gather.
+        let subset = if idxs.len() as u64 >= df.height() as u64 * 3 / 4 {
+            idxs
+        } else {
+            eval_df = unsafe { eval_df.take_slice_unchecked_impl(idxs, false) };
+            identity_idxs.extend(identity_idxs.len() as IdxSize..idxs.len() as IdxSize);
+            &identity_idxs[..idxs.len()]
+        };
+
+        for selector in &self.fused_selectors {
+            let c = selector
+                .evaluate_preserve_len_broadcast(&eval_df, exec_state)
+                .await?;
+            unsafe { eval_df.push_column_unchecked(c.rechunk()) };
+        }
+        Ok(Some((eval_df, subset)))
+    }
+
+    /// Feeds rows `idxs` of `df` to every reduction of this input. The direct reductions
+    /// read `df` itself, the fused ones a frame materialized for those rows only.
+    #[allow(clippy::too_many_arguments)]
+    async fn update_reductions<'a>(
+        &self,
+        df: &DataFrame,
+        idxs: &'a [IdxSize],
+        identity_idxs: &'a mut Vec<IdxSize>,
+        grouped_reduction_cols: &[Vec<PlSmallStr>],
+        reductions: &mut [Box<dyn GroupedReduction>],
+        exec_state: &ExecutionState,
+        mut update: impl FnMut(&mut dyn GroupedReduction, &[&Column], &[IdxSize]) -> PolarsResult<()>,
+    ) -> PolarsResult<()> {
+        let fused_frame = self
+            .materialize_fused(df, idxs, identity_idxs, exec_state)
+            .await?;
+        let direct = (&self.direct_reductions, df, idxs);
+        let fused = fused_frame
+            .as_ref()
+            .map(|(fused_df, subset)| (&self.fused_reductions, fused_df, *subset));
+
+        for (red_idxs, src_df, subset) in std::iter::once(direct).chain(fused) {
+            let mut in_cols = Vec::new();
+            for red_idx in red_idxs {
+                in_cols.clear();
+                in_cols.extend(
+                    grouped_reduction_cols[*red_idx]
+                        .iter()
+                        .map(|col| src_df.column(col).unwrap()),
+                );
+                update(&mut *reductions[*red_idx], &in_cols, subset)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 struct GroupBySinkState {
     key_selectors_per_input: Vec<Vec<StreamExpr>>,
     reductions_per_input: Vec<Vec<usize>>,
+    payload_per_input: Vec<InputPayload>,
     grouper: Box<dyn Grouper>,
-    uniq_grouped_reduction_cols_per_input: Vec<Vec<PlSmallStr>>,
     grouped_reduction_cols: Vec<Vec<PlSmallStr>>,
     grouped_reductions: Vec<Box<dyn GroupedReduction>>,
     locals: Vec<LocalGroupBySinkState>,
@@ -148,7 +236,7 @@ impl GroupBySinkState {
         for (mut recv, local) in receivers.into_iter().zip(&mut self.locals) {
             let key_selectors_per_input = &self.key_selectors_per_input;
             let reductions_per_input = &self.reductions_per_input;
-            let uniq_grouped_reduction_cols_per_input = &self.uniq_grouped_reduction_cols_per_input;
+            let payload_per_input = &self.payload_per_input;
             let grouped_reduction_cols = &self.grouped_reduction_cols;
             let random_state = &self.random_state;
             let partitioner = self.partitioner.clone();
@@ -157,7 +245,7 @@ impl GroupBySinkState {
                 let mut hot_idxs = Vec::new();
                 let mut hot_group_idxs = Vec::new();
                 let mut cold_idxs = Vec::new();
-                let mut in_cols = Vec::new();
+                let mut identity_idxs: Vec<IdxSize> = Vec::new();
                 while let Some((input_idx, morsel)) = recv.recv().await {
                     // Compute hot group indices from key.
                     let seq = morsel.seq().to_u64();
@@ -184,35 +272,35 @@ impl GroupBySinkState {
                         has_order_sensitive_agg,
                     );
 
-                    // Drop columns not used for reductions (key-only columns).
-                    let uniq_grouped_reduction_cols =
-                        &uniq_grouped_reduction_cols_per_input[input_idx];
-                    if uniq_grouped_reduction_cols.len() < df.width() {
-                        df = unsafe { df.select_unchecked(uniq_grouped_reduction_cols.as_slice()) }
-                            .unwrap();
+                    // Drop columns which are neither reduction inputs nor fused sources.
+                    let payload = &payload_per_input[input_idx];
+                    if payload.stored_cols.len() < df.width() {
+                        df = unsafe { df.select_unchecked(&payload.stored_cols) }.unwrap();
                     }
                     df.rechunk_mut(); // For gathers.
 
                     // Update hot reductions.
                     for red_idx in &reductions_per_input[input_idx] {
-                        let cols = &grouped_reduction_cols[*red_idx];
-                        let reduction = &mut local.hot_grouped_reductions[*red_idx];
-                        for col in cols {
-                            in_cols.push(df.column(col).unwrap());
-                        }
-                        unsafe {
-                            // SAFETY: we resize the reduction to the number of groups beforehand.
-                            reduction.resize(hot_grouper.num_groups());
-                            reduction.update_groups_while_evicting(
-                                &in_cols,
-                                &hot_idxs,
-                                &hot_group_idxs,
-                                seq,
-                            )?;
-                        }
-                        in_cols.clear();
-                        in_cols = in_cols.into_iter().map(|_| unreachable!()).collect(); // Clear lifetimes.
+                        local.hot_grouped_reductions[*red_idx].resize(hot_grouper.num_groups());
                     }
+                    payload
+                        .update_reductions(
+                            &df,
+                            &hot_idxs,
+                            &mut identity_idxs,
+                            grouped_reduction_cols,
+                            &mut local.hot_grouped_reductions,
+                            &state.in_memory_exec_state,
+                            |reduction, in_cols, subset| unsafe {
+                                reduction.update_groups_while_evicting(
+                                    in_cols,
+                                    subset,
+                                    &hot_group_idxs,
+                                    seq,
+                                )
+                            },
+                        )
+                        .await?;
 
                     // Store cold keys.
                     if !cold_idxs.is_empty() {
@@ -265,7 +353,10 @@ impl GroupBySinkState {
         }
     }
 
-    fn combine_locals(&mut self) -> PolarsResult<Vec<GroupByPartition>> {
+    fn combine_locals(
+        &mut self,
+        exec_state: &ExecutionState,
+    ) -> PolarsResult<Vec<GroupByPartition>> {
         // Finalize pre-aggregations.
         RAYON.install(|| {
             self.locals
@@ -319,6 +410,7 @@ impl GroupBySinkState {
         let locals = &self.locals;
         let grouper_template = &self.grouper;
         let reductions_per_input = &self.reductions_per_input;
+        let payload_per_input = &self.payload_per_input;
         let grouped_reductions_template = &self.grouped_reductions;
         let grouped_reduction_cols = &self.grouped_reduction_cols;
 
@@ -361,7 +453,7 @@ impl GroupBySinkState {
                     // Insert morsels.
                     let mut skip_drop_attempt = false;
                     let mut group_idxs = Vec::new();
-                    let mut in_cols = Vec::new();
+                    let mut identity_idxs: Vec<IdxSize> = Vec::new();
                     for (l, l_morsels) in locals.iter().zip(morsels_per_local) {
                         // Try to help with dropping.
                         if !skip_drop_attempt {
@@ -387,23 +479,29 @@ impl GroupBySinkState {
                                 );
 
                                 for red_idx in &reductions_per_input[*input_idx] {
-                                    let cols = &grouped_reduction_cols[*red_idx];
-                                    let reduction = &mut p_reductions[*red_idx];
-                                    for col in cols {
-                                        in_cols.push(morsel_df.column(col).unwrap());
-                                    }
-                                    reduction.resize(p_grouper.num_groups());
-                                    reduction.update_groups_subset(
-                                        &in_cols,
-                                        p_morsel_idxs,
-                                        &group_idxs,
-                                        *seq_id,
-                                    )?;
-                                    in_cols = reuse_vec(in_cols);
+                                    p_reductions[*red_idx].resize(p_grouper.num_groups());
                                 }
+
+                                payload_per_input[*input_idx]
+                                    .update_reductions(
+                                        &morsel_df,
+                                        p_morsel_idxs,
+                                        &mut identity_idxs,
+                                        grouped_reduction_cols,
+                                        &mut p_reductions,
+                                        exec_state,
+                                        |reduction, in_cols, subset| {
+                                            reduction.update_groups_subset(
+                                                in_cols,
+                                                subset,
+                                                &group_idxs,
+                                                *seq_id,
+                                            )
+                                        },
+                                    )
+                                    .await?;
                             }
                         }
-                        in_cols = reuse_vec(in_cols);
 
                         if let Some(l) = Arc::into_inner(l_morsels) {
                             // If we're the last thread to process this set of morsels we're probably
@@ -556,6 +654,7 @@ impl GroupByNode {
         grouper: Box<dyn Grouper>,
         // grouped_reductions[k] is passed input cols grouped_reduction_cols[k].
         grouped_reduction_cols: Vec<Vec<PlSmallStr>>,
+        payload_per_input: Vec<InputPayload>,
         grouped_reductions: Vec<Box<dyn GroupedReduction>>,
         output_schema: Arc<Schema>,
         random_state: PlRandomState,
@@ -567,17 +666,6 @@ impl GroupByNode {
             .unwrap_or(DEFAULT_HOT_TABLE_SIZE);
         let num_inputs = key_selectors_per_input.len();
         let num_partitions = num_pipelines;
-        let uniq_grouped_reduction_cols_per_input = reductions_per_input
-            .iter()
-            .map(|rs| {
-                rs.iter()
-                    .flat_map(|k| grouped_reduction_cols[*k].iter())
-                    .cloned()
-                    .collect::<PlHashSet<_>>()
-                    .into_iter()
-                    .collect_vec()
-            })
-            .collect_vec();
         let locals = (0..num_pipelines)
             .map(|_| {
                 let reductions = grouped_reductions.iter().map(|gr| gr.new_empty()).collect();
@@ -595,10 +683,10 @@ impl GroupByNode {
             state: GroupByState::Sink(GroupBySinkState {
                 key_selectors_per_input,
                 reductions_per_input,
+                payload_per_input,
                 grouped_reductions,
                 grouper,
                 random_state,
-                uniq_grouped_reduction_cols_per_input,
                 grouped_reduction_cols,
                 locals,
                 partitioner,
@@ -639,7 +727,7 @@ impl ComputeNode for GroupByNode {
                 else {
                     unreachable!()
                 };
-                let partitions = sink.combine_locals()?;
+                let partitions = sink.combine_locals(&state.in_memory_exec_state)?;
                 let dfs = RAYON.install(|| {
                     partitions
                         .into_par_iter()

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -611,14 +611,32 @@ fn visualize_plan_rec(
         PhysNodeKind::GroupBy {
             inputs,
             key_per_input,
+            fused_agg_inputs_per_input,
             aggs_per_input,
         } => {
             let mut out = String::from("group-by");
-            for (key, aggs) in key_per_input.iter().zip(aggs_per_input) {
+            for ((key, fused), aggs) in key_per_input
+                .iter()
+                .zip(fused_agg_inputs_per_input)
+                .zip(aggs_per_input)
+            {
                 write!(
                     &mut out,
-                    "\\nkey:\\n{}\\naggs:\\n{}",
+                    "\\nkey:\\n{}",
                     fmt_exprs_to_label(key, expr_arena, FormatExprStyle::Select),
+                )
+                .ok();
+                if !fused.is_empty() {
+                    write!(
+                        &mut out,
+                        "\\nfused agg inputs:\\n{}",
+                        fmt_exprs_to_label(fused, expr_arena, FormatExprStyle::Select),
+                    )
+                    .ok();
+                }
+                write!(
+                    &mut out,
+                    "\\naggs:\\n{}",
                     fmt_exprs_to_label(aggs, expr_arena, FormatExprStyle::Select)
                 )
                 .ok();

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{
-    Field, InitHashMaps, PlHashMap, PlIndexMap, PlIndexSet, SortMultipleOptions,
+    Field, InitHashMaps, PlIndexMap, PlIndexSet, SortMultipleOptions,
 };
 use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
@@ -17,7 +17,7 @@ use polars_plan::plans::{
     AExpr, CanonicalExprId, CanonicalExprMap, IR, IRAggExpr, IRFunctionExpr, write_group_by,
 };
 use polars_plan::prelude::{GroupbyOptions, *};
-use polars_plan::utils::{aexpr_to_leaf_names_iter, rename_columns};
+use polars_plan::utils::rename_columns;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::{IdxSize, unique_column_name};

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -2,9 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{
-    Field, InitHashMaps, PlIndexMap, PlIndexSet, SortMultipleOptions,
-};
+use polars_core::prelude::{Field, InitHashMaps, PlIndexMap, PlIndexSet, SortMultipleOptions};
 use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_err};

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{Field, InitHashMaps, PlIndexMap, PlIndexSet, SortMultipleOptions};
+use polars_core::prelude::{
+    Field, InitHashMaps, PlHashMap, PlIndexMap, PlIndexSet, SortMultipleOptions,
+};
 use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_err};
@@ -10,10 +12,12 @@ use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_ops::frame::{JoinArgs, JoinType, MaintainOrderJoin};
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
+use polars_plan::plans::optimizer::cse::split_select::split_pre_post_select_minsize_elementwise;
 use polars_plan::plans::{
     AExpr, CanonicalExprId, CanonicalExprMap, IR, IRAggExpr, IRFunctionExpr, write_group_by,
 };
 use polars_plan::prelude::{GroupbyOptions, *};
+use polars_plan::utils::{aexpr_to_leaf_names_iter, rename_columns};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::{IdxSize, unique_column_name};
@@ -34,6 +38,21 @@ use crate::utils::late_materialized_df::LateMaterializedDataFrame;
 pub enum GroupByLowerKind {
     Groups,
     Over,
+}
+
+/// The schema a `PhysNodeKind::GroupBy` input has after evaluating its fused agg inputs.
+pub fn augmented_group_by_input_schema(
+    input_schema: &Arc<Schema>,
+    fused: &[ExprIR],
+    expr_arena: &Arena<AExpr>,
+) -> PolarsResult<Arc<Schema>> {
+    if fused.is_empty() {
+        return Ok(input_schema.clone());
+    }
+    let fused_schema = compute_output_schema(input_schema, fused, expr_arena)?;
+    let mut schema = Schema::clone(input_schema);
+    schema.merge(Arc::unwrap_or_clone(fused_schema));
+    Ok(Arc::new(schema))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -104,6 +123,7 @@ fn replace_agg_uniq(
     uniq_input_names: &mut PlIndexMap<CanonicalExprId, PlSmallStr>,
     uniq_agg_exprs: &mut PlIndexMap<CanonicalExprId, (ExprIR, Vec<CanonicalExprId>)>,
     uniq_elementwise_exprs: &mut PlIndexMap<CanonicalExprId, ExprIR>,
+    substream_input_ids: &mut PlIndexSet<CanonicalExprId>,
 ) -> Node {
     let aexpr = expr_arena.get(expr).clone();
     let mut inputs = Vec::new();
@@ -125,6 +145,7 @@ fn replace_agg_uniq(
                         expr_arena,
                         uniq_input_names,
                         uniq_elementwise_exprs,
+                        substream_input_ids,
                     );
                     if let Some(id) = input_id {
                         // Already elementwise.
@@ -164,6 +185,7 @@ fn replace_elementwise_components(
     expr_arena: &mut Arena<AExpr>,
     uniq_input_names: &mut PlIndexMap<CanonicalExprId, PlSmallStr>,
     uniq_elementwise_exprs: &mut PlIndexMap<CanonicalExprId, ExprIR>,
+    substream_input_ids: &mut PlIndexSet<CanonicalExprId>,
 ) -> (Option<CanonicalExprId>, Node) {
     if is_elementwise_rec_cached(expr, expr_arena, expr_cache)
         || (is_input_independent(expr, expr_arena, expr_cache) && is_scalar_ae(expr, expr_arena))
@@ -185,15 +207,17 @@ fn replace_elementwise_components(
         inputs.reverse();
 
         for input in &mut inputs {
-            *input = replace_elementwise_components(
+            let (input_id, node) = replace_elementwise_components(
                 *input,
                 canonical_exprs,
                 expr_cache,
                 expr_arena,
                 uniq_input_names,
                 uniq_elementwise_exprs,
-            )
-            .1;
+                substream_input_ids,
+            );
+            substream_input_ids.extend(input_id);
+            *input = node;
         }
         let rec_node = expr_arena.add(aexpr.replace_inputs(&inputs));
         (None, rec_node)
@@ -216,6 +240,7 @@ fn try_lower_elementwise_scalar_agg_expr(
     uniq_input_names: &mut PlIndexMap<CanonicalExprId, PlSmallStr>,
     uniq_agg_exprs: &mut PlIndexMap<CanonicalExprId, (ExprIR, Vec<CanonicalExprId>)>,
     uniq_elementwise_exprs: &mut PlIndexMap<CanonicalExprId, ExprIR>,
+    substream_input_ids: &mut PlIndexSet<CanonicalExprId>,
 ) -> Option<Node> {
     // Helper macros to simplify (recursive) calls.
     macro_rules! lower_rec {
@@ -230,6 +255,7 @@ fn try_lower_elementwise_scalar_agg_expr(
                 uniq_input_names,
                 uniq_agg_exprs,
                 uniq_elementwise_exprs,
+                substream_input_ids,
             )
         };
     }
@@ -245,6 +271,7 @@ fn try_lower_elementwise_scalar_agg_expr(
                 uniq_input_names,
                 uniq_agg_exprs,
                 uniq_elementwise_exprs,
+                substream_input_ids,
             )
         };
     }
@@ -799,6 +826,10 @@ pub fn try_build_streaming_group_by(
     // Maps elementwise input expression ids to column expression.
     let mut uniq_elementwise_exprs = PlIndexMap::new();
 
+    // Elementwise inputs hoisted out of an aggregation input that is resolved by its own
+    // sub-stream derived from the pre-select, which reads them from there as columns.
+    let mut substream_input_ids = PlIndexSet::new();
+
     for agg in aggs {
         let Some(trans_node) = try_lower_elementwise_scalar_agg_expr(
             agg.node(),
@@ -810,6 +841,7 @@ pub fn try_build_streaming_group_by(
             &mut uniq_input_names,
             &mut uniq_agg_exprs,
             &mut uniq_elementwise_exprs,
+            &mut substream_input_ids,
         ) else {
             return Ok(None);
         };
@@ -817,15 +849,47 @@ pub fn try_build_streaming_group_by(
         trans_output_exprs.push(ExprIR::new(trans_node, output_name));
     }
 
-    // We must lower the keys together with the elementwise inputs to the aggregations.
-    let mut pre_select_input_ids = key_ids.clone();
-    pre_select_input_ids.extend(uniq_elementwise_exprs.keys());
+    // Agg inputs the pre-select has to materialize, on top of the keys.
+    let mut must_preselect_ids = key_ids.clone();
+    match gbl_kind {
+        // Over can't fuse agg inputs.
+        GroupByLowerKind::Over => must_preselect_ids.extend(uniq_elementwise_exprs.keys()),
+        GroupByLowerKind::Groups => must_preselect_ids.extend(&substream_input_ids),
+    }
 
-    let mut pre_select_exprs = Vec::new();
-    for uniq_id in pre_select_input_ids {
-        let name = &uniq_input_names[&uniq_id];
-        let node = canonical_exprs.representative(uniq_id);
-        pre_select_exprs.push(ExprIR::new(node, OutputName::Alias(name.clone())));
+    let expr_ir = |id: &CanonicalExprId| {
+        let node = canonical_exprs.representative(*id);
+        ExprIR::new(node, OutputName::Alias(uniq_input_names[id].clone()))
+    };
+    let must_preselect = must_preselect_ids.iter().map(expr_ir).collect::<Vec<_>>();
+    let splittable_agg_inputs = uniq_elementwise_exprs
+        .keys()
+        .filter(|id| !must_preselect_ids.contains(*id))
+        .map(expr_ir)
+        .collect::<Vec<_>>();
+
+    // Keep the pre-select narrow: whatever is cheaper to recompute inside the group-by
+    // node than to store in its (spilled) payload comes back as a post-select expression,
+    // which the node evaluates over the rows that need it.
+    let input_schema = input.output_schema(phys_sm).clone();
+    let (mut pre_select_exprs, post_select_agg_inputs) = split_pre_post_select_minsize_elementwise(
+        &splittable_agg_inputs,
+        &must_preselect,
+        &input_schema,
+        expr_arena,
+    )?;
+
+    // A post-select expression that is a bare column reference means the split chose to
+    // materialize this input in the pre-select, under either the source column's own name
+    // or a generated one. Point the aggregation at that column instead of fusing a rename.
+    let mut fused_agg_inputs = Vec::new();
+    let mut agg_input_renames = PlIndexMap::new();
+    for expr in post_select_agg_inputs {
+        if let AExpr::Column(stored) = expr_arena.get(expr.node()) {
+            agg_input_renames.insert(expr.output_name().clone(), stored.clone());
+        } else {
+            fused_agg_inputs.push(expr);
+        }
     }
 
     // If all inputs are input independent add a dummy column so the group sizes are correct. See #23868.
@@ -835,7 +899,7 @@ pub fn try_build_streaming_group_by(
         .all(|e| is_input_independent(e.node(), expr_arena, expr_cache))
     {
         direct_input_needed = true;
-        let dummy_col_name = input.output_schema(phys_sm).get_at_index(0).unwrap().0;
+        let dummy_col_name = input_schema.get_at_index(0).unwrap().0;
         let dummy_col = expr_arena.add(AExpr::Column(dummy_col_name.clone()));
         pre_select_exprs.push(ExprIR::new(
             dummy_col,
@@ -862,7 +926,13 @@ pub fn try_build_streaming_group_by(
             .iter()
             .all(|i| uniq_elementwise_exprs.contains_key(i))
         {
-            aggs_with_elementwise_inputs.push(agg_expr.clone());
+            let agg_expr = if agg_input_renames.is_empty() {
+                agg_expr.clone()
+            } else {
+                let node = rename_columns(agg_expr.node(), expr_arena, &agg_input_renames);
+                ExprIR::new(node, agg_expr.output_name_inner().clone())
+            };
+            aggs_with_elementwise_inputs.push(agg_expr);
             direct_input_needed = true;
             continue;
         }
@@ -909,19 +979,25 @@ pub fn try_build_streaming_group_by(
     let mut group_by_output_schema = Schema::default();
     let mut inputs = Vec::new();
     let mut key_per_input = Vec::new();
+    let mut fused_agg_inputs_per_input = Vec::new();
     let mut aggs_per_input = Vec::new();
     if direct_input_needed || !all_keys_included_in_other_inputs {
-        let this_input_schema = pre_select.output_schema(phys_sm);
+        let this_input_schema = augmented_group_by_input_schema(
+            pre_select.output_schema(phys_sm),
+            &fused_agg_inputs,
+            expr_arena,
+        )?;
         let exprs = [
             trans_keys.as_slice(),
             aggs_with_elementwise_inputs.as_slice(),
         ]
         .concat();
         let elementwise_out_schema =
-            compute_output_schema(this_input_schema, &exprs, expr_arena).unwrap();
+            compute_output_schema(&this_input_schema, &exprs, expr_arena).unwrap();
         group_by_output_schema.merge((*elementwise_out_schema).clone());
         inputs.push(pre_select);
         key_per_input.push(trans_keys.clone());
+        fused_agg_inputs_per_input.push(fused_agg_inputs);
         aggs_per_input.push(aggs_with_elementwise_inputs);
     }
     for (_input_id, (stream, aggs)) in other_agg_input_streams {
@@ -931,6 +1007,7 @@ pub fn try_build_streaming_group_by(
         group_by_output_schema.merge((*this_out_schema).clone());
         inputs.push(stream);
         key_per_input.push(trans_keys.clone());
+        fused_agg_inputs_per_input.push(Vec::new());
         aggs_per_input.push(aggs);
     }
     let group_by_output_schema = Arc::new(group_by_output_schema);
@@ -940,6 +1017,7 @@ pub fn try_build_streaming_group_by(
         PhysNodeKind::GroupBy {
             inputs,
             key_per_input,
+            fused_agg_inputs_per_input,
             aggs_per_input,
         },
     ));

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -426,7 +426,11 @@ pub enum PhysNodeKind {
         inputs: Vec<PhysStream>,
         // Must have the same schema when applied for each input.
         key_per_input: Vec<Vec<ExprIR>>,
-        // Must be a 'simple' expression, a singular column feeding into a single aggregate, or Len.
+        // Elementwise expressions evaluated inside the group-by node, producing derived
+        // columns which `aggs_per_input` may reference in addition to the input columns.
+        fused_agg_inputs_per_input: Vec<Vec<ExprIR>>,
+        // Must be a 'simple' expression, a singular column (of the input or of
+        // `fused_agg_inputs_per_input`) feeding into a single aggregate, or Len.
         aggs_per_input: Vec<Vec<ExprIR>>,
     },
 

--- a/crates/polars-stream/src/physical_plan/to_description.rs
+++ b/crates/polars-stream/src/physical_plan/to_description.rs
@@ -493,14 +493,18 @@ pub fn phys_props(
         PhysNodeKind::GroupBy {
             inputs,
             key_per_input,
+            fused_agg_inputs_per_input,
             aggs_per_input,
-            ..
         } => (
             PhysicalPropsDescription::GroupBy {
                 num_inputs: inputs.len(),
                 key_per_input: key_per_input
                     .iter()
                     .map(|k| fmt_exprs(k, expr_arena))
+                    .collect(),
+                fused_agg_inputs_per_input: fused_agg_inputs_per_input
+                    .iter()
+                    .map(|f| fmt_exprs(f, expr_arena))
                     .collect(),
                 aggs_per_input: aggs_per_input
                     .iter()

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -970,12 +970,6 @@ fn to_graph_rec<'a>(
                     .try_collect_vec()?;
                 key_selectors_per_input.push(key_selectors);
 
-                // The fused expressions only reference input columns, so they are built
-                // against the un-augmented schema.
-                let fused_selectors = fused
-                    .iter()
-                    .map(|e| create_stream_expr(e, ctx, input_schema))
-                    .try_collect_vec()?;
                 let augmented_schema =
                     augmented_group_by_input_schema(input_schema, fused, ctx.expr_arena)?;
                 let fused_names: PlHashSet<PlSmallStr> =
@@ -1039,11 +1033,18 @@ fn to_graph_rec<'a>(
                     }
                 }
 
+                let gather_cols: Vec<PlSmallStr> = gather_cols.into_iter().collect();
+                let gather_schema = Arc::new(input_schema.try_project(gather_cols.iter())?);
+                let fused_selectors = fused
+                    .iter()
+                    .map(|e| create_stream_expr(e, ctx, &gather_schema))
+                    .try_collect_vec()?;
+
                 payload_per_input.push(nodes::group_by::InputPayload {
                     stored_cols: stored_cols.into_iter().collect(),
                     direct_reductions,
                     fused_selectors,
-                    gather_cols: gather_cols.into_iter().collect(),
+                    gather_cols,
                     fused_reductions,
                 });
                 reductions_per_input.push(reductions_for_this_input);

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use num_traits::AsPrimitive;
 use parking_lot::Mutex;
 use polars_core::config;
-use polars_core::prelude::PlRandomState;
+use polars_core::prelude::{InitHashMaps, PlHashSet, PlIndexSet, PlRandomState};
 use polars_core::schema::{Schema, SchemaRef};
 use polars_error::{PolarsResult, polars_ensure, polars_err};
 use polars_expr::groups::new_hash_grouper;
@@ -40,6 +40,7 @@ use crate::nodes::io_sources::multi_scan::reader_interface::builder::FileReaderB
 use crate::nodes::io_sources::multi_scan::reader_interface::capabilities::ReaderCapabilities;
 use crate::nodes::joins::merge_join::MergeJoinNode;
 use crate::physical_plan::lower_expr::compute_output_schema;
+use crate::physical_plan::lower_group_by::augmented_group_by_input_schema;
 use crate::utils::late_materialized_df::LateMaterializedDataFrame;
 
 fn has_potential_recurring_entrance(node: Node, arena: &Arena<AExpr>) -> bool {
@@ -939,6 +940,7 @@ fn to_graph_rec<'a>(
         GroupBy {
             inputs,
             key_per_input,
+            fused_agg_inputs_per_input,
             aggs_per_input,
         } => {
             let mut key_ports = Vec::new();
@@ -947,8 +949,14 @@ fn to_graph_rec<'a>(
             let mut reductions_per_input = Vec::new();
             let mut grouped_reductions = Vec::new();
             let mut grouped_reduction_cols = Vec::new();
+            let mut payload_per_input = Vec::new();
             let mut has_order_sensitive_agg = false;
-            for ((input, key), aggs) in inputs.iter().zip(key_per_input).zip(aggs_per_input) {
+            for (((input, key), fused), aggs) in inputs
+                .iter()
+                .zip(key_per_input)
+                .zip(fused_agg_inputs_per_input)
+                .zip(aggs_per_input)
+            {
                 let input_key = to_graph_rec(input.node, ctx)?;
                 key_ports.push((input_key, input.port));
 
@@ -962,6 +970,17 @@ fn to_graph_rec<'a>(
                     .try_collect_vec()?;
                 key_selectors_per_input.push(key_selectors);
 
+                // The fused expressions only reference input columns, so they are built
+                // against the un-augmented schema.
+                let fused_selectors = fused
+                    .iter()
+                    .map(|e| create_stream_expr(e, ctx, input_schema))
+                    .try_collect_vec()?;
+                let augmented_schema =
+                    augmented_group_by_input_schema(input_schema, fused, ctx.expr_arena)?;
+                let fused_names: PlHashSet<PlSmallStr> =
+                    fused.iter().map(|e| e.output_name().clone()).collect();
+
                 let mut reductions_for_this_input = Vec::new();
                 for agg in aggs {
                     has_order_sensitive_agg |= matches!(
@@ -974,8 +993,8 @@ fn to_graph_rec<'a>(
                         )
                     );
                     let (reduction, input_nodes) =
-                        into_reduction(agg.node(), ctx.expr_arena, input_schema, true)?;
-                    let cols = input_nodes
+                        into_reduction(agg.node(), ctx.expr_arena, &augmented_schema, true)?;
+                    let cols: Vec<PlSmallStr> = input_nodes
                         .iter()
                         .map(|node| {
                             let AExpr::Column(col) = ctx.expr_arena.get(*node) else {
@@ -989,6 +1008,44 @@ fn to_graph_rec<'a>(
                     grouped_reduction_cols.push(cols);
                 }
 
+                // Columns of the input which must be kept (and spilled): every non-fused
+                // reduction input, plus the leaves the fused expressions are computed from.
+                let mut stored_cols = PlIndexSet::new();
+                let mut gather_cols = PlIndexSet::new();
+                let mut direct_reductions = Vec::new();
+                let mut fused_reductions = Vec::new();
+                for red_idx in &reductions_for_this_input {
+                    let cols = &grouped_reduction_cols[*red_idx];
+                    let touches_fused = cols.iter().any(|c| fused_names.contains(c));
+                    if touches_fused {
+                        fused_reductions.push(*red_idx);
+                    } else {
+                        direct_reductions.push(*red_idx);
+                    }
+                    for col in cols {
+                        if fused_names.contains(col) {
+                            continue;
+                        }
+                        stored_cols.insert(col.clone());
+                        if touches_fused {
+                            gather_cols.insert(col.clone());
+                        }
+                    }
+                }
+                for e in fused {
+                    for leaf in aexpr_to_leaf_names_iter(e.node(), ctx.expr_arena) {
+                        stored_cols.insert(leaf.clone());
+                        gather_cols.insert(leaf.clone());
+                    }
+                }
+
+                payload_per_input.push(nodes::group_by::InputPayload {
+                    stored_cols: stored_cols.into_iter().collect(),
+                    direct_reductions,
+                    fused_selectors,
+                    gather_cols: gather_cols.into_iter().collect(),
+                    fused_reductions,
+                });
                 reductions_per_input.push(reductions_for_this_input);
             }
 
@@ -1003,6 +1060,7 @@ fn to_graph_rec<'a>(
                     reductions_per_input,
                     grouper,
                     grouped_reduction_cols,
+                    payload_per_input,
                     grouped_reductions,
                     node.output_schema(0).clone(),
                     PlRandomState::default(),


### PR DESCRIPTION
The inputs to aggregates for a group-by come in two sets:

1. Those that *reduce* the amount of data that needs to be stored, e.g. `pl.col.a * pl.col.b` when both columns aren't used elsewhere.

2. Those that *increase* the amount of data that needs to be stored, e.g. `pl.col.small.cast(pl.Large)`, or `pl.col.x + 1, pl.col.x + 2, pl.col.x + 3`, repeating the same column many times.

In this PR we split up the inputs to group-by aggregates into two sets of expressions in a clever (min-cut) way such that the second set of expressions can use the first, and the expected size of the intermediate state is minimized. So for example, if we have this query:

```python
df = pl.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [7, 8, 9], "g": [1, 1, 1]})

q = df.lazy().group_by("g").agg(
    a = (pl.col.x * pl.col.y).sum(),
    b = (pl.col.x * pl.col.y * pl.col.z).sum(),
    c = (pl.col.x * pl.col.y * pl.col.z * pl.col.z).sum(),
)
```

This results in the following split:

<img width="868" height="888" alt="image" src="https://github.com/user-attachments/assets/fb7d2b67-1615-4813-85d1-be3baf3cf3a7" />

This means we only have to partition two columns (`z` and `tmp = x * y`), rather than three.


Overall we have Pre-select -> Partition -> Fused-select -> Agg -> Postselect now as our group-by pipeline.


AI disclaimer: I heavily used AI to co-develop this with me, most of it I heavily rewrote/guided, but the stand-alone `split_select.rs` is mostly AI generated.