### PR TITLE
fix(python): Apply "schema_overrides" in `read_database` for Arrow-based drivers

### DIFF
--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -253,7 +253,9 @@ class ConnectionExecutor:
                 frames = (
                     self._apply_overrides(batch, (schema_overrides or {}))
                     if isinstance(batch, DataFrame)
-                    else DataFrame(batch)
+                    else self._apply_overrides(
+                        DataFrame(batch), (schema_overrides or {})
+                    )
                     for batch in self._fetch_arrow(
                         driver_properties,
                         iter_batches=iter_batches,

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -955,6 +955,49 @@ def test_read_database_mocked(
     assert res.rows() == [(1, "aa"), (2, "bb"), (3, "cc")]
 
 
+@pytest.mark.parametrize(
+    ("driver", "batch_size", "iter_batches"),
+    [
+        ("snowflake", None, False),
+        ("snowflake", 10_000, True),
+        ("databricks", None, False),
+        ("databricks", 25_000, True),
+    ],
+)
+def test_read_database_mocked_schema_overrides(
+    driver: str, batch_size: int | None, iter_batches: bool
+) -> None:
+    # ensure `schema_overrides` is applied for Arrow-native drivers that
+    # route through `_from_arrow` (regression test for GH #29253)
+    arrow = pl.DataFrame({"x": [1, 2, 3], "y": ["aa", "bb", "cc"]}).to_arrow()
+
+    reg = ARROW_DRIVER_REGISTRY.get(driver, [{}])[0]  # type: ignore[var-annotated]
+    exact_batch_size = reg.get("exact_batch_size", False)
+    repeat_batch_calls = reg.get("repeat_batch_calls", False)
+
+    mc = MockConnection(
+        driver,
+        batch_size,
+        test_data=arrow,
+        repeat_batch_calls=repeat_batch_calls,
+        exact_batch_size=exact_batch_size,  # type: ignore[arg-type]
+    )
+    res = pl.read_database(
+        query="SELECT * FROM test_data",
+        connection=mc,
+        iter_batches=iter_batches,
+        batch_size=batch_size,
+        schema_overrides={"x": pl.UInt8},
+    )
+    if iter_batches:
+        assert isinstance(res, GeneratorType)
+        res = pl.concat(res)
+
+    res = cast("pl.DataFrame", res)
+    assert res.schema == pl.Schema({"x": pl.UInt8, "y": pl.String})
+    assert res.rows() == [(1, "aa"), (2, "bb"), (3, "cc")]
+
+
 class MockOracleConnection:
     """Mock `python-oracledb` Connection (Arrow `fetch_df_*` on the connection)."""
 


### PR DESCRIPTION
Fixes #29253

1. I used AI to assist with diagnosis and code review.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

## Problem
`read_database` silently ignores `schema_overrides` when using Arrow-based drivers (ADBC, Snowflake, Databricks, arrow-odbc, turbodbc, etc.). Regression from #28442.

## Root Cause
`_fetch_arrow()` always yields `pa.Table`/`pa.RecordBatch`, never `DataFrame`, so `isinstance(batch, DataFrame)` is always `False` and `else DataFrame(batch)` runs — dropping `schema_overrides`.

## Fix
Apply `_apply_overrides` in the `else` branch too, without reverting to `from_arrow` (preserving #28442's intent).

## Tests
Added `test_read_database_mocked_schema_overrides` — 4 parametrized cases covering Snowflake and Databricks (single fetch + iter_batches).

## Test screenshot
<img width="1918" height="1022" alt="Screenshot 2026-09-13 033058" src="https://github.com/user-attachments/assets/7dfe9bdd-d5f1-4f04-809d-6994764dfc83" />
