### PR TITLE
fix(python): Fix comparison expression method comment

### DIFF
--- a/docs/source/src/python/user-guide/expressions/operations.py
+++ b/docs/source/src/python/user-guide/expressions/operations.py
@@ -45,7 +45,7 @@ print(result.equals(result_named_operators))
 # --8<-- [start:comparison]
 result = df.select(
     (pl.col("nrs") > 1).alias("nrs > 1"),  # .gt
-    (pl.col("nrs") >= 3).alias("nrs >= 3"),  # ge
+    (pl.col("nrs") >= 3).alias("nrs >= 3"),  # .ge
     (pl.col("random") < 0.2).alias("random < .2"),  # .lt
     (pl.col("random") <= 0.5).alias("random <= .5"),  # .le
     (pl.col("nrs") != 1).alias("nrs != 1"),  # .ne


### PR DESCRIPTION
Closes #29254

## Summary

Corrects the `>=` comparison-expression comment in `docs/source/src/python/user-guide/expressions/operations.py`.

The comment previously referred to `ge`; this change corrects it to `.ge`, consistent with the other expression method comments in the snippet.

## Validation

- Ran `dprint fmt` from `docs/`
- Ran `mise exec -- make test` locally from `py-polars`
- Local test suite result: `19557 passed, 243 skipped, 8 xfailed`

<img width="1920" height="1080" alt="screenshot-2026-09-10_18-52-01" src="https://github.com/user-attachments/assets/0a004661-6f80-478f-90ca-195cf910b03b" />