### PR TITLE
fix: Disallow rolling functions negative weights

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/min_max.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/min_max.rs
@@ -49,10 +49,7 @@ macro_rules! rolling_minmax_func {
                         T::is_float(),
                         "implementation error, should only be reachable by float types"
                     );
-                    let weights = weights
-                        .iter()
-                        .map(|v| NumCast::from(*v).unwrap())
-                        .collect::<Vec<_>>();
+                    let weights = no_nulls::coerce_weights(weights);
                     no_nulls::rolling_apply_weights(
                         values,
                         window_size,

--- a/crates/polars-compute/src/rolling/no_nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mod.rs
@@ -188,6 +188,9 @@ where
 {
     weights
         .iter()
-        .map(|v| NumCast::from(*v).unwrap())
+        .map(|v| {
+            debug_assert!(v.is_sign_positive(), "weights have to be positive");
+            NumCast::from(*v).unwrap()
+        })
         .collect::<Vec<_>>()
 }

--- a/crates/polars-compute/src/rolling/no_nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/quantile.rs
@@ -176,9 +176,8 @@ where
         Some(weights) => {
             let wsum = weights
                 .iter()
-                .map(|v| {
+                .inspect(|v| {
                     debug_assert!(v.is_sign_positive(), "weights have to be positive");
-                    v
                 })
                 .sum();
             polars_ensure!(

--- a/crates/polars-compute/src/rolling/no_nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/quantile.rs
@@ -174,7 +174,13 @@ where
             )
         },
         Some(weights) => {
-            let wsum = weights.iter().sum();
+            let wsum = weights
+                .iter()
+                .map(|v| {
+                    debug_assert!(v.is_sign_positive(), "weights have to be positive");
+                    v
+                })
+                .sum();
             polars_ensure!(
                 wsum != 0.0,
                 ComputeError: "Weighted quantile is undefined if weights sum to 0"

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -52,12 +52,22 @@ mod inner_mod {
     use crate::prelude::*;
 
     /// utility
-    fn check_input(window_size: usize, min_periods: usize) -> PolarsResult<()> {
+    fn check_input(
+        window_size: usize,
+        min_periods: usize,
+        weights: Option<&Vec<f64>>,
+    ) -> PolarsResult<()> {
         polars_ensure!(
             min_periods <= window_size,
             ComputeError: "`window_size`: {} should be >= `min_periods`: {}",
             window_size, min_periods
         );
+        for w in weights.into_iter().flatten() {
+            polars_ensure!(
+                w.is_sign_positive(),
+                InvalidOperation: "Weights for rolling windows need to be positive."
+            );
+        }
         Ok(())
     }
 
@@ -83,7 +93,11 @@ mod inner_mod {
             f: &dyn Fn(&Series) -> PolarsResult<Series>,
             mut options: RollingOptionsFixedWindow,
         ) -> PolarsResult<Series> {
-            check_input(options.window_size, options.min_periods)?;
+            check_input(
+                options.window_size,
+                options.min_periods,
+                options.weights.as_ref(),
+            )?;
 
             let ca = self.rechunk();
             if options.weights.is_some() && !self.dtype().is_float() {

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -117,7 +117,7 @@ mod inner_mod {
 
             if let Some(weights) = options.weights {
                 debug_assert!(
-                    weights.iter().all(|&w| !(w < 0.0)),
+                    weights.iter().all(|&w| w.is_sign_positive()),
                     "implementation error: rolling weights should not be negative"
                 );
                 let weights_series =

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -102,6 +102,10 @@ mod inner_mod {
             let mut builder = PrimitiveChunkedBuilder::<T>::new(self.name().clone(), self.len());
 
             if let Some(weights) = options.weights {
+                debug_assert!(
+                    weights.iter().all(|&w| !(w < 0.0)),
+                    "implementation error: rolling weights should not be negative"
+                );
                 let weights_series =
                     Float64Chunked::new(PlSmallStr::from_static("weights"), &weights).into_series();
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -764,6 +764,13 @@ pub(super) fn convert_functions(
             use RollingFunction as R;
             use aexpr::IRRollingFunction as IR;
 
+            for w in options.weights.iter().flatten() {
+                polars_ensure!(
+                    w.is_sign_positive(),
+                    InvalidOperation: "Weights for rolling windows need to be positive."
+                );
+            }
+
             I::RollingExpr {
                 function: match function {
                     R::Min => IR::Min,

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1993,6 +1993,28 @@ def test_rolling_weighted_median_all_zero_weights_in_centered_window_29170() -> 
     assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "op",
+    [
+        "rolling_max",
+        "rolling_mean",
+        "rolling_median",
+        "rolling_min",
+        "rolling_std",
+        "rolling_sum",
+        "rolling_var",
+    ],
+)
+def test_rolling_negative_weights_29249(op: str) -> None:
+    s = pl.Series("a", [1.0, 2.0, 3.0, 4.0])
+
+    with pytest.raises(
+        InvalidOperationError,
+        match="Weights for rolling windows need to be positive",
+    ):
+        getattr(s, op)(window_size=3, min_samples=1, weights=[5.0, 1.0, -1.0])
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("with_nulls", [True, False])
 def test_rolling_sum_non_finite_23115(with_nulls: bool) -> None:


### PR DESCRIPTION
Fixes #29249.

Now raises an error if a negative weight is given while lowering from DSL to IR.
As a safeguard for refactoring, debug_asserts are also used when they are evaluated.
Also added a check for this when evaluating user functions: unfortunately this can only be done at evaluation time.